### PR TITLE
[feature] Add --from-json option for submit and cluster (resolves #37)

### DIFF
--- a/docs/_include/cluster_desc.rst
+++ b/docs/_include/cluster_desc.rst
@@ -6,6 +6,10 @@ The input source for tasks is file-like, either a local path, or from *stdin* if
 given. The command-line tasks are pulled in and either directly published to a distributed queue
 (see ``--no-db``) or committed to a database first before being scheduled later.
 
+Alternatively, use ``--from-json`` to read tasks from a JSON file (``FILE[@path]``); each task
+object's keys become named ``{key}`` fields in the ``--template`` (and task tags). In this mode the
+template is expanded when tasks are ingested rather than by the clients.
+
 For large, long running workflows, it might be a good idea to configure a database and run an
 initial ``submit`` job to populate the database, and then run the cluster with ``--restart`` and no
 input *FILE*. If the cluster is interrupted for whatever reason it can gracefully restart where it

--- a/docs/_include/cluster_help.rst
+++ b/docs/_include/cluster_help.rst
@@ -43,6 +43,15 @@ Options
 
     See section on `templates`.
 
+``--from-json`` *SPEC*
+    Read tasks from a JSON file (``FILE[@path]``).
+
+    The optional dotted ``path`` after ``@`` locates the list of task objects inside the
+    document (e.g. ``plan.json@chunks``); with no ``@`` the file's top level must be the
+    list. Each task object's keys become named ``{key}`` fields in the ``--template`` and
+    task tags. In this mode the template is expanded when tasks are ingested (submit-side),
+    not by the clients.
+
 ``-H``, ``--bind`` *ADDR*
     Bind address (default: localhost, or 0.0.0.0 for remote clients).
 

--- a/docs/_include/cluster_usage.rst
+++ b/docs/_include/cluster_usage.rst
@@ -1,4 +1,4 @@
-``hs cluster [-h]`` ``[FILE | --restart | --forever]``
+``hs cluster [-h]`` ``[FILE | --from-json SPEC | --restart | --forever]``
     ``[-N NUM]`` ``[-t CMD]`` ``[-b SIZE]`` ``[-w SEC]`` ``[-Q NUM]``
     ``[-H ADDR]`` ``[-p PORT]`` ``[-r NUM [--eager]]`` ``[-f PATH]`` ``[--capture | [-o PATH] [-e PATH]]``
     ``[--ssh [HOST... | --ssh-group NAME] [--env] | --mpi | --launcher=ARGS...]``

--- a/docs/_include/submit_desc.rst
+++ b/docs/_include/submit_desc.rst
@@ -15,3 +15,12 @@ Any tags specified with ``-t``/``--tag`` are applied to all tasks submitted.
 
 Use the special comment syntax, ``# HYPERSHELL: ...``, to include resource limits or tags inline.
 If the comment is alone on the line it will be applied to all tasks that follow.
+
+With ``--from-json``, read tasks from a JSON file instead. The value is
+``FILE[@path]`` where the optional dotted ``path`` locates the list of task objects
+within the document (e.g. ``plan.json@chunks``); with no ``@`` the file's top level
+must itself be the list, and a ``FILE`` of ``-`` reads from ``<stdin>``. Each task
+object's keys become named ``{key}`` template fields (and task tags), and an optional
+``args`` key provides the base command (reachable as ``{}``). All ``{key}`` fields are
+validated against every task object up front, so submission is rejected before any task
+is committed if a field is missing.

--- a/docs/_include/submit_help.rst
+++ b/docs/_include/submit_help.rst
@@ -10,6 +10,16 @@ Options
 ``-f``, ``--task-file`` *FILE*
     Input file containing one task per line.
 
+``--from-json`` *SPEC*
+    Read tasks from a JSON file (``FILE[@path]``).
+
+    The optional dotted ``path`` after ``@`` locates the list of task objects inside
+    the document (e.g. ``plan.json@chunks``); with no ``@`` the file's top level must
+    be the list, and a ``FILE`` of ``-`` reads from ``<stdin>``. Each task object's keys
+    become named ``{key}`` template fields and task tags; an optional ``args`` key is the
+    base command (reachable as ``{}``). Every ``{key}`` is validated against all task
+    objects before anything is submitted.
+
 ``-q``, ``--queue``
     Submit directly to live queue instead of database.
 

--- a/docs/_include/submit_usage.rst
+++ b/docs/_include/submit_usage.rst
@@ -1,4 +1,4 @@
-``hs`` ``submit`` ``[-h]`` ``[ARGS... | -f FILE]``
+``hs`` ``submit`` ``[-h]`` ``[ARGS... | -f FILE | --from-json SPEC]``
     ``[-q [-H ADDR] [-p NUM] [-k KEY] | --initdb]``
     ``[-b NUM]`` ``[-w SEC]`` ``[-c NUM]`` ``[-m MEM]`` ``[-W SEC]`` ``[-g NUM]``
     ``[--template CMD]`` ``[-t TAG...]``

--- a/docs/_include/templates.rst
+++ b/docs/_include/templates.rst
@@ -15,6 +15,31 @@ These are expanded `prior` to scheduling as the actual `args` for the task.
 
 -------------------
 
+Named Fields
+^^^^^^^^^^^^
+
+|
+
+When tasks are submitted from a JSON file with ``--from-json`` (see the ``submit``
+command), each task object's keys become available as named template fields. A
+``{key}`` pattern expands to that key's value for the given task, and the keys also
+become task tags.
+
+For a task object ``{"seqid": "Chr1", "start": 1, "end": 5000000}`` the template
+
+``process --region {seqid}:{start}-{end}``
+
+expands to
+
+``process --region Chr1:1-5000000``.
+
+Values are stringified: booleans render as ``true``/``false``, ``null`` as an empty
+string, and nested objects/arrays as compact JSON. A built-in pattern (below) takes
+precedence over a task key of the same name. Named fields are resolved at submit time,
+and every ``{key}`` must be present in each task object or the submission is rejected.
+
+-------------------
+
 Filepath Operations
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/_include/templates_alt.rst
+++ b/docs/_include/templates_alt.rst
@@ -13,6 +13,23 @@ argument to all clients.
 In some situations it may be useful to expand a template with the ``submit`` command.
 These are expanded `prior` to scheduling as the actual `args` for the task.
 
+Named Fields
+^^^^^^^^^^^^
+
+When tasks are submitted from a JSON file with ``--from-json`` (see the ``submit``
+command), each task object's keys become available as named template fields. A
+``{key}`` pattern expands to that key's value for the given task, and the keys also
+become task tags.
+
+For a task object ``{"seqid": "Chr1", "start": 1, "end": 5000000}`` the template
+``process --region {seqid}:{start}-{end}`` expands to
+``process --region Chr1:1-5000000``.
+
+Values are stringified: booleans render as ``true``/``false``, ``null`` as an empty
+string, and nested objects/arrays as compact JSON. A built-in pattern (below) takes
+precedence over a task key of the same name. Named fields are resolved at submit time,
+and every ``{key}`` must be present in each task object or the submission is rejected.
+
 Filepath Operations
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -195,4 +195,20 @@ Add arbitrary tags to one or whole collections of tasks to track additional cont
 
             INFO [hypershell.submit] Submitted 20 tasks
 
+Tasks can also come from a structured JSON plan. With ``--from-json`` each task object's
+keys become named ``{key}`` template fields (and task tags), so a plan produced by another
+tool can be executed directly without an intermediate flat task file.
+
+.. admonition:: Submit from a JSON plan
+    :class: note
+
+    .. code-block:: shell
+
+        hsx --from-json plan.json@chunks -N8 \
+            -t 'process_data --region {seqid}:{start}-{end} --id {chunk_id} -o out/{chunk_id}.tsv'
+
+    Where ``plan.json`` contains a ``chunks`` list of task objects, e.g.
+    ``{"chunk_id": "chunk_001", "seqid": "Chr1", "start": 1, "end": 5000000}``. The value is
+    ``FILE[@path]``; the optional dotted ``path`` locates the list within the document.
+
 |

--- a/src/hypershell/cluster/__init__.py
+++ b/src/hypershell/cluster/__init__.py
@@ -28,7 +28,7 @@ from hypershell.core.exceptions import get_shared_exception_mapping
 from hypershell.data import initdb, checkdb, DATABASE_DIALECT
 from hypershell.client import DEFAULT_NUM_THREADS, DEFAULT_DELAY, DEFAULT_SIGNALWAIT
 from hypershell.server import DEFAULT_BUNDLESIZE, DEFAULT_ATTEMPTS, DEFAULT_SERVER_POLL, DEFAULT_PORT
-from hypershell.submit import DEFAULT_BUNDLEWAIT
+from hypershell.submit import DEFAULT_BUNDLEWAIT, load_json_tasks, validate_json_expansion
 from hypershell.cluster.ssh import run_ssh, SSHCluster, NodeList, DEFAULT_REMOTE_EXE
 from hypershell.cluster.local import run_local, LocalCluster
 from hypershell.cluster.remote import (run_cluster, RemoteCluster, AutoScalingCluster,
@@ -50,7 +50,7 @@ log = Logger.with_name(__name__)
 APP_NAME = 'hs cluster'
 APP_USAGE = """\
 Usage:
-  hs cluster [-h] [FILE | --restart | --forever] [-N NUM] [-t CMD] [-b SIZE] [-w SEC] [-c NUM] [-m MEM] [-W SEC]  
+  hs cluster [-h] [FILE | --from-json SPEC | --restart | --forever] [-N NUM] [-t CMD] [-b SIZE] [-w SEC] [-c NUM] [-m MEM] [-W SEC]
              [--initdb | --no-db [--no-confirm]] [-d SEC] [-T SEC] [-C NUM] [-M MEM] [-S SEC] [-R NUM] [-Q NUM]
              [-H ADDR] [-p PORT] [-r NUM [--eager]] [-f PATH] [--capture | [-o PATH] [-e PATH]] [--monitor]
              [--ssh [HOST... | --ssh-group NAME] [--env] | --mpi | --launcher=ARGS...]
@@ -74,6 +74,7 @@ Modes:
 Options:
   -N, --num-threads    NUM      Number of executor threads per client, 0=auto (default: {DEFAULT_NUM_THREADS}).
   -t, --template       CMD      Command-line template pattern (default: "{DEFAULT_TEMPLATE}").
+      --from-json      SPEC     Read tasks from a JSON file ("FILE[@path]").
   -H, --bind           ADDR     Special bind address (default: "localhost" or "0.0.0.0" remote).
   -p, --port           PORT     Port number (default: {DEFAULT_PORT}).
   -b, --bundlesize     SIZE     Size of task bundle (default: {DEFAULT_BUNDLESIZE}).
@@ -126,6 +127,9 @@ class ClusterApp(Application):
 
     filepath: str
     interface.add_argument('filepath', nargs='?', default=None)
+
+    from_json: str = None
+    interface.add_argument('--from-json', default=from_json, dest='from_json')
 
     num_threads: int = DEFAULT_NUM_THREADS
     interface.add_argument('-N', '--num-threads', '--num-tasks', type=int, default=num_threads, dest='num_threads')
@@ -266,7 +270,8 @@ class ClusterApp(Application):
                  capture=self.capture, monitor=self.monitor, client_timeout=self.client_timeout,
                  task_timeout=self.task_timeout, task_signalwait=self.task_signalwait,
                  cores=self.cores, memory=self.memory, client_cores=self.client_cores,
-                 client_memory=self.client_memory, ratelimit=self.ratelimit, tls=self.tls)
+                 client_memory=self.client_memory, ratelimit=self.ratelimit,
+                 from_json=bool(self.from_json), tls=self.tls)
 
     def run_local(self: ClusterApp, **options) -> None:
         """Run local cluster."""
@@ -330,7 +335,13 @@ class ClusterApp(Application):
     def check_arguments(self: ClusterApp) -> None:
         """Various checks on input arguments."""
         given_filepath = self.filepath is not None
-        if self.filepath is None and not self.restart_mode:
+        if self.from_json:
+            if given_filepath:
+                raise ArgumentError('Cannot combine --from-json with a positional task file')
+            if self.restart_mode:
+                raise ArgumentError('Cannot combine --from-json with --restart')
+            validate_json_expansion(self.json_records, self.template)
+        elif self.filepath is None and not self.restart_mode:
             self.filepath = '-'  # NOTE: assume STDIN
         if self.restart_mode and self.in_memory:
             raise ArgumentError('Cannot restart without database (given --no-db)')
@@ -410,15 +421,24 @@ class ClusterApp(Application):
     @cached_property
     def input_stream(self: ClusterApp) -> Optional[IO]:
         """IO stream to read task command-line args."""
-        if self.restart_mode:
+        if self.restart_mode or self.from_json:
             return None
         else:
             return sys.stdin if self.filepath == '-' else open(self.filepath, mode='r')
 
     @cached_property
-    def source(self: ClusterApp) -> Iterable[str]:
-        """Input source for task command-line args."""
-        return [] if self.restart_mode else self.input_stream
+    def json_records(self: ClusterApp) -> list:
+        """Task records loaded from the --from-json spec (read once)."""
+        return load_json_tasks(self.from_json)
+
+    @cached_property
+    def source(self: ClusterApp) -> Iterable[str | dict]:
+        """Input source for task command-line args (or JSON records with --from-json)."""
+        if self.restart_mode:
+            return []
+        if self.from_json:
+            return self.json_records
+        return self.input_stream
 
     def __enter__(self: ClusterApp) -> ClusterApp:
         """Set up resources and attributes."""

--- a/src/hypershell/cluster/local.py
+++ b/src/hypershell/cluster/local.py
@@ -205,9 +205,13 @@ class LocalCluster(Thread):
                  task_timeout: int = None,
                  task_signalwait: int = DEFAULT_SIGNALWAIT,
                  ratelimit: int = None,
+                 from_json: bool = False,
                  tls: Optional[TLSConfig] = None) -> None:
         """Initialize with server and single client thread."""
         auth = secrets.token_hex(64)
+        # In JSON mode the server expands the template submit-side; the client
+        # runs the fully resolved commands verbatim (avoids double expansion).
+        client_template = DEFAULT_TEMPLATE if from_json else template
         self.server = ServerThread(source=source,
                                    task_cores=cores,
                                    task_memory=memory,
@@ -224,9 +228,11 @@ class LocalCluster(Thread):
                                    forever_mode=forever_mode,
                                    restart_mode=restart_mode,
                                    redirect_failures=redirect_failures,
+                                   template=template,
+                                   from_json=from_json,
                                    tls=tls)
         self.client = ClientThread(num_threads=num_threads,
-                                   template=template,
+                                   template=client_template,
                                    bundlesize=bundlesize,
                                    bundlewait=bundlewait,
                                    auth=auth,

--- a/src/hypershell/cluster/remote.py
+++ b/src/hypershell/cluster/remote.py
@@ -247,9 +247,13 @@ class RemoteCluster(Thread):
                  task_timeout: int = None,
                  task_signalwait: int = DEFAULT_SIGNALWAIT,
                  ratelimit: int = None,
+                 from_json: bool = False,
                  tls: Optional[TLSConfig] = None) -> None:
         """Initialize server and client threads with external launcher."""
         auth = secrets.token_hex(64)
+        # In JSON mode the template is expanded submit-side by the server; remote clients
+        # run the fully-resolved commands verbatim (avoids double expansion).
+        client_template = DEFAULT_TEMPLATE if from_json else template
         self.server = ServerThread(source=source,
                                    task_cores=cores,
                                    task_memory=memory,
@@ -266,6 +270,8 @@ class RemoteCluster(Thread):
                                    forever_mode=forever_mode,
                                    restart_mode=restart_mode,
                                    redirect_failures=redirect_failures,
+                                   template=template,
+                                   from_json=from_json,
                                    tls=tls)
         launcher = shlex.split(launcher)
         if launcher_args is None:
@@ -297,7 +303,7 @@ class RemoteCluster(Thread):
         self.client_argv = [
             *launcher, *launcher_args, remote_exe, 'client',
             '-H', target, '-p', str(bind[1]), '-N', str(num_threads), '-b', str(bundlesize), '-w', str(bundlewait),
-            '-t', template, '-k', auth, '-d', str(delay_start), '-S', str(task_signalwait), *client_args
+            '-t', client_template, '-k', auth, '-d', str(delay_start), '-S', str(task_signalwait), *client_args
         ]
         super().__init__(name='hypershell-cluster')
 
@@ -775,10 +781,14 @@ class AutoScalingCluster(Thread):
                  init_size: int = DEFAULT_AUTOSCALE_INIT_SIZE,
                  min_size: int = DEFAULT_AUTOSCALE_MIN_SIZE,
                  max_size: int = DEFAULT_AUTOSCALE_MAX_SIZE,
+                 from_json: bool = False,
                  tls: Optional[TLSConfig] = None,
                  ) -> None:
         """Initialize server and autoscaler."""
         auth = secrets.token_hex(64)
+        # In JSON mode the template is expanded submit-side by the server; remote clients
+        # run the fully-resolved commands verbatim (avoids double expansion).
+        client_template = DEFAULT_TEMPLATE if from_json else template
         self.server = ServerThread(source=source,
                                    auth=auth,
                                    address=bind,
@@ -792,6 +802,8 @@ class AutoScalingCluster(Thread):
                                    eager=eager,
                                    forever_mode=True,
                                    redirect_failures=redirect_failures,
+                                   template=template,
+                                   from_json=from_json,
                                    tls=tls)
         launcher = shlex.split(launcher)
         if launcher_args is None:
@@ -820,7 +832,7 @@ class AutoScalingCluster(Thread):
         launcher.extend([
             *launcher_args, remote_exe, 'client',
             '-H', HOSTNAME, '-p', str(bind[1]), '-N', str(num_threads), '-b', str(bundlesize), '-w', str(bundlewait),
-            '-t', template, '-k', auth, '-d', str(delay_start), '-S', str(task_signalwait), *client_args
+            '-t', client_template, '-k', auth, '-d', str(delay_start), '-S', str(task_signalwait), *client_args
         ])
         self.autoscaler = AutoScalerThread(launcher, policy=policy, factor=factor, period=period,
                                            init_size=init_size, min_size=min_size, max_size=max_size)

--- a/src/hypershell/cluster/ssh.py
+++ b/src/hypershell/cluster/ssh.py
@@ -240,11 +240,15 @@ class SSHCluster(Thread):
                  task_timeout: int = None,
                  task_signalwait: int = DEFAULT_SIGNALWAIT,
                  ratelimit: int = None,
+                 from_json: bool = False,
                  tls: Optional[TLSConfig] = None) -> None:
         """Initialize server and client threads."""
         if nodelist is None:
             raise AttributeError('Expected nodelist')
         auth = secrets.token_hex(64)
+        # In JSON mode the template is expanded submit-side by the server; SSH clients
+        # run the fully-resolved commands verbatim (avoids double expansion).
+        client_template = DEFAULT_TEMPLATE if from_json else template
         self.server = ServerThread(source=source,
                                    task_cores=cores,
                                    task_memory=memory,
@@ -261,6 +265,8 @@ class SSHCluster(Thread):
                                    forever_mode=forever_mode,
                                    restart_mode=restart_mode,
                                    redirect_failures=redirect_failures,
+                                   template=template,
+                                   from_json=from_json,
                                    tls=tls)
         launcher = shlex.split(launcher)
         launcher_env = shlex.split('' if not export_env else compile_env())
@@ -290,7 +296,7 @@ class SSHCluster(Thread):
         self.client_argv = [
             [*launcher, *launcher_args, host, *launcher_env, remote_exe, 'client', '-H', HOSTNAME,
              '-p', str(bind[1]), '-N', str(num_threads), '-b', str(bundlesize), '-w', str(bundlewait),
-             '-t', f'\'{template}\'', '-k', auth, '-d', str(delay_start),
+             '-t', f'\'{client_template}\'', '-k', auth, '-d', str(delay_start),
              '-S', str(task_signalwait), *client_args]
             for host in nodelist
         ]

--- a/src/hypershell/core/template.py
+++ b/src/hypershell/core/template.py
@@ -6,12 +6,13 @@
 
 # Type annotations
 from __future__ import annotations
-from typing import Dict, Callable, Final
+from typing import Any, Dict, Callable, Final, Optional
 from types import ModuleType
 
 # Standard libs
 import os
 import re
+import json
 import math
 import datetime
 import subprocess
@@ -21,7 +22,7 @@ import functools
 from hypershell.core.types import smart_coerce
 
 # Public interface
-__all__ = ['Template', 'DEFAULT_TEMPLATE', ]
+__all__ = ['Template', 'DEFAULT_TEMPLATE', 'render_value', ]
 
 
 # Matched in template and expanded accordingly
@@ -31,6 +32,19 @@ PATTERN: re.Pattern = re.compile(r'{(.*?)}')
 # A plain {} is replaced verbatim with the input arguments
 DEFAULT_TEMPLATE: Final[str] = '{}'
 """Default command pattern for template expansion."""
+
+
+def render_value(value: Any) -> str:
+    """Render a (JSON) `value` as a string for named ``{key}`` template expansion."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool):
+        return 'true' if value else 'false'
+    if value is None:
+        return ''
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, separators=(',', ':'))
+    return str(value)
 
 
 # Exposed modules for lambda expressions in templates
@@ -73,24 +87,27 @@ class Template:
     class FailedExpansion(Error):
         """Failure to successfully expand a pattern given input arguments."""
 
-    def expand(self: Template, args: str) -> str:
-        """Expand template against input `args`."""
+    def expand(self: Template, args: str, context: Optional[Dict[str, Any]] = None) -> str:
+        """Expand template against input `args` and optional named `context`."""
         index = 0
         expansion = ''
         if not PATTERN.search(self.template):
             return self.template
         for match in PATTERN.finditer(self.template):
             (key, ), start, end = match.groups(), match.start(), match.end()
-            expansion += self.template[index:start] + self._expand(args, key, start)
+            expansion += self.template[index:start] + self._expand(args, key, start, context)
             index = end
         else:
             return expansion + self.template[index:]
 
-    def _expand(self: Template, args: str, key: str, start: int) -> str:
-        """Determine simple vs complex pattern expansion."""
+    def _expand(self: Template, args: str, key: str, start: int,
+                context: Optional[Dict[str, Any]] = None) -> str:
+        """Determine simple vs named vs complex pattern expansion."""
         key = key.strip()  # allow whitespace (likely in shell and lambda patterns)
         if key in self.simple_patterns:
             return self.simple_patterns[key](args)
+        elif context is not None and key in context:
+            return render_value(context[key])
         else:
             return self._expand_complex(args, key, start)
 

--- a/src/hypershell/data/model.py
+++ b/src/hypershell/data/model.py
@@ -328,10 +328,20 @@ class Task(Entity):
             retried: bool = False,
             tag: Dict[str, JSONData] = None,
             group: int = DEFAULT_TASK_GROUP,
+            strict_tag: bool = True,
+            parse_inline: bool = True,
             **other: Any) -> Task:
-        """Create a new Task."""
-        cls.ensure_valid_tag(tag)
-        args, inline_tags = cls.split_argline(args)
+        """Create a new Task.
+
+        With ``strict_tag=False`` the tag character-set/length checks are relaxed
+        (for JSON-sourced tags). With ``parse_inline=False`` the inline
+        ``# HYPERSHELL:`` tag comment is not parsed and `args` is taken verbatim.
+        """
+        cls.ensure_valid_tag(tag, strict=strict_tag)
+        if parse_inline:
+            args, inline_tags = cls.split_argline(args)
+        else:
+            args, inline_tags = str(args).strip(), {}
         tag = {**(tag or {}), **inline_tags, **{'part': 0, }}
         other['group'] = tag.pop('group', group)
         other['cores'] = tag.pop('cores', other.get('cores', None))
@@ -360,8 +370,13 @@ class Task(Entity):
             return args.strip(), {}
 
     @staticmethod
-    def ensure_valid_tag(tag: Optional[Dict[str, JSONData]]) -> None:
-        """Check tag dictionary and raise if invalid."""
+    def ensure_valid_tag(tag: Optional[Dict[str, JSONData]], *, strict: bool = True) -> None:
+        """Check tag dictionary and raise if invalid.
+
+        With ``strict=False`` (used for JSON-sourced tags) the character-set and
+        length restrictions on keys and values are relaxed; only the structural
+        type checks (key is a non-empty string, value is a scalar) are enforced.
+        """
         if tag is None:
             return
         if not isinstance(tag, dict):
@@ -371,13 +386,15 @@ class Task(Entity):
                 raise TypeError(f'Tag key, {key} ({type(key)}) is not string')
             if len(key.strip()) == 0:
                 raise ValueError(f'Tag key was empty, "{key}:{value}"')
+            if not isinstance(value, (str, int, float, bool, type(None))):
+                raise TypeError(f'Invalid type for tag value, {type(value)})')
+            if not strict:
+                continue
             if len(key.strip()) > 120:
                 raise ValueError(f'Tag key size ({len(value)}) exceeds 120 characters ({key}:{value})')
             if not re.match(r'^[A-Za-z0-9_.+-]+$', key):
                 raise ValueError(f'Tag key must only contain alphanumerics and basic symbols [+._-]: '
                                  f'"{key}:{value}"')
-            if not isinstance(value, (str, int, float, bool, type(None))):
-                raise TypeError(f'Invalid type for tag value, {type(value)})')
             if isinstance(value, str):
                 if not value.strip():
                     return  # Empty value is a naked tag (no value).

--- a/src/hypershell/server.py
+++ b/src/hypershell/server.py
@@ -71,7 +71,7 @@ from hypershell.core.signal import check_signal, SIGNAL_MAP, SIGUSR1, SIGUSR2
 from hypershell.core.heartbeat import Heartbeat, ClientState
 from hypershell.data.model import Task, Client, serialize_tasks, deserialize_tasks
 from hypershell.data import ensuredb, DATABASE_ENABLED
-from hypershell.submit import SubmitThread, LiveSubmitThread, DEFAULT_BUNDLEWAIT
+from hypershell.submit import SubmitThread, LiveSubmitThread, DEFAULT_BUNDLEWAIT, DEFAULT_TEMPLATE
 from hypershell.client import ClientInfo
 
 # Public interface
@@ -777,6 +777,8 @@ class ServerThread(Thread):
                  eager: bool = False,
                  redirect_failures: IO = None,
                  evict_after: int = DEFAULT_EVICT,
+                 template: str = DEFAULT_TEMPLATE,
+                 from_json: bool = False,
                  tls: Optional[TLSConfig] = None) -> None:
         """Initialize queue manager and child threads."""
         self.in_memory = in_memory
@@ -788,15 +790,19 @@ class ServerThread(Thread):
             log.warning('Retries disabled when database disabled')
         queue_config = QueueConfig(host=address[0], port=address[1], auth=auth, size=config.server.queuesize, tls=tls)
         self.queue = QueueServer(config=queue_config)
+        # NOTE: In JSON mode the template is expanded submit-side (here) against each
+        # record's context; otherwise the flat source is passed through verbatim and the
+        # client applies the template. See hypershell.submit.Loader.
+        submit_template = template if from_json else DEFAULT_TEMPLATE
         if self.in_memory:
             self.scheduler = None
             self.submitter = None if not source else LiveSubmitThread(
                 source, cores=task_cores, memory=task_memory, timeout=task_timeout, queue_config=queue_config,
-                bundlesize=bundlesize, bundlewait=bundlewait)
+                bundlesize=bundlesize, bundlewait=bundlewait, template=submit_template)
         else:
             self.submitter = None if not source else SubmitThread(
                 source, cores=task_cores, memory=task_memory, timeout=task_timeout,
-                bundlesize=bundlesize, bundlewait=bundlewait)
+                bundlesize=bundlesize, bundlewait=bundlewait, template=submit_template)
             self.scheduler = SchedulerThread(queue=self.queue, bundlesize=bundlesize, attempts=max_retries + 1,
                                              eager=eager, forever_mode=forever_mode, restart_mode=restart_mode,
                                              poll=poll)

--- a/src/hypershell/submit.py
+++ b/src/hypershell/submit.py
@@ -47,6 +47,7 @@ import os
 import re
 import io
 import sys
+import json
 import functools
 from enum import Enum
 from datetime import datetime
@@ -75,7 +76,8 @@ from hypershell.data.model import Task, DEFAULT_TASK_GROUP, serialize_tasks
 from hypershell.data import initdb, checkdb, DATABASE_DIALECT
 
 # Public interface
-__all__ = ['submit_from', 'submit_file', 'SubmitThread', 'LiveSubmitThread', 'SubmitApp',
+__all__ = ['submit_from', 'submit_file', 'load_json_tasks', 'validate_json_expansion',
+           'SubmitThread', 'LiveSubmitThread', 'SubmitApp',
            'DEFAULT_TASK_GROUP', 'DEFAULT_BUNDLESIZE', 'DEFAULT_BUNDLEWAIT', 'DEFAULT_TEMPLATE']
 
 # Initialize logger
@@ -100,7 +102,7 @@ class Loader(StateMachine):
     """Enqueue tasks from iterable source."""
 
     task: Task
-    source: Iterator[str]
+    source: Iterator[str | dict]
     queue: Queue[Optional[Task]]
     cores: Optional[int]
     memory: Optional[int]
@@ -114,7 +116,7 @@ class Loader(StateMachine):
     states = LoaderState
 
     def __init__(self: Loader,
-                 source: Iterable[str],
+                 source: Iterable[str | dict],
                  queue: Queue[Optional[Task]],
                  cores: int = None,
                  memory: int = None,
@@ -124,7 +126,7 @@ class Loader(StateMachine):
                  tags: Dict[str, str] = None) -> None:
         """Initialize source to read tasks and submit to database."""
         self.template = Template(template)
-        self.source = map(self.template.expand, map(str.strip, map(str, source)))
+        self.source = iter(source)
         self.queue = queue
         self.cores = cores
         self.memory = memory
@@ -149,28 +151,51 @@ class Loader(StateMachine):
         return LoaderState.GET
 
     def get_task(self: Loader) -> LoaderState:
-        """Get the next task from the source."""
+        """Get the next item from the source and dispatch by its kind."""
         try:
-            args = next(self.source)
-            self.task = Task.new(args=args, cores=self.cores, memory=self.memory, timeout=self.timeout,
-                                 group=self.group, tag=self.tags)
-            if self.task.args:
-                log.trace(f'Loaded task ({self.task.args})')
-                return LoaderState.PUT
-            else:
-                # NOTE: group, cores, memory, etc. are processed as "tags" here,
-                # Though passed as 'tag' they are re-extracted in Task.new()
-                _, inline_tags = Task.split_argline(args)  # Simpler to just reprocess
-                if inline_tags:
-                    tagline = ', '.join(format_tag(k, v) for k, v in inline_tags.items())
-                    log.debug(f'Setting global attribute or tag: {tagline}')
-                    for k, v in inline_tags.items():
-                        self.tags[k] = v
-                else:
-                    log.trace(f'Skipping empty line')
-                return LoaderState.GET
+            item = next(self.source)
         except StopIteration:
             return LoaderState.FINAL
+        if isinstance(item, dict):
+            return self.load_json_task(item)
+        else:
+            return self.load_line_task(item)
+
+    def load_line_task(self: Loader, line: str) -> LoaderState:
+        """Build the next task from a command-line string in the text source."""
+        args = self.template.expand(str(line).strip())
+        self.task = Task.new(args=args, cores=self.cores, memory=self.memory, timeout=self.timeout,
+                             group=self.group, tag=self.tags)
+        if self.task.args:
+            log.trace(f'Loaded task ({self.task.args})')
+            return LoaderState.PUT
+        else:
+            # NOTE: group, cores, memory, etc. are processed as "tags" here,
+            # Though passed as 'tag' they are re-extracted in Task.new()
+            _, inline_tags = Task.split_argline(args)  # Simpler to just reprocess
+            if inline_tags:
+                tagline = ', '.join(format_tag(k, v) for k, v in inline_tags.items())
+                log.debug(f'Setting global attribute or tag: {tagline}')
+                for k, v in inline_tags.items():
+                    self.tags[k] = v
+            else:
+                log.trace(f'Skipping empty line')
+            return LoaderState.GET
+
+    def load_json_task(self: Loader, record: dict) -> LoaderState:
+        """Build the next task from a JSON record (named `{key}` expansion + tags)."""
+        # The optional `args` key is the base command; the template ({} -> base)
+        # is expanded against the record as named context. All other keys become
+        # tags (nested values are JSON-serialized; scalars are kept as-is).
+        base = str(record.get('args', ''))
+        args = self.template.expand(base, context=record)
+        record_tags = {key: (json.dumps(value, separators=(',', ':')) if isinstance(value, (dict, list)) else value)
+                       for key, value in record.items() if key != 'args'}
+        tags = {**(self.tags or {}), **record_tags}
+        self.task = Task.new(args=args, cores=self.cores, memory=self.memory, timeout=self.timeout,
+                             group=self.group, tag=tags, strict_tag=False, parse_inline=False)
+        log.trace(f'Loaded task ({self.task.args})')
+        return LoaderState.PUT
 
     def put_task(self: Loader) -> LoaderState:
         """Enqueue loaded task."""
@@ -192,7 +217,7 @@ class LoaderThread(Thread):
     """Run loader within dedicated thread."""
 
     def __init__(self: LoaderThread,
-                 source: Iterable[str],
+                 source: Iterable[str | dict],
                  queue: Queue[Optional[Task]],
                  template: str = DEFAULT_TEMPLATE,
                  cores: int = None,
@@ -372,13 +397,13 @@ class SubmitThread(Thread):
         - :meth:`submit_file`
     """
 
-    source: Iterable[str]
+    source: Iterable[str | dict]
     queue: Queue[Optional[Task]]
     loader: LoaderThread
     committer: DatabaseCommitterThread
 
     def __init__(self: SubmitThread,
-                 source: Iterable[str],
+                 source: Iterable[str | dict],
                  cores: int = None,
                  memory: int = None,
                  timeout: int = None,
@@ -605,14 +630,14 @@ class LiveSubmitThread(Thread):
         - :meth:`submit_file`
     """
 
-    source: Iterable[str]
+    source: Iterable[str | dict]
     local: Queue[Optional[Task]]
     client: QueueClient
     loader: LoaderThread
     committer: QueueCommitterThread
 
     def __init__(self: LiveSubmitThread,
-                 source: Iterable[str],
+                 source: Iterable[str | dict],
                  queue_config: QueueConfig,
                  template: str = DEFAULT_TEMPLATE,
                  cores: int = None,
@@ -669,7 +694,7 @@ class LiveSubmitThread(Thread):
         return self.loader.machine.count
 
 
-def submit_from(source: Iterable[str],
+def submit_from(source: Iterable[str | dict],
                 queue_config: QueueConfig = None,
                 bundlesize: int = DEFAULT_BUNDLESIZE,
                 bundlewait: int = DEFAULT_BUNDLEWAIT,
@@ -842,6 +867,72 @@ def submit_file(path: str,
                            template=template, cores=cores, memory=memory, timeout=timeout, group=group, tags=tags)
 
 
+def load_json_tasks(spec: str) -> List[dict]:
+    """
+    Load a list of task records from a JSON file `spec`.
+
+    The `spec` is ``FILE[@dotted.path]``: split on the first ``@``, the remainder
+    is a dotted path of object keys locating the task list inside the document
+    (e.g. ``plan.json@results.tasks``). With no ``@`` the file's top level must
+    itself be the list. A `FILE` of ``-`` reads from ``<stdin>``.
+
+    The located node must be a non-empty list of objects; each object's key/values
+    become both a task's tags and its ``{key}`` template-expansion context.
+
+    Returns:
+        records (List[dict]): The list of task record objects.
+    """
+    filepath, _, path = spec.partition('@')
+    if not filepath:
+        raise ArgumentError(f'Missing filename in --from-json spec: "{spec}"')
+    try:
+        if filepath == '-':
+            data = json.load(sys.stdin)
+        else:
+            with open(filepath, mode='r') as stream:
+                data = json.load(stream)
+    except FileNotFoundError as error:
+        raise ArgumentError(f'File not found: {filepath}') from error
+    except json.JSONDecodeError as error:
+        raise ArgumentError(f'Invalid JSON in {filepath}: {error}') from error
+    node = data
+    if path:
+        for segment in path.split('.'):
+            if not isinstance(node, dict) or segment not in node:
+                raise ArgumentError(f'Path "{path}" not found in {filepath} (no key "{segment}")')
+            node = node[segment]
+    location = f'"{path}"' if path else 'top level'
+    if not isinstance(node, list):
+        raise ArgumentError(f'Expected a list of task objects at {location} in {filepath}, '
+                            f'found {type(node).__name__}')
+    if not node:
+        raise ArgumentError(f'Task list at {location} in {filepath} is empty')
+    for index, record in enumerate(node):
+        if not isinstance(record, dict):
+            raise ArgumentError(f'Task {index} at {location} in {filepath} is not an object '
+                                f'(found {type(record).__name__})')
+    return node
+
+
+def validate_json_expansion(records: List[dict], template: str = DEFAULT_TEMPLATE) -> None:
+    """
+    Fail-fast pre-flight: ensure every record in `records` fully expands against
+    `template` (all ``{key}`` present, resulting command non-empty). Raises
+    :class:`~cmdkit.cli.ArgumentError` naming the offending record on the first
+    failure, before any task is committed.
+    """
+    engine = Template(template)
+    for index, record in enumerate(records):
+        base = str(record.get('args', ''))
+        try:
+            command = engine.expand(base, context=record)
+        except Template.Error as error:
+            raise ArgumentError(f'record {index}: {error}') from error
+        if not command.strip():
+            raise ArgumentError(f'record {index}: expands to an empty command '
+                                f'(provide an "args" field or a --template with fields)')
+
+
 DEFAULT_HOST: Final[str] = QueueConfig.host
 """Default host for server connection."""
 
@@ -856,7 +947,7 @@ APP_NAME: Final[str] = 'hs submit'
 PAD_NAME: Final[str] = ' ' * len(APP_NAME)
 APP_USAGE: Final[str] = f"""\
 Usage:
-  {APP_NAME} [-h] [ARGS... | -f FILE] [-q [-H ADDR] [-p NUM] [-k KEY] | --initdb]
+  {APP_NAME} [-h] [ARGS... | -f FILE | --from-json SPEC] [-q [-H ADDR] [-p NUM] [-k KEY] | --initdb]
   {PAD_NAME} [-b NUM] [-w SEC] [-c NUM] [-m MEM] [-W SEC] [-g NUM] [--template CMD] [-t TAG...]
   {PAD_NAME} [--no-tls | [--tls-ca PATH] [--tls-cert PATH] [--tls-key PATH]]
 
@@ -868,6 +959,8 @@ APP_HELP: Final[str] = f"""\
 
   Submit a single command using positional arguments.
   If a filepath is provided, read many tasks from the file instead.
+  With --from-json, read tasks from a JSON file and expand named "{{key}}"
+  fields in the template from each task object (keys also become tags).
   Submit directly to a live queue with --queue.
 
 Arguments:
@@ -875,6 +968,7 @@ Arguments:
 
 Options:
   -f, --task-file    FILE    Path to task file ("-" for <stdin>).
+      --from-json    SPEC    Read tasks from a JSON file ("FILE[@path]").
   -q, --queue                Submit to live queue instead of database.
   -H, --host         ADDR    Hostname for server (default: {DEFAULT_HOST}). Used with --queue.
   -p, --port         NUM     Port number for server (default: {DEFAULT_PORT}). Used with --queue.
@@ -905,8 +999,10 @@ class SubmitApp(Application):
     source: IO | List[str] | None = None
     task_args: List[str] = []
     task_file: str = None
+    from_json: str = None
     interface.add_argument('task_args', nargs='*')
     interface.add_argument('-f', '--task-file', default=task_file)
+    interface.add_argument('--from-json', default=from_json, dest='from_json')
 
     bundlesize: int = config.submit.bundlesize
     interface.add_argument('-b', '--bundlesize', type=int, default=bundlesize)
@@ -1027,6 +1123,14 @@ class SubmitApp(Application):
 
     def check_source(self: SubmitApp) -> None:
         """Determine task submission mode."""
+        if self.from_json:
+            if self.task_args or self.task_file:
+                raise ArgumentError('Cannot combine --from-json with -f/--task-file or positional arguments')
+            records = load_json_tasks(self.from_json)
+            validate_json_expansion(records, self.template)
+            log.debug(f'Loaded {len(records)} tasks from JSON ({self.from_json})')
+            self.source = records
+            return
         if self.task_args and self.task_file:
             raise ArgumentError(f'Cannot specify both -f/--task-file and positional arguments')
         if self.task_file == '-':
@@ -1084,5 +1188,5 @@ class SubmitApp(Application):
                  exc_val: Optional[Exception],
                  exc_tb: Optional[TracebackType]) -> None:
         """Close file if not stdin."""
-        if self.source is not None and self.source is not sys.stdin:
+        if self.source is not None and self.source is not sys.stdin and hasattr(self.source, 'close'):
             self.source.close()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,12 +11,13 @@ from typing import Final, List, Tuple, Dict, Any
 # Standard libs
 import os
 import re
+import json
 from pathlib import Path
 from subprocess import run, PIPE
 
 # Public interface
 __all__ = ['NO_OUTPUT', 'main', 'main_lines', 'assert_output',
-           'create_taskfile', 'create_taskfile_echo',
+           'create_taskfile', 'create_taskfile_echo', 'create_json_taskfile',
            'UUID_PATTERN']
 
 
@@ -68,6 +69,14 @@ def create_taskfile_echo(temp_site: Path, count: int, tags: Dict[str, Any] = Non
     """Produce task input file with 'echo {}' lines, return path."""
     tagline = ' '.join([f'{k}:{v}' for k, v in (tags or {}).items()])
     return create_taskfile(temp_site, lines=[f'echo {n}  # HYPERSHELL: {tagline} n:{n}' for n in range(count)])
+
+
+def create_json_taskfile(temp_site: Path, data: Any, filename: str = 'plan.json') -> Path:
+    """Produce a JSON task plan file for test, return path."""
+    taskfile = temp_site / filename
+    with open(taskfile, mode='w', encoding='utf-8') as stream:
+        json.dump(data, stream)
+    return taskfile
 
 
 UUID_PATTERN: re.Pattern = re.compile(

--- a/tests/test_submit_json.py
+++ b/tests/test_submit_json.py
@@ -1,0 +1,287 @@
+# SPDX-FileCopyrightText: 2026 Geoffrey Lentner
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test JSON task-plan submission (--from-json) and named {key} template expansion."""
+
+
+# Type annotations
+from __future__ import annotations
+from pathlib import Path
+
+# Standard libs
+import re
+
+# External libs
+from pytest import mark
+from cmdkit.app import exit_status
+
+# Internal libs
+from tests import main, main_lines, NO_OUTPUT, create_json_taskfile, assert_output
+from hypershell.core.template import Template, render_value
+
+
+# ---------------------------------------------------------------------------
+# Template engine unit tests (named {key} context + render_value)
+# ---------------------------------------------------------------------------
+
+@mark.unit
+def test_template_named_expansion() -> None:
+    """Named keys resolve from the provided context."""
+    template = Template('{a}-{b}')
+    assert template.expand('', context={'a': 'X', 'b': 'Y'}) == 'X-Y'
+
+
+@mark.unit
+def test_template_base_and_named() -> None:
+    """The base args ({}) and named keys expand together."""
+    template = Template('{} --region {seqid}')
+    assert template.expand('process Chr1', context={'seqid': 'Chr1'}) == 'process Chr1 --region Chr1'
+
+
+@mark.unit
+def test_template_missing_key_raises() -> None:
+    """A named key absent from context raises UnmatchedPattern."""
+    template = Template('{x}')
+    try:
+        template.expand('', context={})
+    except Template.UnmatchedPattern:
+        pass
+    else:
+        raise AssertionError('Expected Template.UnmatchedPattern for missing key')
+
+
+@mark.unit
+def test_template_builtin_precedence() -> None:
+    """Built-in simple patterns take precedence over same-named context keys."""
+    template = Template('{/}')
+    assert template.expand('/data/x/y.bam', context={'/': 'shadowed'}) == 'y.bam'
+
+
+@mark.unit
+def test_template_no_context_backcompat() -> None:
+    """Expansion without context behaves exactly as before (positional args)."""
+    assert Template('echo {}').expand('hello world') == 'echo hello world'
+
+
+@mark.unit
+@mark.parametrize('value,expected', [
+    ('abc', 'abc'),
+    (5, '5'),
+    (1.5, '1.5'),
+    (True, 'true'),
+    (False, 'false'),
+    (None, ''),
+    ({'a': 1}, '{"a":1}'),
+    ([1, 2], '[1,2]'),
+])
+def test_render_value(value, expected) -> None:
+    """render_value stringifies JSON values for {key} expansion."""
+    assert render_value(value) == expected
+
+
+# ---------------------------------------------------------------------------
+# `hs submit --from-json` integration tests
+# ---------------------------------------------------------------------------
+
+CHUNK_PLAN = {
+    'metadata': {'strategy': 'adaptive'},
+    'chunks': [
+        {'chunk_id': 'c1', 'seqid': 'Chr1', 'start': 1, 'end': 5000000},
+        {'chunk_id': 'c2', 'seqid': 'Chr2', 'start': 1, 'end': 3000000},
+    ],
+}
+
+
+@mark.integration
+def test_from_json_basic(temp_site: Path) -> None:
+    """Named {key} fields expand from each JSON record."""
+    plan = create_json_taskfile(temp_site, CHUNK_PLAN)
+    rc, stdout, stderr = main(['hs', 'submit', f'--from-json={plan}@chunks',
+                               '--template', 'process --region {seqid}:{start}-{end} --id {chunk_id}'])
+    assert rc == exit_status.success
+    assert_output(r'INFO .* Submitted 2 tasks$', stderr, 1)
+    _, args, _ = main_lines(['hs', 'list', 'args', '-f', 'plain'])
+    assert sorted(args) == [
+        'process --region Chr1:1-5000000 --id c1',
+        'process --region Chr2:1-3000000 --id c2',
+    ]
+
+
+@mark.integration
+def test_from_json_top_level_array(temp_site: Path) -> None:
+    """A top-level JSON array requires no @path."""
+    plan = create_json_taskfile(temp_site, [{'seqid': 'Chr1'}, {'seqid': 'Chr2'}])
+    rc, _, _ = main(['hs', 'submit', f'--from-json={plan}', '--template', 'echo {seqid}'])
+    assert rc == exit_status.success
+    _, args, _ = main_lines(['hs', 'list', 'args', '-f', 'plain'])
+    assert sorted(args) == ['echo Chr1', 'echo Chr2']
+
+
+@mark.integration
+def test_from_json_dotted_path(temp_site: Path) -> None:
+    """A dotted @path traverses nested objects to the task list."""
+    plan = create_json_taskfile(temp_site, {'results': {'tasks': [{'x': 'A'}, {'x': 'B'}]}})
+    rc, _, _ = main(['hs', 'submit', f'--from-json={plan}@results.tasks', '--template', 'echo {x}'])
+    assert rc == exit_status.success
+    _, args, _ = main_lines(['hs', 'list', 'args', '-f', 'plain'])
+    assert sorted(args) == ['echo A', 'echo B']
+
+
+@mark.integration
+def test_from_json_args_field(temp_site: Path) -> None:
+    """The 'args' key supplies the base command reachable via {}."""
+    plan = create_json_taskfile(temp_site, [{'args': 'process Chr1', 'region': 'Chr1:1-10'}])
+    rc, _, _ = main(['hs', 'submit', f'--from-json={plan}', '--template', '{} --region {region}'])
+    assert rc == exit_status.success
+    assert main_lines(['hs', 'list', 'args', '-f', 'plain']) == (
+        exit_status.success, ['process Chr1 --region Chr1:1-10'], NO_OUTPUT
+    )
+
+
+@mark.integration
+def test_from_json_default_template_empty_command_errors(temp_site: Path) -> None:
+    """Without an 'args' field, the default template ({}) yields an empty command."""
+    plan = create_json_taskfile(temp_site, [{'seqid': 'Chr1'}])
+    rc, stdout, stderr = main(['hs', 'submit', f'--from-json={plan}'])
+    assert rc == exit_status.bad_argument
+    assert_output(r'CRITICAL .* record 0: expands to an empty command', stderr, 1)
+    # Nothing committed
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['0'], NO_OUTPUT)
+
+
+@mark.integration
+def test_from_json_relaxed_tags(temp_site: Path) -> None:
+    """JSON values with spaces/slashes/colons are stored as tags (validator relaxed)."""
+    plan = create_json_taskfile(temp_site, [{'seqid': 'Chr1', 'note': 'a b/c:d'}])
+    rc, _, _ = main(['hs', 'submit', f'--from-json={plan}', '--template', 'echo {seqid}'])
+    assert rc == exit_status.success
+    _, stdout, _ = main(['hs', 'list', 'tag', '-f', 'plain'])
+    assert 'a b/c:d' in stdout
+
+
+@mark.integration
+def test_from_json_nested_value_rendered(temp_site: Path) -> None:
+    """Nested JSON values render as compact JSON for {key} expansion."""
+    plan = create_json_taskfile(temp_site, [{'meta': {'nested': True}}])
+    rc, _, _ = main(['hs', 'submit', f'--from-json={plan}', '--template', 'echo {meta}'])
+    assert rc == exit_status.success
+    assert main_lines(['hs', 'list', 'args', '-f', 'plain']) == (
+        exit_status.success, ['echo {"nested":true}'], NO_OUTPUT
+    )
+
+
+@mark.integration
+def test_from_json_bool_null_render(temp_site: Path) -> None:
+    """Booleans render true/false and null renders empty in {key} expansion."""
+    plan = create_json_taskfile(temp_site, [{'flag': True, 'off': False, 'empty': None, 'n': 1}])
+    rc, _, _ = main(['hs', 'submit', f'--from-json={plan}',
+                     '--template', 'echo f={flag} o={off} e=[{empty}] n={n}'])
+    assert rc == exit_status.success
+    assert main_lines(['hs', 'list', 'args', '-f', 'plain']) == (
+        exit_status.success, ['echo f=true o=false e=[] n=1'], NO_OUTPUT
+    )
+
+
+@mark.integration
+def test_from_json_reserved_key_promotion(temp_site: Path) -> None:
+    """Reserved keys (cores) promote to columns and remain available for {key}."""
+    plan = create_json_taskfile(temp_site, [{'x': 'y', 'cores': 8}])
+    rc, _, _ = main(['hs', 'submit', f'--from-json={plan}', '--template', 'echo {x} c={cores}'])
+    assert rc == exit_status.success
+    assert main_lines(['hs', 'list', 'args', 'cores', '-f', 'plain']) == (
+        exit_status.success, ['echo y c=8\t8'], NO_OUTPUT
+    )
+
+
+@mark.integration
+def test_from_json_failfast_missing_key(temp_site: Path) -> None:
+    """A record missing a referenced key aborts before committing anything."""
+    plan = create_json_taskfile(temp_site, [{'seqid': 'Chr1', 'end': 10}, {'seqid': 'Chr2'}])
+    rc, stdout, stderr = main(['hs', 'submit', f'--from-json={plan}', '--template', 'echo {seqid}:{end}'])
+    assert rc == exit_status.bad_argument
+    assert_output(r"CRITICAL .* record 1: '\{end\}'", stderr, 1)
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['0'], NO_OUTPUT)
+
+
+@mark.integration
+def test_from_json_empty_list(temp_site: Path) -> None:
+    """An empty task list is a clear error."""
+    plan = create_json_taskfile(temp_site, {'chunks': []})
+    rc, _, stderr = main(['hs', 'submit', f'--from-json={plan}@chunks', '--template', 'echo {x}'])
+    assert rc == exit_status.bad_argument
+    assert_output(r'CRITICAL .* Task list at "chunks" .* is empty', stderr, 1)
+
+
+@mark.integration
+def test_from_json_not_a_list(temp_site: Path) -> None:
+    """A path that resolves to a non-list is a clear error."""
+    plan = create_json_taskfile(temp_site, {'chunks': {'not': 'a list'}})
+    rc, _, stderr = main(['hs', 'submit', f'--from-json={plan}@chunks', '--template', 'echo {x}'])
+    assert rc == exit_status.bad_argument
+    assert_output(r'CRITICAL .* Expected a list of task objects .* found dict', stderr, 1)
+
+
+@mark.integration
+def test_from_json_bad_path(temp_site: Path) -> None:
+    """A missing path segment is a clear error."""
+    plan = create_json_taskfile(temp_site, {'chunks': [{'x': 1}]})
+    rc, _, stderr = main(['hs', 'submit', f'--from-json={plan}@does.not.exist', '--template', 'echo {x}'])
+    assert rc == exit_status.bad_argument
+    assert_output(r'CRITICAL .* Path "does.not.exist" not found.*no key "does"', stderr, 1)
+
+
+@mark.integration
+def test_from_json_element_not_object(temp_site: Path) -> None:
+    """A non-object list element is a clear error."""
+    plan = create_json_taskfile(temp_site, [{'x': 1}, 'not-an-object'])
+    rc, _, stderr = main(['hs', 'submit', f'--from-json={plan}', '--template', 'echo {x}'])
+    assert rc == exit_status.bad_argument
+    assert_output(r'CRITICAL .* Task 1 .* is not an object.*found str', stderr, 1)
+
+
+@mark.integration
+def test_from_json_file_not_found(temp_site: Path) -> None:
+    """A missing JSON file is a clear error."""
+    missing = str(temp_site / 'missing.json')
+    rc, _, stderr = main(['hs', 'submit', f'--from-json={missing}@chunks', '--template', 'echo {x}'])
+    assert rc == exit_status.bad_argument
+    assert_output(r'CRITICAL .* File not found: ' + re.escape(missing), stderr, 1)
+
+
+@mark.integration
+def test_from_json_mixed_with_positional(temp_site: Path) -> None:
+    """--from-json cannot be combined with positional args."""
+    plan = create_json_taskfile(temp_site, [{'x': 1}])
+    rc, _, stderr = main(['hs', 'submit', 'echo', 'hi', '--from-json', str(plan), '-g0'])
+    assert rc == exit_status.bad_argument
+    assert_output(r'CRITICAL .* Cannot combine --from-json', stderr, 1)
+
+
+# ---------------------------------------------------------------------------
+# `hsx` / `hs cluster` --from-json end-to-end
+# ---------------------------------------------------------------------------
+
+@mark.integration
+def test_cluster_from_json(temp_site: Path) -> None:
+    """A local cluster expands JSON records submit-side and runs them verbatim."""
+    plan = create_json_taskfile(temp_site, {'chunks': [
+        {'seqid': 'Chr1', 'chunk_id': 'c1'},
+        {'seqid': 'Chr2', 'chunk_id': 'c2'},
+        {'seqid': 'Chr3', 'chunk_id': 'c3'},
+    ]})
+    rc, stdout, stderr = main(['hsx', f'--from-json={plan}@chunks',
+                               '--template', 'echo {seqid} {chunk_id}', '-N', '2'])
+    assert rc == exit_status.success
+    assert sorted(stdout.splitlines()) == ['Chr1 c1', 'Chr2 c2', 'Chr3 c3']
+    assert_output(r'\[hypershell.server\] Completed task', stderr, 3)
+
+    # Stored args are fully expanded; commands ran once (no double expansion)
+    _, args, _ = main_lines(['hs', 'list', 'args', '-f', 'plain'])
+    assert sorted(args) == ['echo Chr1 c1', 'echo Chr2 c2', 'echo Chr3 c3']
+
+    # Status all success, and tags queryable
+    assert main_lines(['hs', 'list', 'exit_status', '-f', 'plain']) == (
+        exit_status.success, ['0'] * 3, NO_OUTPUT
+    )
+    rc, stdout, _ = main(['hs', 'list', 'id', '-t', 'seqid:Chr1', '-f', 'plain'])
+    assert rc == exit_status.success and len(stdout.splitlines()) == 1


### PR DESCRIPTION
The templating engine now supports simple `{name}` pattern substitution. These names are matched to task tags and errors on missing tag keys. Ingesting from JSON input stores known fields (e.g., group, cores) as column data and all other keys are stored as task tags.