### PR TITLE
[feature] Add source-gated re-submission (--restart / --repeat / --update)

### DIFF
--- a/docs/_include/cluster_desc.rst
+++ b/docs/_include/cluster_desc.rst
@@ -8,7 +8,10 @@ given. The command-line tasks are pulled in and either directly published to a d
 
 Alternatively, use ``--from-json`` to read tasks from a JSON file (``FILE[@path]``); each task
 object's keys become named ``{key}`` fields in the ``--template`` (and task tags). In this mode the
-template is expanded when tasks are ingested rather than by the clients.
+template is expanded when tasks are ingested rather than by the clients. A JSON source participates
+in the same re-submission gating as a plain *FILE* — ``--restart`` (idempotent requeue),
+``--repeat``, and ``--update --restart`` all apply — keyed by the file's absolute path together
+with any ``@path`` selector.
 
 For large, long running workflows, it might be a good idea to configure a database and run an
 initial ``submit`` job to populate the database, and then run the cluster with ``--restart`` and no

--- a/docs/_include/cluster_desc.rst
+++ b/docs/_include/cluster_desc.rst
@@ -15,6 +15,12 @@ initial ``submit`` job to populate the database, and then run the cluster with `
 input *FILE*. If the cluster is interrupted for whatever reason it can gracefully restart where it
 left off.
 
+Alternatively, pass the *FILE* directly with ``--restart``: the submission is detected, only tasks
+that never landed are submitted, and interrupted tasks are re-run — so a requeued
+``hsx <FILE> --restart`` job is safe to run repeatedly. Use ``--repeat`` to deliberately submit a
+known file's tasks again as a new source, or ``--update --restart`` to add only the tasks that are
+new since the file was last seen.
+
 Use ``--autoscaling`` with either *fixed* or *dynamic* to run a persistent, elastically scalable
 cluster using an external ``--launcher`` to bring up clients as needed.
 

--- a/docs/_include/cluster_desc.rst
+++ b/docs/_include/cluster_desc.rst
@@ -24,6 +24,10 @@ that never landed are submitted, and interrupted tasks are re-run — so a reque
 known file's tasks again as a new source, or ``--update --restart`` to add only the tasks that are
 new since the file was last seen.
 
+De-dup cost scales with the file's own source lineage rather than the whole database, so requeues stay
+fast at scale; for very large workflows, a one-time ``submit`` followed by a bare ``hsx --restart`` (no
+file re-read) is cheaper than re-feeding the *FILE* each run.
+
 Use ``--autoscaling`` with either *fixed* or *dynamic* to run a persistent, elastically scalable
 cluster using an external ``--launcher`` to bring up clients as needed.
 

--- a/docs/_include/cluster_help.rst
+++ b/docs/_include/cluster_help.rst
@@ -141,17 +141,39 @@ Options
     Conflicts with ``--no-db`` and mutually exclusive to ``--restart``.
 
 ``--restart``
-    Start scheduling from last completed task.
+    Start scheduling from where a prior run left off.
 
-    Instead of pulling a new list of tasks from some input `FILE`, with ``--restart`` enabled the
-    `cluster` will restart scheduling tasks where it left off. Any task in the database that was
-    previously scheduled but not completed will be reverted.
+    With no *FILE*, ``--restart`` resumes purely from the database: any task previously
+    scheduled but not completed is reverted, scheduling continues, and the `cluster` halts when
+    nothing is left to do. This is the classic "populate with ``submit``, then requeue" strategy
+    for very large workflows — if the `cluster` is interrupted it can gracefully continue where
+    it left off.
 
-    For very large workflows, an effective strategy is to first use the ``submit`` workflow to
-    populate the database, and then to use ``--restart`` so that if the `cluster` is interrupted,
-    it can easily continue where it left off, halting if nothing to be done.
+    When a *FILE* is given, ``--restart`` becomes file-aware and idempotent. The file is read
+    upfront (a content fingerprint and task count), and only tasks whose identity is not already
+    present from a prior submission of that same path are submitted; the revert-interrupted flow
+    re-runs anything that was mid-flight. Requeuing the same ``hsx <FILE> --restart`` job as many
+    times as needed therefore never double-submits work. If the file's content has changed since
+    it was last seen, the run is refused with a suggestion to use ``--update --restart``.
 
-    Conflicts with ``--no-db`` and mutually exclusive to ``--forever``.
+    Conflicts with ``--no-db`` and ``--repeat``, and mutually exclusive to ``--forever``.
+
+``--repeat``
+    Re-submit a known file's tasks again as a new source.
+
+    Re-submitting a file that has already been ingested is normally refused. ``--repeat``
+    overrides that: the file is recorded as a brand-new source and *all* of its tasks are
+    submitted again, even if an identical prior submission exists. Combine with ``-t``/tags to
+    represent a new phase or trial of the same work.
+
+``--update``
+    Submit only the tasks that are new since a file was last seen.
+
+    Used together with ``--restart`` (``hsx <FILE> --update --restart``): the file is recorded as
+    a new source and only tasks whose identity is not already present in the prior same-path
+    lineage are submitted — novel tasks run while previously-submitted tasks are skipped. On its
+    own (without ``--restart``) it is ambiguous and refused; it also cannot be combined with
+    ``--repeat``.
 
 ``--ssh-args`` *ARGS*...
     Command-line arguments for SSH. For example, ``--ssh-args '-i ~/.ssh/my_key'``.

--- a/docs/_include/cluster_usage.rst
+++ b/docs/_include/cluster_usage.rst
@@ -1,4 +1,4 @@
-``hs cluster [-h]`` ``[FILE | --from-json SPEC | --restart | --forever]``
+``hs cluster [-h]`` ``[FILE | --from-json SPEC | --restart | --forever]`` ``[--repeat | --update]``
     ``[-N NUM]`` ``[-t CMD]`` ``[-b SIZE]`` ``[-w SEC]`` ``[-Q NUM]``
     ``[-H ADDR]`` ``[-p PORT]`` ``[-r NUM [--eager]]`` ``[-f PATH]`` ``[--capture | [-o PATH] [-e PATH]]``
     ``[--ssh [HOST... | --ssh-group NAME] [--env] | --mpi | --launcher=ARGS...]``

--- a/docs/_include/submit_desc.rst
+++ b/docs/_include/submit_desc.rst
@@ -34,3 +34,8 @@ not already present from earlier versions of the same file. JSON task files (``-
 are gated the same way, keyed by their absolute path together with any ``@path`` selector.
 Single-command and ``<stdin>`` submissions (including ``--from-json -``) are treated as
 explicit intent and are exempt from these checks.
+
+Detection and ``--update`` de-dup are index-backed on the source lineage, so their cost scales with
+that file's own size, not the size of the database: re-submitting a normal file stays fast even against
+a very large database, while ``--update`` on a source of millions of tasks pays to re-read and
+fingerprint the entire file to find what is new.

--- a/docs/_include/submit_desc.rst
+++ b/docs/_include/submit_desc.rst
@@ -24,3 +24,11 @@ object's keys become named ``{key}`` template fields (and task tags), and an opt
 ``args`` key provides the base command (reachable as ``{}``). All ``{key}`` fields are
 validated against every task object up front, so submission is rejected before any task
 is committed if a field is missing.
+
+Re-submitting a named task file is guarded to prevent accidental double submission. Each
+named file is recorded as a *source* (its absolute path, a content fingerprint, and the
+task count); submitting the same file again with no flag is refused, and if the path was
+seen but the content changed the refusal suggests ``--update``. Pass ``--repeat`` to
+deliberately submit all tasks again as a new source, or ``--update`` to submit only tasks
+not already present from earlier versions of the same file. Single-command and ``<stdin>``
+submissions are treated as explicit intent and are exempt from these checks.

--- a/docs/_include/submit_desc.rst
+++ b/docs/_include/submit_desc.rst
@@ -30,5 +30,7 @@ named file is recorded as a *source* (its absolute path, a content fingerprint, 
 task count); submitting the same file again with no flag is refused, and if the path was
 seen but the content changed the refusal suggests ``--update``. Pass ``--repeat`` to
 deliberately submit all tasks again as a new source, or ``--update`` to submit only tasks
-not already present from earlier versions of the same file. Single-command and ``<stdin>``
-submissions are treated as explicit intent and are exempt from these checks.
+not already present from earlier versions of the same file. JSON task files (``--from-json``)
+are gated the same way, keyed by their absolute path together with any ``@path`` selector.
+Single-command and ``<stdin>`` submissions (including ``--from-json -``) are treated as
+explicit intent and are exempt from these checks.

--- a/docs/_include/submit_help.rst
+++ b/docs/_include/submit_help.rst
@@ -20,6 +20,23 @@ Options
     base command (reachable as ``{}``). Every ``{key}`` is validated against all task
     objects before anything is submitted.
 
+``--repeat``
+    Re-submit a known file's tasks again as a brand-new source.
+
+    By default, submitting a named file whose path and content match a prior submission is
+    refused to guard against accidental double submission. ``--repeat`` overrides that: the
+    file is ingested as a new source and all of its tasks are submitted again, even if
+    identical tasks already exist. May be combined with new ``-t``/``--tag`` values to mark
+    a new phase or trial.
+
+``--update``
+    Submit only the tasks in a known file that are not already present.
+
+    Creates a new source record and submits only tasks whose identity (a stable hash of the
+    pre-template arguments, group, and tags) is absent from the prior same-path submissions;
+    tasks already submitted are skipped. Use this after editing a task file to add only the
+    new work. Cannot be combined with ``--repeat``.
+
 ``-q``, ``--queue``
     Submit directly to live queue instead of database.
 

--- a/docs/_include/submit_usage.rst
+++ b/docs/_include/submit_usage.rst
@@ -1,5 +1,5 @@
 ``hs`` ``submit`` ``[-h]`` ``[ARGS... | -f FILE | --from-json SPEC]``
     ``[-q [-H ADDR] [-p NUM] [-k KEY] | --initdb]``
     ``[-b NUM]`` ``[-w SEC]`` ``[-c NUM]`` ``[-m MEM]`` ``[-W SEC]`` ``[-g NUM]``
-    ``[--template CMD]`` ``[-t TAG...]``
+    ``[--repeat | --update]`` ``[--template CMD]`` ``[-t TAG...]``
     ``[--no-tls | [--tls-ca PATH] [--tls-cert PATH] [--tls-key PATH]]``

--- a/share/bash_completion.d/hs
+++ b/share/bash_completion.d/hs
@@ -517,7 +517,7 @@ function _hs_submit() {
 	local previous="${COMP_WORDS[COMP_CWORD - 1]}"
 	local all_opts="-h --help -f --task-file -q --queue -H --host -p --port -k --auth
 	--no-tls --tls-key --tls-cert --tls-ca --template -t --tag -b --bundlesize -w --bundlewait
-	-c --cores -m --memory -W --timeout -g --group --initdb --"
+	-c --cores -m --memory -W --timeout -g --group --repeat --update --initdb --"
 
 	if [ "${COMP_CWORD}" -eq 2 ]
 	then

--- a/share/bash_completion.d/hs
+++ b/share/bash_completion.d/hs
@@ -515,7 +515,7 @@ function _hs_task_update() {
 function _hs_submit() {
 	local current="${COMP_WORDS[COMP_CWORD]}"
 	local previous="${COMP_WORDS[COMP_CWORD - 1]}"
-	local all_opts="-h --help -f --task-file -q --queue -H --host -p --port -k --auth
+	local all_opts="-h --help -f --task-file --from-json -q --queue -H --host -p --port -k --auth
 	--no-tls --tls-key --tls-cert --tls-ca --template -t --tag -b --bundlesize -w --bundlewait
 	-c --cores -m --memory -W --timeout -g --group --repeat --update --initdb --"
 
@@ -545,7 +545,7 @@ function _hs_submit() {
 	esac
 
 	case "${previous}" in
-		-f | --task-file | --tls-key | --tls-cert | --tls-ca)
+		-f | --task-file | --from-json | --tls-key | --tls-cert | --tls-ca)
 			COMPREPLY=($(compgen -f -- "${current}")); return ;;
 		-b | --bundlesize) COMPREPLY=($(compgen -W "1 10 100 1000" -- "${current}")); return ;;
 		-w | --bundlewait) COMPREPLY=($(compgen -W "5 10 30 60 600" -- "${current}")); return ;;
@@ -651,7 +651,7 @@ function _hs_server() {
 function _hs_cluster() {
 	local current="${COMP_WORDS[COMP_CWORD]}"
 	local previous="${COMP_WORDS[COMP_CWORD - 1]}"
-	local all_opts="-h --help -N --num-threads -t --template -H --bind -p --port
+	local all_opts="-h --help -N --num-threads -t --template --from-json -H --bind -p --port
 	--no-tls --tls-key --tls-cert --tls-ca -b --bundlesize -w --bundlewait
 	-r --max-retries --eager -Q --poll --no-db --initdb --no-confirm --forever --restart --repeat --update
 	--ssh --mpi --launcher --ssh-args --ssh-group -E --env --remote-exe
@@ -685,7 +685,7 @@ function _hs_cluster() {
 	fi
 
 	case "${previous}" in
-		-o | --output | -e | --errors | -f | --failures | --tls-key | --tls-cert | --tls-ca)
+		-o | --output | -e | --errors | -f | --failures | --from-json | --tls-key | --tls-cert | --tls-ca)
 			COMPREPLY=($(compgen -f -- "${current}")); return ;;
 		-N | --num-threads)
 			COMPREPLY=($(compgen -W "0 1 $(seq 2 2 "$(hs client --available-cores 2>/dev/null)" 2>/dev/null)" -- "${current}")); return ;;

--- a/share/bash_completion.d/hs
+++ b/share/bash_completion.d/hs
@@ -653,7 +653,7 @@ function _hs_cluster() {
 	local previous="${COMP_WORDS[COMP_CWORD - 1]}"
 	local all_opts="-h --help -N --num-threads -t --template -H --bind -p --port
 	--no-tls --tls-key --tls-cert --tls-ca -b --bundlesize -w --bundlewait
-	-r --max-retries --eager -Q --poll --no-db --initdb --no-confirm --forever --restart
+	-r --max-retries --eager -Q --poll --no-db --initdb --no-confirm --forever --restart --repeat --update
 	--ssh --mpi --launcher --ssh-args --ssh-group -E --env --remote-exe
 	-d --delay-start --capture -o --output -e --errors -f --failures
 	-c --cores -m --memory -C --client-cores -M --client-memory --monitor

--- a/share/man/man1/hs.1
+++ b/share/man/man1/hs.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "HS" "1" "Jul 11, 2026" "2.8.1" "hypershell"
+.TH "HS" "1" "Jul 12, 2026" "2.8.1" "hypershell"
 .SH NAME
 hs \- Process shell commands over a distributed, asynchronous queue
 .SH SYNOPSIS
@@ -123,6 +123,10 @@ that never landed are submitted, and interrupted tasks are re\-run — so a requ
 \fBhsx <FILE> \-\-restart\fP job is safe to run repeatedly. Use \fB\-\-repeat\fP to deliberately submit a
 known file\(aqs tasks again as a new source, or \fB\-\-update \-\-restart\fP to add only the tasks that are
 new since the file was last seen.
+.sp
+De\-dup cost scales with the file\(aqs own source lineage rather than the whole database, so requeues stay
+fast at scale; for very large workflows, a one\-time \fBsubmit\fP followed by a bare \fBhsx \-\-restart\fP (no
+file re\-read) is cheaper than re\-feeding the \fIFILE\fP each run.
 .sp
 Use \fB\-\-autoscaling\fP with either \fIfixed\fP or \fIdynamic\fP to run a persistent, elastically scalable
 cluster using an external \fB\-\-launcher\fP to bring up clients as needed.
@@ -988,6 +992,11 @@ not already present from earlier versions of the same file. JSON task files (\fB
 are gated the same way, keyed by their absolute path together with any \fB@path\fP selector.
 Single\-command and \fB<stdin>\fP submissions (including \fB\-\-from\-json \-\fP) are treated as
 explicit intent and are exempt from these checks.
+.sp
+Detection and \fB\-\-update\fP de\-dup are index\-backed on the source lineage, so their cost scales with
+that file\(aqs own size, not the size of the database: re\-submitting a normal file stays fast even against
+a very large database, while \fB\-\-update\fP on a source of millions of tasks pays to re\-read and
+fingerprint the entire file to find what is new.
 .SS Arguments
 .INDENT 0.0
 .TP

--- a/share/man/man1/hs.1
+++ b/share/man/man1/hs.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "HS" "1" "Jul 08, 2026" "2.8.1" "hypershell"
+.TH "HS" "1" "Jul 11, 2026" "2.8.1" "hypershell"
 .SH NAME
 hs \- Process shell commands over a distributed, asynchronous queue
 .SH SYNOPSIS
@@ -88,7 +88,7 @@ Stand up the \fBserver\fP on its own and scale \fBclients\fP as desired, and \fB
 .SH CLUSTER USAGE
 .INDENT 0.0
 .TP
-.B \fBhs cluster [\-h]\fP \fB[FILE | \-\-restart | \-\-forever]\fP
+.B \fBhs cluster [\-h]\fP \fB[FILE | \-\-from\-json SPEC | \-\-restart | \-\-forever]\fP \fB[\-\-repeat | \-\-update]\fP
 \fB[\-N NUM]\fP \fB[\-t CMD]\fP \fB[\-b SIZE]\fP \fB[\-w SEC]\fP \fB[\-Q NUM]\fP
 \fB[\-H ADDR]\fP \fB[\-p PORT]\fP \fB[\-r NUM [\-\-eager]]\fP \fB[\-f PATH]\fP \fB[\-\-capture | [\-o PATH] [\-e PATH]]\fP
 \fB[\-\-ssh [HOST... | \-\-ssh\-group NAME] [\-\-env] | \-\-mpi | \-\-launcher=ARGS...]\fP
@@ -106,10 +106,23 @@ The input source for tasks is file\-like, either a local path, or from \fIstdin\
 given. The command\-line tasks are pulled in and either directly published to a distributed queue
 (see \fB\-\-no\-db\fP) or committed to a database first before being scheduled later.
 .sp
+Alternatively, use \fB\-\-from\-json\fP to read tasks from a JSON file (\fBFILE[@path]\fP); each task
+object\(aqs keys become named \fB{key}\fP fields in the \fB\-\-template\fP (and task tags). In this mode the
+template is expanded when tasks are ingested rather than by the clients. A JSON source participates
+in the same re\-submission gating as a plain \fIFILE\fP — \fB\-\-restart\fP (idempotent requeue),
+\fB\-\-repeat\fP, and \fB\-\-update \-\-restart\fP all apply — keyed by the file\(aqs absolute path together
+with any \fB@path\fP selector.
+.sp
 For large, long running workflows, it might be a good idea to configure a database and run an
 initial \fBsubmit\fP job to populate the database, and then run the cluster with \fB\-\-restart\fP and no
 input \fIFILE\fP\&. If the cluster is interrupted for whatever reason it can gracefully restart where it
 left off.
+.sp
+Alternatively, pass the \fIFILE\fP directly with \fB\-\-restart\fP: the submission is detected, only tasks
+that never landed are submitted, and interrupted tasks are re\-run — so a requeued
+\fBhsx <FILE> \-\-restart\fP job is safe to run repeatedly. Use \fB\-\-repeat\fP to deliberately submit a
+known file\(aqs tasks again as a new source, or \fB\-\-update \-\-restart\fP to add only the tasks that are
+new since the file was last seen.
 .sp
 Use \fB\-\-autoscaling\fP with either \fIfixed\fP or \fIdynamic\fP to run a persistent, elastically scalable
 cluster using an external \fB\-\-launcher\fP to bring up clients as needed.
@@ -159,6 +172,15 @@ arguments (e.g., file paths) to be transformed into some common form; such as
 \fB\-t \(aq./some_command.py {} >outputs/{/\-}.out\(aq\fP\&.
 .sp
 See section on \fItemplates\fP\&.
+.TP
+.B \fB\-\-from\-json\fP \fISPEC\fP
+Read tasks from a JSON file (\fBFILE[@path]\fP).
+.sp
+The optional dotted \fBpath\fP after \fB@\fP locates the list of task objects inside the
+document (e.g. \fBplan.json@chunks\fP); with no \fB@\fP the file\(aqs top level must be the
+list. Each task object\(aqs keys become named \fB{key}\fP fields in the \fB\-\-template\fP and
+task tags. In this mode the template is expanded when tasks are ingested (submit\-side),
+not by the clients.
 .TP
 .B \fB\-H\fP, \fB\-\-bind\fP \fIADDR\fP
 Bind address (default: localhost, or 0.0.0.0 for remote clients).
@@ -249,17 +271,39 @@ no more tasks left to schedule, the \fIcluster\fP will begin its shutdown proced
 Conflicts with \fB\-\-no\-db\fP and mutually exclusive to \fB\-\-restart\fP\&.
 .TP
 .B \fB\-\-restart\fP
-Start scheduling from last completed task.
+Start scheduling from where a prior run left off.
 .sp
-Instead of pulling a new list of tasks from some input \fIFILE\fP, with \fB\-\-restart\fP enabled the
-\fIcluster\fP will restart scheduling tasks where it left off. Any task in the database that was
-previously scheduled but not completed will be reverted.
+With no \fIFILE\fP, \fB\-\-restart\fP resumes purely from the database: any task previously
+scheduled but not completed is reverted, scheduling continues, and the \fIcluster\fP halts when
+nothing is left to do. This is the classic \(dqpopulate with \fBsubmit\fP, then requeue\(dq strategy
+for very large workflows — if the \fIcluster\fP is interrupted it can gracefully continue where
+it left off.
 .sp
-For very large workflows, an effective strategy is to first use the \fBsubmit\fP workflow to
-populate the database, and then to use \fB\-\-restart\fP so that if the \fIcluster\fP is interrupted,
-it can easily continue where it left off, halting if nothing to be done.
+When a \fIFILE\fP is given, \fB\-\-restart\fP becomes file\-aware and idempotent. The file is read
+upfront (a content fingerprint and task count), and only tasks whose identity is not already
+present from a prior submission of that same path are submitted; the revert\-interrupted flow
+re\-runs anything that was mid\-flight. Requeuing the same \fBhsx <FILE> \-\-restart\fP job as many
+times as needed therefore never double\-submits work. If the file\(aqs content has changed since
+it was last seen, the run is refused with a suggestion to use \fB\-\-update \-\-restart\fP\&.
 .sp
-Conflicts with \fB\-\-no\-db\fP and mutually exclusive to \fB\-\-forever\fP\&.
+Conflicts with \fB\-\-no\-db\fP and \fB\-\-repeat\fP, and mutually exclusive to \fB\-\-forever\fP\&.
+.TP
+.B \fB\-\-repeat\fP
+Re\-submit a known file\(aqs tasks again as a new source.
+.sp
+Re\-submitting a file that has already been ingested is normally refused. \fB\-\-repeat\fP
+overrides that: the file is recorded as a brand\-new source and \fIall\fP of its tasks are
+submitted again, even if an identical prior submission exists. Combine with \fB\-t\fP/tags to
+represent a new phase or trial of the same work.
+.TP
+.B \fB\-\-update\fP
+Submit only the tasks that are new since a file was last seen.
+.sp
+Used together with \fB\-\-restart\fP (\fBhsx <FILE> \-\-update \-\-restart\fP): the file is recorded as
+a new source and only tasks whose identity is not already present in the prior same\-path
+lineage are submitted — novel tasks run while previously\-submitted tasks are skipped. On its
+own (without \fB\-\-restart\fP) it is ambiguous and refused; it also cannot be combined with
+\fB\-\-repeat\fP\&.
 .TP
 .B \fB\-\-ssh\-args\fP \fIARGS\fP\&...
 Command\-line arguments for SSH. For example, \fB\-\-ssh\-args \(aq\-i ~/.ssh/my_key\(aq\fP\&.
@@ -901,10 +945,10 @@ See the \fIsecurity\fP section for peer verification modes.
 .SH SUBMIT USAGE
 .INDENT 0.0
 .TP
-.B \fBhs\fP \fBsubmit\fP \fB[\-h]\fP \fB[ARGS... | \-f FILE]\fP
+.B \fBhs\fP \fBsubmit\fP \fB[\-h]\fP \fB[ARGS... | \-f FILE | \-\-from\-json SPEC]\fP
 \fB[\-q [\-H ADDR] [\-p NUM] [\-k KEY] | \-\-initdb]\fP
 \fB[\-b NUM]\fP \fB[\-w SEC]\fP \fB[\-c NUM]\fP \fB[\-m MEM]\fP \fB[\-W SEC]\fP \fB[\-g NUM]\fP
-\fB[\-\-template CMD]\fP \fB[\-t TAG...]\fP
+\fB[\-\-repeat | \-\-update]\fP \fB[\-\-template CMD]\fP \fB[\-t TAG...]\fP
 \fB[\-\-no\-tls | [\-\-tls\-ca PATH] [\-\-tls\-cert PATH] [\-\-tls\-key PATH]]\fP
 .UNINDENT
 .sp
@@ -925,6 +969,25 @@ Any tags specified with \fB\-t\fP/\fB\-\-tag\fP are applied to all tasks submitt
 .sp
 Use the special comment syntax, \fB# HYPERSHELL: ...\fP, to include resource limits or tags inline.
 If the comment is alone on the line it will be applied to all tasks that follow.
+.sp
+With \fB\-\-from\-json\fP, read tasks from a JSON file instead. The value is
+\fBFILE[@path]\fP where the optional dotted \fBpath\fP locates the list of task objects
+within the document (e.g. \fBplan.json@chunks\fP); with no \fB@\fP the file\(aqs top level
+must itself be the list, and a \fBFILE\fP of \fB\-\fP reads from \fB<stdin>\fP\&. Each task
+object\(aqs keys become named \fB{key}\fP template fields (and task tags), and an optional
+\fBargs\fP key provides the base command (reachable as \fB{}\fP). All \fB{key}\fP fields are
+validated against every task object up front, so submission is rejected before any task
+is committed if a field is missing.
+.sp
+Re\-submitting a named task file is guarded to prevent accidental double submission. Each
+named file is recorded as a \fIsource\fP (its absolute path, a content fingerprint, and the
+task count); submitting the same file again with no flag is refused, and if the path was
+seen but the content changed the refusal suggests \fB\-\-update\fP\&. Pass \fB\-\-repeat\fP to
+deliberately submit all tasks again as a new source, or \fB\-\-update\fP to submit only tasks
+not already present from earlier versions of the same file. JSON task files (\fB\-\-from\-json\fP)
+are gated the same way, keyed by their absolute path together with any \fB@path\fP selector.
+Single\-command and \fB<stdin>\fP submissions (including \fB\-\-from\-json \-\fP) are treated as
+explicit intent and are exempt from these checks.
 .SS Arguments
 .INDENT 0.0
 .TP
@@ -936,6 +999,33 @@ Command\-line task arguments (for single task submission).
 .TP
 .B \fB\-f\fP, \fB\-\-task\-file\fP \fIFILE\fP
 Input file containing one task per line.
+.TP
+.B \fB\-\-from\-json\fP \fISPEC\fP
+Read tasks from a JSON file (\fBFILE[@path]\fP).
+.sp
+The optional dotted \fBpath\fP after \fB@\fP locates the list of task objects inside
+the document (e.g. \fBplan.json@chunks\fP); with no \fB@\fP the file\(aqs top level must
+be the list, and a \fBFILE\fP of \fB\-\fP reads from \fB<stdin>\fP\&. Each task object\(aqs keys
+become named \fB{key}\fP template fields and task tags; an optional \fBargs\fP key is the
+base command (reachable as \fB{}\fP). Every \fB{key}\fP is validated against all task
+objects before anything is submitted.
+.TP
+.B \fB\-\-repeat\fP
+Re\-submit a known file\(aqs tasks again as a brand\-new source.
+.sp
+By default, submitting a named file whose path and content match a prior submission is
+refused to guard against accidental double submission. \fB\-\-repeat\fP overrides that: the
+file is ingested as a new source and all of its tasks are submitted again, even if
+identical tasks already exist. May be combined with new \fB\-t\fP/\fB\-\-tag\fP values to mark
+a new phase or trial.
+.TP
+.B \fB\-\-update\fP
+Submit only the tasks in a known file that are not already present.
+.sp
+Creates a new source record and submits only tasks whose identity (a stable hash of the
+pre\-template arguments, group, and tags) is absent from the prior same\-path submissions;
+tasks already submitted are skipped. Use this after editing a task file to add only the
+new work. Cannot be combined with \fB\-\-repeat\fP\&.
 .TP
 .B \fB\-q\fP, \fB\-\-queue\fP
 Submit directly to live queue instead of database.
@@ -1257,7 +1347,18 @@ A database must be configured.
 Specifying \fIFIELD\fP names defines what is included in the output
 (by default all fields are included).
 .sp
+As a safeguard against accidentally dumping an entire database, \fBhs list\fP refuses to return
+more than 1,000 tasks unless the intent is made explicit with \fB\-\-all\fP (dump everything),
+\fB\-\-limit\fP \fIN\fP (bound the result), or \fB\-\-count\fP (count only) \- much as \fBhs update\fP confirms
+a bulk change before applying it. A bare \fBhs list\fP with no arguments prints the usage statement.
+.sp
 This command maps directly to underlying SQL queries.
+.sp
+When printing to a terminal, task records are colorized by \fIexit_status\fP: successful tasks
+(0) are green, cancelled tasks (\-1, including those terminated by \fBSIGHUP\fP) are shown faint,
+tasks that terminated abnormally (killed by a signal, or that never ran \- any other negative
+status) are yellow, and tasks that ran and returned a non\-zero code are red. Tasks that have
+not yet run are left uncolored.
 .SS Arguments
 .INDENT 0.0
 .TP
@@ -1267,6 +1368,14 @@ Default is to include all fields.
 .UNINDENT
 .SS Options
 .INDENT 0.0
+.TP
+.B \fB\-\-all\fP
+Dump all matching tasks, imposing no limit.
+.sp
+As a guard against accidentally dumping an entire database, \fBhs list\fP refuses to return
+more than 1,000 results unless the intent is made explicit. \fB\-\-all\fP dumps them all,
+\fB\-\-limit\fP \fIN\fP bounds the result, and \fB\-\-count\fP only counts them; the three are mutually
+exclusive (e.g. \fBhs list \-\-all\fP or \fBhs list \-\-all \-\-csv\fP).
 .TP
 .B \fB\-w\fP, \fB\-\-where\fP \fICOND...\fP
 List of conditional statements to filter results (e.g., \fB\-w \(aqduration >= 600\(aq\fP).
@@ -1300,8 +1409,19 @@ For backwards compatibility, \fB\-\-finished\fP is also valid.
 .B \fB\-R\fP, \fB\-\-remaining\fP
 Alias for \fB\-w \(aqexit_status == null\(aq\fP\&.
 .TP
+.B \fB\-X\fP, \fB\-\-cancelled\fP
+Alias for \fB\-w \(aqexit_status == \-1\(aq\fP (tasks that were cancelled).
+.TP
 .B \fB\-\-retries\fP
 Alias for \fB\-w \(aqattempt > 1\(aq\fP (tasks that have been retried).
+.TP
+.B \fB\-\-signal\fP \fINAME\fP
+Match tasks whose process was terminated by signal \fINAME\fP (e.g. \fBTERM\fP, \fBKILL\fP, \fBHUP\fP).
+.sp
+A task killed by signal \fIN\fP is recorded with \fBexit_status = \-N\fP (the convention used by
+Python\(aqs subprocess module). The \fBSIG\fP prefix is optional and the name is case\-insensitive.
+A task terminated by \fBHUP\fP lands on \-1 and is therefore treated as cancelled
+(see \fB\-\-cancelled\fP).
 .TP
 .B \fB\-f\fP, \fB\-\-format\fP \fIFORMAT\fP
 Specify output format (either \fBnormal\fP, \fBplain\fP, \fBtable\fP, \fBcsv\fP, \fBjson\fP).
@@ -1386,6 +1506,12 @@ Cancelling a task means it will no longer be scheduled. This is done by setting 
 \fIschedule_time\fP and \fIcompletion_time\fP to \fInow\fP and the \fIexit_status\fP to \-1. The task
 becomes terminal: it will not be scheduled, retried, or reverted on \fB\-\-restart\fP\&.
 A task cannot be cancelled after it is sent to remote clients.
+.sp
+A running task can also be cancelled \fIin flight\fP on the client by terminating its
+process with \fBSIGHUP\fP (e.g. \fBkill \-HUP\fP). Because a process killed by signal \fIN\fP is
+recorded with \fBexit_status = \-N\fP, a \fBSIGHUP\fP (signal 1) death lands on \-1 \- the same
+cancelled state \- so such a task is likewise not retried. See \fBhs list \-\-cancelled\fP and
+\fBhs list \-\-signal HUP\fP\&.
 .TP
 .B \fB\-\-revert\fP
 Revert specified tasks.
@@ -1439,8 +1565,19 @@ Alias for \fB\-w \(aqexit_status != null\(aq\fP\&.
 .B \fB\-R\fP, \fB\-\-remaining\fP
 Alias for \fB\-w \(aqexit_status == null\(aq\fP\&.
 .TP
+.B \fB\-X\fP, \fB\-\-cancelled\fP
+Alias for \fB\-w \(aqexit_status == \-1\(aq\fP (tasks that were cancelled).
+.TP
 .B \fB\-\-retries\fP
 Alias for \fB\-w \(aqattempt > 1\(aq\fP (tasks that have been retried).
+.TP
+.B \fB\-\-signal\fP \fINAME\fP
+Match tasks whose process was terminated by signal \fINAME\fP (e.g. \fBTERM\fP, \fBKILL\fP, \fBHUP\fP).
+.sp
+A task killed by signal \fIN\fP is recorded with \fBexit_status = \-N\fP (the convention used by
+Python\(aqs subprocess module). The \fBSIG\fP prefix is optional and the name is case\-insensitive.
+A task terminated by \fBHUP\fP lands on \-1 and is therefore treated as cancelled
+(see \fB\-\-cancelled\fP).
 .TP
 .B \fB\-f\fP, \fB\-\-no\-confirm\fP
 Do not ask for confirmation.
@@ -1640,6 +1777,21 @@ argument to all clients.
 .sp
 In some situations it may be useful to expand a template with the \fBsubmit\fP command.
 These are expanded \fIprior\fP to scheduling as the actual \fIargs\fP for the task.
+.SS Named Fields
+.sp
+When tasks are submitted from a JSON file with \fB\-\-from\-json\fP (see the \fBsubmit\fP
+command), each task object\(aqs keys become available as named template fields. A
+\fB{key}\fP pattern expands to that key\(aqs value for the given task, and the keys also
+become task tags.
+.sp
+For a task object \fB{\(dqseqid\(dq: \(dqChr1\(dq, \(dqstart\(dq: 1, \(dqend\(dq: 5000000}\fP the template
+\fBprocess \-\-region {seqid}:{start}\-{end}\fP expands to
+\fBprocess \-\-region Chr1:1\-5000000\fP\&.
+.sp
+Values are stringified: booleans render as \fBtrue\fP/\fBfalse\fP, \fBnull\fP as an empty
+string, and nested objects/arrays as compact JSON. A built\-in pattern (below) takes
+precedence over a task key of the same name. Named fields are resolved at submit time,
+and every \fB{key}\fP must be present in each task object or the submission is rejected.
 .SS Filepath Operations
 .sp
 Shell commands often operate on filepaths. In such cases, it may be useful to manipulate

--- a/share/man/man1/hsx.1
+++ b/share/man/man1/hsx.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "HS" "1" "Jul 11, 2026" "2.8.1" "hypershell"
+.TH "HS" "1" "Jul 12, 2026" "2.8.1" "hypershell"
 .SH NAME
 hs \- Process shell commands over a distributed, asynchronous queue
 .SH SYNOPSIS
@@ -123,6 +123,10 @@ that never landed are submitted, and interrupted tasks are re\-run — so a requ
 \fBhsx <FILE> \-\-restart\fP job is safe to run repeatedly. Use \fB\-\-repeat\fP to deliberately submit a
 known file\(aqs tasks again as a new source, or \fB\-\-update \-\-restart\fP to add only the tasks that are
 new since the file was last seen.
+.sp
+De\-dup cost scales with the file\(aqs own source lineage rather than the whole database, so requeues stay
+fast at scale; for very large workflows, a one\-time \fBsubmit\fP followed by a bare \fBhsx \-\-restart\fP (no
+file re\-read) is cheaper than re\-feeding the \fIFILE\fP each run.
 .sp
 Use \fB\-\-autoscaling\fP with either \fIfixed\fP or \fIdynamic\fP to run a persistent, elastically scalable
 cluster using an external \fB\-\-launcher\fP to bring up clients as needed.
@@ -988,6 +992,11 @@ not already present from earlier versions of the same file. JSON task files (\fB
 are gated the same way, keyed by their absolute path together with any \fB@path\fP selector.
 Single\-command and \fB<stdin>\fP submissions (including \fB\-\-from\-json \-\fP) are treated as
 explicit intent and are exempt from these checks.
+.sp
+Detection and \fB\-\-update\fP de\-dup are index\-backed on the source lineage, so their cost scales with
+that file\(aqs own size, not the size of the database: re\-submitting a normal file stays fast even against
+a very large database, while \fB\-\-update\fP on a source of millions of tasks pays to re\-read and
+fingerprint the entire file to find what is new.
 .SS Arguments
 .INDENT 0.0
 .TP

--- a/share/man/man1/hsx.1
+++ b/share/man/man1/hsx.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "HS" "1" "Jul 08, 2026" "2.8.1" "hypershell"
+.TH "HS" "1" "Jul 11, 2026" "2.8.1" "hypershell"
 .SH NAME
 hs \- Process shell commands over a distributed, asynchronous queue
 .SH SYNOPSIS
@@ -88,7 +88,7 @@ Stand up the \fBserver\fP on its own and scale \fBclients\fP as desired, and \fB
 .SH CLUSTER USAGE
 .INDENT 0.0
 .TP
-.B \fBhs cluster [\-h]\fP \fB[FILE | \-\-restart | \-\-forever]\fP
+.B \fBhs cluster [\-h]\fP \fB[FILE | \-\-from\-json SPEC | \-\-restart | \-\-forever]\fP \fB[\-\-repeat | \-\-update]\fP
 \fB[\-N NUM]\fP \fB[\-t CMD]\fP \fB[\-b SIZE]\fP \fB[\-w SEC]\fP \fB[\-Q NUM]\fP
 \fB[\-H ADDR]\fP \fB[\-p PORT]\fP \fB[\-r NUM [\-\-eager]]\fP \fB[\-f PATH]\fP \fB[\-\-capture | [\-o PATH] [\-e PATH]]\fP
 \fB[\-\-ssh [HOST... | \-\-ssh\-group NAME] [\-\-env] | \-\-mpi | \-\-launcher=ARGS...]\fP
@@ -106,10 +106,23 @@ The input source for tasks is file\-like, either a local path, or from \fIstdin\
 given. The command\-line tasks are pulled in and either directly published to a distributed queue
 (see \fB\-\-no\-db\fP) or committed to a database first before being scheduled later.
 .sp
+Alternatively, use \fB\-\-from\-json\fP to read tasks from a JSON file (\fBFILE[@path]\fP); each task
+object\(aqs keys become named \fB{key}\fP fields in the \fB\-\-template\fP (and task tags). In this mode the
+template is expanded when tasks are ingested rather than by the clients. A JSON source participates
+in the same re\-submission gating as a plain \fIFILE\fP — \fB\-\-restart\fP (idempotent requeue),
+\fB\-\-repeat\fP, and \fB\-\-update \-\-restart\fP all apply — keyed by the file\(aqs absolute path together
+with any \fB@path\fP selector.
+.sp
 For large, long running workflows, it might be a good idea to configure a database and run an
 initial \fBsubmit\fP job to populate the database, and then run the cluster with \fB\-\-restart\fP and no
 input \fIFILE\fP\&. If the cluster is interrupted for whatever reason it can gracefully restart where it
 left off.
+.sp
+Alternatively, pass the \fIFILE\fP directly with \fB\-\-restart\fP: the submission is detected, only tasks
+that never landed are submitted, and interrupted tasks are re\-run — so a requeued
+\fBhsx <FILE> \-\-restart\fP job is safe to run repeatedly. Use \fB\-\-repeat\fP to deliberately submit a
+known file\(aqs tasks again as a new source, or \fB\-\-update \-\-restart\fP to add only the tasks that are
+new since the file was last seen.
 .sp
 Use \fB\-\-autoscaling\fP with either \fIfixed\fP or \fIdynamic\fP to run a persistent, elastically scalable
 cluster using an external \fB\-\-launcher\fP to bring up clients as needed.
@@ -159,6 +172,15 @@ arguments (e.g., file paths) to be transformed into some common form; such as
 \fB\-t \(aq./some_command.py {} >outputs/{/\-}.out\(aq\fP\&.
 .sp
 See section on \fItemplates\fP\&.
+.TP
+.B \fB\-\-from\-json\fP \fISPEC\fP
+Read tasks from a JSON file (\fBFILE[@path]\fP).
+.sp
+The optional dotted \fBpath\fP after \fB@\fP locates the list of task objects inside the
+document (e.g. \fBplan.json@chunks\fP); with no \fB@\fP the file\(aqs top level must be the
+list. Each task object\(aqs keys become named \fB{key}\fP fields in the \fB\-\-template\fP and
+task tags. In this mode the template is expanded when tasks are ingested (submit\-side),
+not by the clients.
 .TP
 .B \fB\-H\fP, \fB\-\-bind\fP \fIADDR\fP
 Bind address (default: localhost, or 0.0.0.0 for remote clients).
@@ -249,17 +271,39 @@ no more tasks left to schedule, the \fIcluster\fP will begin its shutdown proced
 Conflicts with \fB\-\-no\-db\fP and mutually exclusive to \fB\-\-restart\fP\&.
 .TP
 .B \fB\-\-restart\fP
-Start scheduling from last completed task.
+Start scheduling from where a prior run left off.
 .sp
-Instead of pulling a new list of tasks from some input \fIFILE\fP, with \fB\-\-restart\fP enabled the
-\fIcluster\fP will restart scheduling tasks where it left off. Any task in the database that was
-previously scheduled but not completed will be reverted.
+With no \fIFILE\fP, \fB\-\-restart\fP resumes purely from the database: any task previously
+scheduled but not completed is reverted, scheduling continues, and the \fIcluster\fP halts when
+nothing is left to do. This is the classic \(dqpopulate with \fBsubmit\fP, then requeue\(dq strategy
+for very large workflows — if the \fIcluster\fP is interrupted it can gracefully continue where
+it left off.
 .sp
-For very large workflows, an effective strategy is to first use the \fBsubmit\fP workflow to
-populate the database, and then to use \fB\-\-restart\fP so that if the \fIcluster\fP is interrupted,
-it can easily continue where it left off, halting if nothing to be done.
+When a \fIFILE\fP is given, \fB\-\-restart\fP becomes file\-aware and idempotent. The file is read
+upfront (a content fingerprint and task count), and only tasks whose identity is not already
+present from a prior submission of that same path are submitted; the revert\-interrupted flow
+re\-runs anything that was mid\-flight. Requeuing the same \fBhsx <FILE> \-\-restart\fP job as many
+times as needed therefore never double\-submits work. If the file\(aqs content has changed since
+it was last seen, the run is refused with a suggestion to use \fB\-\-update \-\-restart\fP\&.
 .sp
-Conflicts with \fB\-\-no\-db\fP and mutually exclusive to \fB\-\-forever\fP\&.
+Conflicts with \fB\-\-no\-db\fP and \fB\-\-repeat\fP, and mutually exclusive to \fB\-\-forever\fP\&.
+.TP
+.B \fB\-\-repeat\fP
+Re\-submit a known file\(aqs tasks again as a new source.
+.sp
+Re\-submitting a file that has already been ingested is normally refused. \fB\-\-repeat\fP
+overrides that: the file is recorded as a brand\-new source and \fIall\fP of its tasks are
+submitted again, even if an identical prior submission exists. Combine with \fB\-t\fP/tags to
+represent a new phase or trial of the same work.
+.TP
+.B \fB\-\-update\fP
+Submit only the tasks that are new since a file was last seen.
+.sp
+Used together with \fB\-\-restart\fP (\fBhsx <FILE> \-\-update \-\-restart\fP): the file is recorded as
+a new source and only tasks whose identity is not already present in the prior same\-path
+lineage are submitted — novel tasks run while previously\-submitted tasks are skipped. On its
+own (without \fB\-\-restart\fP) it is ambiguous and refused; it also cannot be combined with
+\fB\-\-repeat\fP\&.
 .TP
 .B \fB\-\-ssh\-args\fP \fIARGS\fP\&...
 Command\-line arguments for SSH. For example, \fB\-\-ssh\-args \(aq\-i ~/.ssh/my_key\(aq\fP\&.
@@ -901,10 +945,10 @@ See the \fIsecurity\fP section for peer verification modes.
 .SH SUBMIT USAGE
 .INDENT 0.0
 .TP
-.B \fBhs\fP \fBsubmit\fP \fB[\-h]\fP \fB[ARGS... | \-f FILE]\fP
+.B \fBhs\fP \fBsubmit\fP \fB[\-h]\fP \fB[ARGS... | \-f FILE | \-\-from\-json SPEC]\fP
 \fB[\-q [\-H ADDR] [\-p NUM] [\-k KEY] | \-\-initdb]\fP
 \fB[\-b NUM]\fP \fB[\-w SEC]\fP \fB[\-c NUM]\fP \fB[\-m MEM]\fP \fB[\-W SEC]\fP \fB[\-g NUM]\fP
-\fB[\-\-template CMD]\fP \fB[\-t TAG...]\fP
+\fB[\-\-repeat | \-\-update]\fP \fB[\-\-template CMD]\fP \fB[\-t TAG...]\fP
 \fB[\-\-no\-tls | [\-\-tls\-ca PATH] [\-\-tls\-cert PATH] [\-\-tls\-key PATH]]\fP
 .UNINDENT
 .sp
@@ -925,6 +969,25 @@ Any tags specified with \fB\-t\fP/\fB\-\-tag\fP are applied to all tasks submitt
 .sp
 Use the special comment syntax, \fB# HYPERSHELL: ...\fP, to include resource limits or tags inline.
 If the comment is alone on the line it will be applied to all tasks that follow.
+.sp
+With \fB\-\-from\-json\fP, read tasks from a JSON file instead. The value is
+\fBFILE[@path]\fP where the optional dotted \fBpath\fP locates the list of task objects
+within the document (e.g. \fBplan.json@chunks\fP); with no \fB@\fP the file\(aqs top level
+must itself be the list, and a \fBFILE\fP of \fB\-\fP reads from \fB<stdin>\fP\&. Each task
+object\(aqs keys become named \fB{key}\fP template fields (and task tags), and an optional
+\fBargs\fP key provides the base command (reachable as \fB{}\fP). All \fB{key}\fP fields are
+validated against every task object up front, so submission is rejected before any task
+is committed if a field is missing.
+.sp
+Re\-submitting a named task file is guarded to prevent accidental double submission. Each
+named file is recorded as a \fIsource\fP (its absolute path, a content fingerprint, and the
+task count); submitting the same file again with no flag is refused, and if the path was
+seen but the content changed the refusal suggests \fB\-\-update\fP\&. Pass \fB\-\-repeat\fP to
+deliberately submit all tasks again as a new source, or \fB\-\-update\fP to submit only tasks
+not already present from earlier versions of the same file. JSON task files (\fB\-\-from\-json\fP)
+are gated the same way, keyed by their absolute path together with any \fB@path\fP selector.
+Single\-command and \fB<stdin>\fP submissions (including \fB\-\-from\-json \-\fP) are treated as
+explicit intent and are exempt from these checks.
 .SS Arguments
 .INDENT 0.0
 .TP
@@ -936,6 +999,33 @@ Command\-line task arguments (for single task submission).
 .TP
 .B \fB\-f\fP, \fB\-\-task\-file\fP \fIFILE\fP
 Input file containing one task per line.
+.TP
+.B \fB\-\-from\-json\fP \fISPEC\fP
+Read tasks from a JSON file (\fBFILE[@path]\fP).
+.sp
+The optional dotted \fBpath\fP after \fB@\fP locates the list of task objects inside
+the document (e.g. \fBplan.json@chunks\fP); with no \fB@\fP the file\(aqs top level must
+be the list, and a \fBFILE\fP of \fB\-\fP reads from \fB<stdin>\fP\&. Each task object\(aqs keys
+become named \fB{key}\fP template fields and task tags; an optional \fBargs\fP key is the
+base command (reachable as \fB{}\fP). Every \fB{key}\fP is validated against all task
+objects before anything is submitted.
+.TP
+.B \fB\-\-repeat\fP
+Re\-submit a known file\(aqs tasks again as a brand\-new source.
+.sp
+By default, submitting a named file whose path and content match a prior submission is
+refused to guard against accidental double submission. \fB\-\-repeat\fP overrides that: the
+file is ingested as a new source and all of its tasks are submitted again, even if
+identical tasks already exist. May be combined with new \fB\-t\fP/\fB\-\-tag\fP values to mark
+a new phase or trial.
+.TP
+.B \fB\-\-update\fP
+Submit only the tasks in a known file that are not already present.
+.sp
+Creates a new source record and submits only tasks whose identity (a stable hash of the
+pre\-template arguments, group, and tags) is absent from the prior same\-path submissions;
+tasks already submitted are skipped. Use this after editing a task file to add only the
+new work. Cannot be combined with \fB\-\-repeat\fP\&.
 .TP
 .B \fB\-q\fP, \fB\-\-queue\fP
 Submit directly to live queue instead of database.
@@ -1257,7 +1347,18 @@ A database must be configured.
 Specifying \fIFIELD\fP names defines what is included in the output
 (by default all fields are included).
 .sp
+As a safeguard against accidentally dumping an entire database, \fBhs list\fP refuses to return
+more than 1,000 tasks unless the intent is made explicit with \fB\-\-all\fP (dump everything),
+\fB\-\-limit\fP \fIN\fP (bound the result), or \fB\-\-count\fP (count only) \- much as \fBhs update\fP confirms
+a bulk change before applying it. A bare \fBhs list\fP with no arguments prints the usage statement.
+.sp
 This command maps directly to underlying SQL queries.
+.sp
+When printing to a terminal, task records are colorized by \fIexit_status\fP: successful tasks
+(0) are green, cancelled tasks (\-1, including those terminated by \fBSIGHUP\fP) are shown faint,
+tasks that terminated abnormally (killed by a signal, or that never ran \- any other negative
+status) are yellow, and tasks that ran and returned a non\-zero code are red. Tasks that have
+not yet run are left uncolored.
 .SS Arguments
 .INDENT 0.0
 .TP
@@ -1267,6 +1368,14 @@ Default is to include all fields.
 .UNINDENT
 .SS Options
 .INDENT 0.0
+.TP
+.B \fB\-\-all\fP
+Dump all matching tasks, imposing no limit.
+.sp
+As a guard against accidentally dumping an entire database, \fBhs list\fP refuses to return
+more than 1,000 results unless the intent is made explicit. \fB\-\-all\fP dumps them all,
+\fB\-\-limit\fP \fIN\fP bounds the result, and \fB\-\-count\fP only counts them; the three are mutually
+exclusive (e.g. \fBhs list \-\-all\fP or \fBhs list \-\-all \-\-csv\fP).
 .TP
 .B \fB\-w\fP, \fB\-\-where\fP \fICOND...\fP
 List of conditional statements to filter results (e.g., \fB\-w \(aqduration >= 600\(aq\fP).
@@ -1300,8 +1409,19 @@ For backwards compatibility, \fB\-\-finished\fP is also valid.
 .B \fB\-R\fP, \fB\-\-remaining\fP
 Alias for \fB\-w \(aqexit_status == null\(aq\fP\&.
 .TP
+.B \fB\-X\fP, \fB\-\-cancelled\fP
+Alias for \fB\-w \(aqexit_status == \-1\(aq\fP (tasks that were cancelled).
+.TP
 .B \fB\-\-retries\fP
 Alias for \fB\-w \(aqattempt > 1\(aq\fP (tasks that have been retried).
+.TP
+.B \fB\-\-signal\fP \fINAME\fP
+Match tasks whose process was terminated by signal \fINAME\fP (e.g. \fBTERM\fP, \fBKILL\fP, \fBHUP\fP).
+.sp
+A task killed by signal \fIN\fP is recorded with \fBexit_status = \-N\fP (the convention used by
+Python\(aqs subprocess module). The \fBSIG\fP prefix is optional and the name is case\-insensitive.
+A task terminated by \fBHUP\fP lands on \-1 and is therefore treated as cancelled
+(see \fB\-\-cancelled\fP).
 .TP
 .B \fB\-f\fP, \fB\-\-format\fP \fIFORMAT\fP
 Specify output format (either \fBnormal\fP, \fBplain\fP, \fBtable\fP, \fBcsv\fP, \fBjson\fP).
@@ -1386,6 +1506,12 @@ Cancelling a task means it will no longer be scheduled. This is done by setting 
 \fIschedule_time\fP and \fIcompletion_time\fP to \fInow\fP and the \fIexit_status\fP to \-1. The task
 becomes terminal: it will not be scheduled, retried, or reverted on \fB\-\-restart\fP\&.
 A task cannot be cancelled after it is sent to remote clients.
+.sp
+A running task can also be cancelled \fIin flight\fP on the client by terminating its
+process with \fBSIGHUP\fP (e.g. \fBkill \-HUP\fP). Because a process killed by signal \fIN\fP is
+recorded with \fBexit_status = \-N\fP, a \fBSIGHUP\fP (signal 1) death lands on \-1 \- the same
+cancelled state \- so such a task is likewise not retried. See \fBhs list \-\-cancelled\fP and
+\fBhs list \-\-signal HUP\fP\&.
 .TP
 .B \fB\-\-revert\fP
 Revert specified tasks.
@@ -1439,8 +1565,19 @@ Alias for \fB\-w \(aqexit_status != null\(aq\fP\&.
 .B \fB\-R\fP, \fB\-\-remaining\fP
 Alias for \fB\-w \(aqexit_status == null\(aq\fP\&.
 .TP
+.B \fB\-X\fP, \fB\-\-cancelled\fP
+Alias for \fB\-w \(aqexit_status == \-1\(aq\fP (tasks that were cancelled).
+.TP
 .B \fB\-\-retries\fP
 Alias for \fB\-w \(aqattempt > 1\(aq\fP (tasks that have been retried).
+.TP
+.B \fB\-\-signal\fP \fINAME\fP
+Match tasks whose process was terminated by signal \fINAME\fP (e.g. \fBTERM\fP, \fBKILL\fP, \fBHUP\fP).
+.sp
+A task killed by signal \fIN\fP is recorded with \fBexit_status = \-N\fP (the convention used by
+Python\(aqs subprocess module). The \fBSIG\fP prefix is optional and the name is case\-insensitive.
+A task terminated by \fBHUP\fP lands on \-1 and is therefore treated as cancelled
+(see \fB\-\-cancelled\fP).
 .TP
 .B \fB\-f\fP, \fB\-\-no\-confirm\fP
 Do not ask for confirmation.
@@ -1640,6 +1777,21 @@ argument to all clients.
 .sp
 In some situations it may be useful to expand a template with the \fBsubmit\fP command.
 These are expanded \fIprior\fP to scheduling as the actual \fIargs\fP for the task.
+.SS Named Fields
+.sp
+When tasks are submitted from a JSON file with \fB\-\-from\-json\fP (see the \fBsubmit\fP
+command), each task object\(aqs keys become available as named template fields. A
+\fB{key}\fP pattern expands to that key\(aqs value for the given task, and the keys also
+become task tags.
+.sp
+For a task object \fB{\(dqseqid\(dq: \(dqChr1\(dq, \(dqstart\(dq: 1, \(dqend\(dq: 5000000}\fP the template
+\fBprocess \-\-region {seqid}:{start}\-{end}\fP expands to
+\fBprocess \-\-region Chr1:1\-5000000\fP\&.
+.sp
+Values are stringified: booleans render as \fBtrue\fP/\fBfalse\fP, \fBnull\fP as an empty
+string, and nested objects/arrays as compact JSON. A built\-in pattern (below) takes
+precedence over a task key of the same name. Named fields are resolved at submit time,
+and every \fB{key}\fP must be present in each task object or the submission is rejected.
 .SS Filepath Operations
 .sp
 Shell commands often operate on filepaths. In such cases, it may be useful to manipulate

--- a/share/man/man1/hyper-shell.1
+++ b/share/man/man1/hyper-shell.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "HYPER-SHELL" "1" "Jul 08, 2026" "2.8.1" "hypershell"
+.TH "HYPER-SHELL" "1" "Jul 11, 2026" "2.8.1" "hypershell"
 .SH NAME
 hyper-shell \- Process shell commands over a distributed, asynchronous queue
 .SH SYNOPSIS
@@ -88,7 +88,7 @@ Stand up the \fBserver\fP on its own and scale \fBclients\fP as desired, and \fB
 .SH CLUSTER USAGE
 .INDENT 0.0
 .TP
-.B \fBhs cluster [\-h]\fP \fB[FILE | \-\-restart | \-\-forever]\fP
+.B \fBhs cluster [\-h]\fP \fB[FILE | \-\-from\-json SPEC | \-\-restart | \-\-forever]\fP \fB[\-\-repeat | \-\-update]\fP
 \fB[\-N NUM]\fP \fB[\-t CMD]\fP \fB[\-b SIZE]\fP \fB[\-w SEC]\fP \fB[\-Q NUM]\fP
 \fB[\-H ADDR]\fP \fB[\-p PORT]\fP \fB[\-r NUM [\-\-eager]]\fP \fB[\-f PATH]\fP \fB[\-\-capture | [\-o PATH] [\-e PATH]]\fP
 \fB[\-\-ssh [HOST... | \-\-ssh\-group NAME] [\-\-env] | \-\-mpi | \-\-launcher=ARGS...]\fP
@@ -106,10 +106,23 @@ The input source for tasks is file\-like, either a local path, or from \fIstdin\
 given. The command\-line tasks are pulled in and either directly published to a distributed queue
 (see \fB\-\-no\-db\fP) or committed to a database first before being scheduled later.
 .sp
+Alternatively, use \fB\-\-from\-json\fP to read tasks from a JSON file (\fBFILE[@path]\fP); each task
+object\(aqs keys become named \fB{key}\fP fields in the \fB\-\-template\fP (and task tags). In this mode the
+template is expanded when tasks are ingested rather than by the clients. A JSON source participates
+in the same re\-submission gating as a plain \fIFILE\fP — \fB\-\-restart\fP (idempotent requeue),
+\fB\-\-repeat\fP, and \fB\-\-update \-\-restart\fP all apply — keyed by the file\(aqs absolute path together
+with any \fB@path\fP selector.
+.sp
 For large, long running workflows, it might be a good idea to configure a database and run an
 initial \fBsubmit\fP job to populate the database, and then run the cluster with \fB\-\-restart\fP and no
 input \fIFILE\fP\&. If the cluster is interrupted for whatever reason it can gracefully restart where it
 left off.
+.sp
+Alternatively, pass the \fIFILE\fP directly with \fB\-\-restart\fP: the submission is detected, only tasks
+that never landed are submitted, and interrupted tasks are re\-run — so a requeued
+\fBhsx <FILE> \-\-restart\fP job is safe to run repeatedly. Use \fB\-\-repeat\fP to deliberately submit a
+known file\(aqs tasks again as a new source, or \fB\-\-update \-\-restart\fP to add only the tasks that are
+new since the file was last seen.
 .sp
 Use \fB\-\-autoscaling\fP with either \fIfixed\fP or \fIdynamic\fP to run a persistent, elastically scalable
 cluster using an external \fB\-\-launcher\fP to bring up clients as needed.
@@ -159,6 +172,15 @@ arguments (e.g., file paths) to be transformed into some common form; such as
 \fB\-t \(aq./some_command.py {} >outputs/{/\-}.out\(aq\fP\&.
 .sp
 See section on \fItemplates\fP\&.
+.TP
+.B \fB\-\-from\-json\fP \fISPEC\fP
+Read tasks from a JSON file (\fBFILE[@path]\fP).
+.sp
+The optional dotted \fBpath\fP after \fB@\fP locates the list of task objects inside the
+document (e.g. \fBplan.json@chunks\fP); with no \fB@\fP the file\(aqs top level must be the
+list. Each task object\(aqs keys become named \fB{key}\fP fields in the \fB\-\-template\fP and
+task tags. In this mode the template is expanded when tasks are ingested (submit\-side),
+not by the clients.
 .TP
 .B \fB\-H\fP, \fB\-\-bind\fP \fIADDR\fP
 Bind address (default: localhost, or 0.0.0.0 for remote clients).
@@ -249,17 +271,39 @@ no more tasks left to schedule, the \fIcluster\fP will begin its shutdown proced
 Conflicts with \fB\-\-no\-db\fP and mutually exclusive to \fB\-\-restart\fP\&.
 .TP
 .B \fB\-\-restart\fP
-Start scheduling from last completed task.
+Start scheduling from where a prior run left off.
 .sp
-Instead of pulling a new list of tasks from some input \fIFILE\fP, with \fB\-\-restart\fP enabled the
-\fIcluster\fP will restart scheduling tasks where it left off. Any task in the database that was
-previously scheduled but not completed will be reverted.
+With no \fIFILE\fP, \fB\-\-restart\fP resumes purely from the database: any task previously
+scheduled but not completed is reverted, scheduling continues, and the \fIcluster\fP halts when
+nothing is left to do. This is the classic \(dqpopulate with \fBsubmit\fP, then requeue\(dq strategy
+for very large workflows — if the \fIcluster\fP is interrupted it can gracefully continue where
+it left off.
 .sp
-For very large workflows, an effective strategy is to first use the \fBsubmit\fP workflow to
-populate the database, and then to use \fB\-\-restart\fP so that if the \fIcluster\fP is interrupted,
-it can easily continue where it left off, halting if nothing to be done.
+When a \fIFILE\fP is given, \fB\-\-restart\fP becomes file\-aware and idempotent. The file is read
+upfront (a content fingerprint and task count), and only tasks whose identity is not already
+present from a prior submission of that same path are submitted; the revert\-interrupted flow
+re\-runs anything that was mid\-flight. Requeuing the same \fBhsx <FILE> \-\-restart\fP job as many
+times as needed therefore never double\-submits work. If the file\(aqs content has changed since
+it was last seen, the run is refused with a suggestion to use \fB\-\-update \-\-restart\fP\&.
 .sp
-Conflicts with \fB\-\-no\-db\fP and mutually exclusive to \fB\-\-forever\fP\&.
+Conflicts with \fB\-\-no\-db\fP and \fB\-\-repeat\fP, and mutually exclusive to \fB\-\-forever\fP\&.
+.TP
+.B \fB\-\-repeat\fP
+Re\-submit a known file\(aqs tasks again as a new source.
+.sp
+Re\-submitting a file that has already been ingested is normally refused. \fB\-\-repeat\fP
+overrides that: the file is recorded as a brand\-new source and \fIall\fP of its tasks are
+submitted again, even if an identical prior submission exists. Combine with \fB\-t\fP/tags to
+represent a new phase or trial of the same work.
+.TP
+.B \fB\-\-update\fP
+Submit only the tasks that are new since a file was last seen.
+.sp
+Used together with \fB\-\-restart\fP (\fBhsx <FILE> \-\-update \-\-restart\fP): the file is recorded as
+a new source and only tasks whose identity is not already present in the prior same\-path
+lineage are submitted — novel tasks run while previously\-submitted tasks are skipped. On its
+own (without \fB\-\-restart\fP) it is ambiguous and refused; it also cannot be combined with
+\fB\-\-repeat\fP\&.
 .TP
 .B \fB\-\-ssh\-args\fP \fIARGS\fP\&...
 Command\-line arguments for SSH. For example, \fB\-\-ssh\-args \(aq\-i ~/.ssh/my_key\(aq\fP\&.
@@ -901,10 +945,10 @@ See the \fIsecurity\fP section for peer verification modes.
 .SH SUBMIT USAGE
 .INDENT 0.0
 .TP
-.B \fBhs\fP \fBsubmit\fP \fB[\-h]\fP \fB[ARGS... | \-f FILE]\fP
+.B \fBhs\fP \fBsubmit\fP \fB[\-h]\fP \fB[ARGS... | \-f FILE | \-\-from\-json SPEC]\fP
 \fB[\-q [\-H ADDR] [\-p NUM] [\-k KEY] | \-\-initdb]\fP
 \fB[\-b NUM]\fP \fB[\-w SEC]\fP \fB[\-c NUM]\fP \fB[\-m MEM]\fP \fB[\-W SEC]\fP \fB[\-g NUM]\fP
-\fB[\-\-template CMD]\fP \fB[\-t TAG...]\fP
+\fB[\-\-repeat | \-\-update]\fP \fB[\-\-template CMD]\fP \fB[\-t TAG...]\fP
 \fB[\-\-no\-tls | [\-\-tls\-ca PATH] [\-\-tls\-cert PATH] [\-\-tls\-key PATH]]\fP
 .UNINDENT
 .sp
@@ -925,6 +969,25 @@ Any tags specified with \fB\-t\fP/\fB\-\-tag\fP are applied to all tasks submitt
 .sp
 Use the special comment syntax, \fB# HYPERSHELL: ...\fP, to include resource limits or tags inline.
 If the comment is alone on the line it will be applied to all tasks that follow.
+.sp
+With \fB\-\-from\-json\fP, read tasks from a JSON file instead. The value is
+\fBFILE[@path]\fP where the optional dotted \fBpath\fP locates the list of task objects
+within the document (e.g. \fBplan.json@chunks\fP); with no \fB@\fP the file\(aqs top level
+must itself be the list, and a \fBFILE\fP of \fB\-\fP reads from \fB<stdin>\fP\&. Each task
+object\(aqs keys become named \fB{key}\fP template fields (and task tags), and an optional
+\fBargs\fP key provides the base command (reachable as \fB{}\fP). All \fB{key}\fP fields are
+validated against every task object up front, so submission is rejected before any task
+is committed if a field is missing.
+.sp
+Re\-submitting a named task file is guarded to prevent accidental double submission. Each
+named file is recorded as a \fIsource\fP (its absolute path, a content fingerprint, and the
+task count); submitting the same file again with no flag is refused, and if the path was
+seen but the content changed the refusal suggests \fB\-\-update\fP\&. Pass \fB\-\-repeat\fP to
+deliberately submit all tasks again as a new source, or \fB\-\-update\fP to submit only tasks
+not already present from earlier versions of the same file. JSON task files (\fB\-\-from\-json\fP)
+are gated the same way, keyed by their absolute path together with any \fB@path\fP selector.
+Single\-command and \fB<stdin>\fP submissions (including \fB\-\-from\-json \-\fP) are treated as
+explicit intent and are exempt from these checks.
 .SS Arguments
 .INDENT 0.0
 .TP
@@ -936,6 +999,33 @@ Command\-line task arguments (for single task submission).
 .TP
 .B \fB\-f\fP, \fB\-\-task\-file\fP \fIFILE\fP
 Input file containing one task per line.
+.TP
+.B \fB\-\-from\-json\fP \fISPEC\fP
+Read tasks from a JSON file (\fBFILE[@path]\fP).
+.sp
+The optional dotted \fBpath\fP after \fB@\fP locates the list of task objects inside
+the document (e.g. \fBplan.json@chunks\fP); with no \fB@\fP the file\(aqs top level must
+be the list, and a \fBFILE\fP of \fB\-\fP reads from \fB<stdin>\fP\&. Each task object\(aqs keys
+become named \fB{key}\fP template fields and task tags; an optional \fBargs\fP key is the
+base command (reachable as \fB{}\fP). Every \fB{key}\fP is validated against all task
+objects before anything is submitted.
+.TP
+.B \fB\-\-repeat\fP
+Re\-submit a known file\(aqs tasks again as a brand\-new source.
+.sp
+By default, submitting a named file whose path and content match a prior submission is
+refused to guard against accidental double submission. \fB\-\-repeat\fP overrides that: the
+file is ingested as a new source and all of its tasks are submitted again, even if
+identical tasks already exist. May be combined with new \fB\-t\fP/\fB\-\-tag\fP values to mark
+a new phase or trial.
+.TP
+.B \fB\-\-update\fP
+Submit only the tasks in a known file that are not already present.
+.sp
+Creates a new source record and submits only tasks whose identity (a stable hash of the
+pre\-template arguments, group, and tags) is absent from the prior same\-path submissions;
+tasks already submitted are skipped. Use this after editing a task file to add only the
+new work. Cannot be combined with \fB\-\-repeat\fP\&.
 .TP
 .B \fB\-q\fP, \fB\-\-queue\fP
 Submit directly to live queue instead of database.
@@ -1257,7 +1347,18 @@ A database must be configured.
 Specifying \fIFIELD\fP names defines what is included in the output
 (by default all fields are included).
 .sp
+As a safeguard against accidentally dumping an entire database, \fBhs list\fP refuses to return
+more than 1,000 tasks unless the intent is made explicit with \fB\-\-all\fP (dump everything),
+\fB\-\-limit\fP \fIN\fP (bound the result), or \fB\-\-count\fP (count only) \- much as \fBhs update\fP confirms
+a bulk change before applying it. A bare \fBhs list\fP with no arguments prints the usage statement.
+.sp
 This command maps directly to underlying SQL queries.
+.sp
+When printing to a terminal, task records are colorized by \fIexit_status\fP: successful tasks
+(0) are green, cancelled tasks (\-1, including those terminated by \fBSIGHUP\fP) are shown faint,
+tasks that terminated abnormally (killed by a signal, or that never ran \- any other negative
+status) are yellow, and tasks that ran and returned a non\-zero code are red. Tasks that have
+not yet run are left uncolored.
 .SS Arguments
 .INDENT 0.0
 .TP
@@ -1267,6 +1368,14 @@ Default is to include all fields.
 .UNINDENT
 .SS Options
 .INDENT 0.0
+.TP
+.B \fB\-\-all\fP
+Dump all matching tasks, imposing no limit.
+.sp
+As a guard against accidentally dumping an entire database, \fBhs list\fP refuses to return
+more than 1,000 results unless the intent is made explicit. \fB\-\-all\fP dumps them all,
+\fB\-\-limit\fP \fIN\fP bounds the result, and \fB\-\-count\fP only counts them; the three are mutually
+exclusive (e.g. \fBhs list \-\-all\fP or \fBhs list \-\-all \-\-csv\fP).
 .TP
 .B \fB\-w\fP, \fB\-\-where\fP \fICOND...\fP
 List of conditional statements to filter results (e.g., \fB\-w \(aqduration >= 600\(aq\fP).
@@ -1300,8 +1409,19 @@ For backwards compatibility, \fB\-\-finished\fP is also valid.
 .B \fB\-R\fP, \fB\-\-remaining\fP
 Alias for \fB\-w \(aqexit_status == null\(aq\fP\&.
 .TP
+.B \fB\-X\fP, \fB\-\-cancelled\fP
+Alias for \fB\-w \(aqexit_status == \-1\(aq\fP (tasks that were cancelled).
+.TP
 .B \fB\-\-retries\fP
 Alias for \fB\-w \(aqattempt > 1\(aq\fP (tasks that have been retried).
+.TP
+.B \fB\-\-signal\fP \fINAME\fP
+Match tasks whose process was terminated by signal \fINAME\fP (e.g. \fBTERM\fP, \fBKILL\fP, \fBHUP\fP).
+.sp
+A task killed by signal \fIN\fP is recorded with \fBexit_status = \-N\fP (the convention used by
+Python\(aqs subprocess module). The \fBSIG\fP prefix is optional and the name is case\-insensitive.
+A task terminated by \fBHUP\fP lands on \-1 and is therefore treated as cancelled
+(see \fB\-\-cancelled\fP).
 .TP
 .B \fB\-f\fP, \fB\-\-format\fP \fIFORMAT\fP
 Specify output format (either \fBnormal\fP, \fBplain\fP, \fBtable\fP, \fBcsv\fP, \fBjson\fP).
@@ -1386,6 +1506,12 @@ Cancelling a task means it will no longer be scheduled. This is done by setting 
 \fIschedule_time\fP and \fIcompletion_time\fP to \fInow\fP and the \fIexit_status\fP to \-1. The task
 becomes terminal: it will not be scheduled, retried, or reverted on \fB\-\-restart\fP\&.
 A task cannot be cancelled after it is sent to remote clients.
+.sp
+A running task can also be cancelled \fIin flight\fP on the client by terminating its
+process with \fBSIGHUP\fP (e.g. \fBkill \-HUP\fP). Because a process killed by signal \fIN\fP is
+recorded with \fBexit_status = \-N\fP, a \fBSIGHUP\fP (signal 1) death lands on \-1 \- the same
+cancelled state \- so such a task is likewise not retried. See \fBhs list \-\-cancelled\fP and
+\fBhs list \-\-signal HUP\fP\&.
 .TP
 .B \fB\-\-revert\fP
 Revert specified tasks.
@@ -1439,8 +1565,19 @@ Alias for \fB\-w \(aqexit_status != null\(aq\fP\&.
 .B \fB\-R\fP, \fB\-\-remaining\fP
 Alias for \fB\-w \(aqexit_status == null\(aq\fP\&.
 .TP
+.B \fB\-X\fP, \fB\-\-cancelled\fP
+Alias for \fB\-w \(aqexit_status == \-1\(aq\fP (tasks that were cancelled).
+.TP
 .B \fB\-\-retries\fP
 Alias for \fB\-w \(aqattempt > 1\(aq\fP (tasks that have been retried).
+.TP
+.B \fB\-\-signal\fP \fINAME\fP
+Match tasks whose process was terminated by signal \fINAME\fP (e.g. \fBTERM\fP, \fBKILL\fP, \fBHUP\fP).
+.sp
+A task killed by signal \fIN\fP is recorded with \fBexit_status = \-N\fP (the convention used by
+Python\(aqs subprocess module). The \fBSIG\fP prefix is optional and the name is case\-insensitive.
+A task terminated by \fBHUP\fP lands on \-1 and is therefore treated as cancelled
+(see \fB\-\-cancelled\fP).
 .TP
 .B \fB\-f\fP, \fB\-\-no\-confirm\fP
 Do not ask for confirmation.
@@ -1640,6 +1777,21 @@ argument to all clients.
 .sp
 In some situations it may be useful to expand a template with the \fBsubmit\fP command.
 These are expanded \fIprior\fP to scheduling as the actual \fIargs\fP for the task.
+.SS Named Fields
+.sp
+When tasks are submitted from a JSON file with \fB\-\-from\-json\fP (see the \fBsubmit\fP
+command), each task object\(aqs keys become available as named template fields. A
+\fB{key}\fP pattern expands to that key\(aqs value for the given task, and the keys also
+become task tags.
+.sp
+For a task object \fB{\(dqseqid\(dq: \(dqChr1\(dq, \(dqstart\(dq: 1, \(dqend\(dq: 5000000}\fP the template
+\fBprocess \-\-region {seqid}:{start}\-{end}\fP expands to
+\fBprocess \-\-region Chr1:1\-5000000\fP\&.
+.sp
+Values are stringified: booleans render as \fBtrue\fP/\fBfalse\fP, \fBnull\fP as an empty
+string, and nested objects/arrays as compact JSON. A built\-in pattern (below) takes
+precedence over a task key of the same name. Named fields are resolved at submit time,
+and every \fB{key}\fP must be present in each task object or the submission is rejected.
 .SS Filepath Operations
 .sp
 Shell commands often operate on filepaths. In such cases, it may be useful to manipulate

--- a/share/man/man1/hyper-shell.1
+++ b/share/man/man1/hyper-shell.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "HYPER-SHELL" "1" "Jul 11, 2026" "2.8.1" "hypershell"
+.TH "HYPER-SHELL" "1" "Jul 12, 2026" "2.8.1" "hypershell"
 .SH NAME
 hyper-shell \- Process shell commands over a distributed, asynchronous queue
 .SH SYNOPSIS
@@ -123,6 +123,10 @@ that never landed are submitted, and interrupted tasks are re\-run — so a requ
 \fBhsx <FILE> \-\-restart\fP job is safe to run repeatedly. Use \fB\-\-repeat\fP to deliberately submit a
 known file\(aqs tasks again as a new source, or \fB\-\-update \-\-restart\fP to add only the tasks that are
 new since the file was last seen.
+.sp
+De\-dup cost scales with the file\(aqs own source lineage rather than the whole database, so requeues stay
+fast at scale; for very large workflows, a one\-time \fBsubmit\fP followed by a bare \fBhsx \-\-restart\fP (no
+file re\-read) is cheaper than re\-feeding the \fIFILE\fP each run.
 .sp
 Use \fB\-\-autoscaling\fP with either \fIfixed\fP or \fIdynamic\fP to run a persistent, elastically scalable
 cluster using an external \fB\-\-launcher\fP to bring up clients as needed.
@@ -988,6 +992,11 @@ not already present from earlier versions of the same file. JSON task files (\fB
 are gated the same way, keyed by their absolute path together with any \fB@path\fP selector.
 Single\-command and \fB<stdin>\fP submissions (including \fB\-\-from\-json \-\fP) are treated as
 explicit intent and are exempt from these checks.
+.sp
+Detection and \fB\-\-update\fP de\-dup are index\-backed on the source lineage, so their cost scales with
+that file\(aqs own size, not the size of the database: re\-submitting a normal file stays fast even against
+a very large database, while \fB\-\-update\fP on a source of millions of tasks pays to re\-read and
+fingerprint the entire file to find what is new.
 .SS Arguments
 .INDENT 0.0
 .TP

--- a/share/zsh/site-functions/_hs
+++ b/share/zsh/site-functions/_hs
@@ -461,7 +461,8 @@ function _hs_update() {
 function _hs_submit() {
     _arguments -s -S \
         '(-h --help)'{-h,--help}'[Show this message and exit]' \
-        '(-f --task-file)'{-f,--task-file}'[Path to task file ("-" for <stdin>)]:task file:_files' \
+        '(-f --task-file --from-json)'{-f,--task-file}'[Path to task file ("-" for <stdin>)]:task file:_files' \
+        '(-f --task-file --from-json)--from-json[Read tasks from a JSON file ("FILE[@path]")]:json spec:_files' \
         '(-q --queue)'{-q,--queue}'[Submit to live queue instead of database]' \
         '(-H --host)'{-H,--host}'[Hostname for server (used with --queue)]:host:_hs_known_hosts' \
         '(-p --port)'{-p,--port}'[Port number for server (used with --queue)]:port:_hs_ports' \
@@ -558,6 +559,7 @@ function _hs_cluster() {
         '(-h --help)'{-h,--help}'[Show this message and exit]' \
         '(-N --num-threads)'{-N,--num-threads}'[Executor threads per client, 0=auto (default: 1)]:threads:_hs_thread_counts' \
         '(-t --template)'{-t,--template}'[Command-line template pattern (default "{}")]:template:' \
+        '(1)--from-json[Read tasks from a JSON file ("FILE[@path]")]:json spec:_files' \
         '(-H --bind)'{-H,--bind}'[Special bind address (default localhost/0.0.0.0)]:address:(localhost 127.0.0.1 0.0.0.0)' \
         '(-p --port)'{-p,--port}'[Port number (default: 50001)]:port:_hs_ports' \
         '(--no-tls)--no-tls[Disable TLS for queue interface (not recommended)]' \
@@ -603,7 +605,7 @@ function _hs_cluster() {
         '(-I --init-size)'{-I,--init-size}'[Initial size of cluster (default: 1)]:size:(0 1 2 5)' \
         '(-X --min-size)'{-X,--min-size}'[Minimum size of cluster (default: 0)]:size:(0 1)' \
         '(-Y --max-size)'{-Y,--max-size}'[Maximum size of cluster (default: 1)]:size:(1 2 5 10 20)' \
-        '1:input file:_files'
+        '(--from-json)1:input file:_files'
 }
 
 # Autoloaded via the #compdef tag: the file body defines the helpers and

--- a/share/zsh/site-functions/_hs
+++ b/share/zsh/site-functions/_hs
@@ -477,6 +477,8 @@ function _hs_submit() {
         '(-g --group)'{-g,--group}'[Task group for dependency management]:group:' \
         '(-b --bundlesize)'{-b,--bundlesize}'[Number of lines to buffer]:size:(1 10 100 1000)' \
         '(-w --bundlewait)'{-w,--bundlewait}'[Seconds to wait before flushing tasks]:seconds:(5 10 30 60 600)' \
+        '(--update)--repeat[Re-submit a known file again as a new source]' \
+        '(--repeat)--update[Submit only tasks not already present from a known file]' \
         '--initdb[Auto-initialize database]' \
         '*'{-t,--tag}'[Assign tags as key:value]:tag:_hs_tags' \
         '(-)--[End of options; task arguments follow]' \

--- a/share/zsh/site-functions/_hs
+++ b/share/zsh/site-functions/_hs
@@ -573,7 +573,9 @@ function _hs_cluster() {
         '(--no-db --initdb)--initdb[Auto-initialize database]' \
         '--no-confirm[Disable client confirmation of task bundle received]' \
         '--forever[Schedule forever]' \
-        '--restart[Start scheduling from last completed task]' \
+        '(--repeat)--restart[Resume a prior run; with FILE submit only tasks not already present]' \
+        '(--update --restart)--repeat[Re-submit a known file again as a new source]' \
+        '(--repeat)--update[Submit only new tasks from a known file (use with --restart)]' \
         '(--mpi --launcher)--ssh[Launch directly with SSH host(s)]::host:_hs_known_hosts' \
         '(--ssh --launcher)--mpi[Same as --launcher=mpirun]' \
         '(--ssh --mpi)--launcher[Use specific launch interface]:launcher:_command_names -e' \

--- a/spec/cli-cluster-restart-repeat-update/GOAL.md
+++ b/spec/cli-cluster-restart-repeat-update/GOAL.md
@@ -1,0 +1,151 @@
+# GOAL — Safe re-submission: `--restart` / `--repeat` / `--update` source gating
+
+> **Origin spec.** The *what* and *why* — the locked contract `hs-review` grades against.
+> The *how* lives in [`PLAN.md`](PLAN.md) and [`TECH.md`](TECH.md) (written by `hs-plan`).
+> Keep this at the right altitude: solved and bounded, but not over-specified — leave design
+> freedom for the plan. Edit requirements here; do **not** silently drift them during build.
+
+- **slug:** cli-cluster-restart-repeat-update
+- **kind:** feature
+- **appetite:** big
+
+## Problem
+
+The very first thing new users tend to do is run the `hsx <taskfile>` workflow inside a Slurm job
+with `--restart` so a requeued job can pick up where it left off. `--restart` has since been
+**disabled** to protect users from accidentally double-submitting the same tasks into a live
+database. The current safe pattern — run `hs submit` out-of-band (e.g. on a login node) once, then
+put a bare restart-style `hsx` in the job script — is awkward to explain and is exactly the friction
+a first-time user hits first.
+
+We want re-submission to be safe *by construction* so that expressing intent (restart, repeat,
+update) relaxes the refusal gate only where it is provably safe, and refuses loudly where it is not.
+The engine already reverts interrupted tasks on server start; what is missing is a way to know
+whether a given task file has already been ingested, whether all of its tasks actually landed, and
+which tasks are genuinely new — cheaply, even on databases holding billions–trillions of rows.
+
+## Outcome / vision
+
+A user can put `hsx <taskfile> --restart` in a job script and requeue the job as many times as they
+like: each run detects the prior submission, submits only the tasks that never made it, and lets the
+existing revert-interrupted flow re-run anything that was mid-flight — never duplicating work. When a
+user *changes* the file they get a clear path (`--update`) that submits only the novel tasks, and
+when they genuinely want to run the same work again they get another clear path (`--repeat`).
+Ambiguous or contradictory intent is refused with an actionable message. Detection stays fast and
+well-logged at extreme scale.
+
+To make this possible the database gains a **source** record per ingested named file (a unique
+source UUID, the absolute path, a file-content fingerprint, the ingested task count, a timestamp),
+each task is stamped with its **source** and a stable **identity fingerprint**, and submission
+consults these to decide whether to proceed, de-dup, or refuse.
+
+## Acceptance criteria (the contract)
+
+### Source & task identity
+
+- **R1** — The system SHALL record, for every ingested **named** task file, a source record
+  capturing at least: a unique source UUID, the absolute file path, a file-content fingerprint
+  (e.g. md5), the ingested task count, and a creation timestamp.
+- **R2** — The system SHALL stamp every task with a stable **identity fingerprint** derived from a
+  canonical (order-independent) hash of the task's **args**, **group**, and **tags**. `args` is the
+  raw submitted argument string *before* template expansion — the meaningful unit of work, since the
+  resolved command can differ by template. The UUID, attempt/retry counters, timing, exit status,
+  and the execution template SHALL NOT participate in identity.
+- **R3** — The system SHALL associate every task ingested from a named file with its source UUID.
+  Single command-line submissions (`hs submit '<cmd>'`) SHALL use the reserved source `<direct>` and
+  streamed/stdin submissions SHALL use `<stdin>`; both are considered explicit user intent and are
+  **exempt** from all gating in R5–R14.
+
+### `hs submit` gate matrix
+
+- **R4** — WHEN `hs submit <file>` ingests a named file, the system SHALL read the file upfront to
+  compute its source fingerprint and task count; `<stdin>` submissions SHALL remain streamed and are
+  exempt from fingerprint/count gating (R3).
+- **R5** — WHEN `hs submit <file>` is invoked with no gating flag and the file's (path, fingerprint)
+  matches a prior source, the system SHALL refuse and exit without submitting, identifying the prior
+  submission.
+- **R6** — WHEN `hs submit <file>` is invoked with no gating flag and the path was seen before but
+  the fingerprint differs, the system SHALL refuse and exit, suggesting `--update`.
+- **R7** — WHEN a named file's source is known, the system SHALL compare the DB task count for that
+  source against the source's recorded count and SHALL warn if fewer tasks landed than expected
+  (an incomplete prior submission).
+- **R8** — WHEN `hs submit <file> --repeat` is invoked, the system SHALL ingest the file as a new
+  source and submit all of its tasks even if an identical prior source already exists.
+- **R9** — WHEN `hs submit <file> --update` is invoked, the system SHALL create a new source record
+  and submit only tasks whose identity fingerprint (R2) is not already present from the prior
+  same-path source lineage, skipping tasks already submitted.
+- **R10** — IF `hs submit` is invoked with both `--update` and `--repeat`, THEN the system SHALL
+  reject the invocation as contradictory and exit non-zero.
+
+### `hsx` / `hs cluster` gate matrix
+
+- **R11** — WHEN `hsx <file>` is invoked with no gating flag, the system SHALL apply the same
+  detection, refusal, and count-warning behavior as bare `hs submit` (R5–R7).
+- **R12** — WHEN `hsx <file> --restart` is invoked, the system SHALL NOT refuse solely because the
+  file was seen before. If the file fingerprint differs from the prior same-path source it SHALL
+  alert and refuse, suggesting `--update`. If the fingerprint matches it SHALL submit only tasks
+  whose identity fingerprint is not already present, relying on the existing revert-interrupted flow
+  to re-run any interrupted tasks.
+- **R13** — IF `hsx <file> --update` is invoked *without* `--restart` (and without `--repeat`), THEN
+  the system SHALL reject the invocation as ambiguous and exit non-zero.
+- **R14** — WHEN `hsx <file> --update --restart` is invoked, the system SHALL acknowledge the prior
+  source and, if the fingerprint differs, create a new source and submit only tasks whose identity
+  is not already present in the prior same-path source lineage (de-dup), adding only novel tasks.
+- **R15** — WHEN `hsx <file> --repeat` is invoked, the system SHALL allow submission even if a
+  matching prior source exists — the behavior `--restart` had in older versions — submitting all
+  tasks; this MAY be combined with new tags to represent a new phase/trial.
+- **R16** — IF `hsx <file> --update --repeat` is invoked, THEN the system SHALL reject the invocation
+  as contradictory and exit non-zero.
+
+### Scale & ergonomics
+
+- **R17** — Source lookup, count checks, and de-dup SHALL be backed by appropriate indices (on
+  source identity and task identity fingerprint) so that detection cost does not scale linearly with
+  total task count and a bare `hs submit` on a very large table (targeting billions–trillions of
+  rows on PostgreSQL/TimescaleDB) is not materially slower than today.
+- **R18** — The system SHALL emit clear, helpful logging during upfront ingest and during detection
+  (e.g. how many tasks were found, how many already existed, how many will be submitted, and why an
+  invocation was refused).
+
+## Non-goals (no-gos)
+
+- **No migration/backfill** of databases created before this feature — the feature assumes a
+  database initialized with `hs initdb` after the upgrade. The schema change is additive; historical
+  tasks simply carry no source and are never retroactively de-duplicated.
+- **No global content de-duplication** across unrelated files — de-dup is scoped to the same-path
+  source lineage, not "have I ever run this command anywhere."
+- **No intra-file de-duplication** — duplicate lines within a single file remain distinct tasks.
+- **No change to the retry / revert-interrupted mechanism** — interrupted tasks continue to be
+  re-run by the existing server revert flow; this feature only decides what to *submit*.
+- **No source tracking for `in_memory` mode** — with no persistent database there is nothing to gate
+  against; gating applies only to persistent SQLite/PostgreSQL.
+- **No new DAG / dependency semantics** — HyperShell remains a flat many-task engine.
+
+## Clarifications
+
+- **Q:** Is task identity the fresh per-submit UUID, or something stable? — **A:** Stable: a
+  canonical hash of **args + group + tags**, where `args` is the pre-template argument string (the
+  resolved command can vary by template, so args is the meaningful identity). (resolved 2026-07-11)
+- **Q:** Bare `hs submit`/`hsx` on a *changed* file at a previously-seen path (no flag)? — **A:**
+  Refuse and exit, suggesting `--update`. (resolved 2026-07-11)
+- **Q:** Which flag combos are valid on `hs submit` (which has no `--restart`)? — **A:** `--update`
+  alone is valid; `--repeat` alone is valid; `--update`+`--repeat` is rejected. (resolved 2026-07-11)
+- **Q:** How do databases predating the feature behave? — **A:** Require a fresh `hs initdb`; schema
+  is additive, no backfill. (resolved 2026-07-11)
+- **Assumption (confirm at plan time):** `--update` de-dup scope is the **same-path source lineage**
+  for both `hs submit --update` (R9) and `hsx --update --restart` (R14). The seed text described the
+  cluster case as de-dup "against existing tasks in the database"; treating both as same-path lineage
+  keeps the two forms consistent.
+- **Assumption (confirm at plan time):** because **tags** participate in identity (R2), changing
+  only a task's tags between file versions makes it a *new* task under `--update` (it will be
+  re-submitted). This is the price of letting `--repeat` re-tag a new phase; flag if unwanted.
+
+## Related materials
+
+- Issue: <https://github.com/hypershell/hypershell/issues/37>
+- Task ingest & source of truth: `src/hypershell/submit.py` (`SubmitApp` / UUID assignment /
+  `# HYPERSHELL:` tag parsing).
+- Task state & identity queries: `src/hypershell/data/model.py` (`Task`/`Client` ORM, `Task.new`,
+  state classmethods); schema/engine in `src/hypershell/data/core.py` (`InitDBApp`).
+- Cluster entry / `--restart` wiring: `src/hypershell/cluster/__init__.py`, `src/hypershell/server.py`
+  (revert-interrupted flow).

--- a/spec/cli-cluster-restart-repeat-update/PLAN.md
+++ b/spec/cli-cluster-restart-repeat-update/PLAN.md
@@ -1,0 +1,258 @@
+# PLAN — Safe re-submission: `--restart` / `--repeat` / `--update` source gating
+
+> **Status:** Draft for review · **Last updated:** 2026-07-11
+> **Authoritative technical design.** The *how*. Vision/contract is [`GOAL.md`](GOAL.md);
+> the phased executable roadmap is [`TECH.md`](TECH.md). Backing detail is in
+> [`research/`](research/). Every design element traces to a GOAL R-ID.
+
+## 1. Summary
+
+Give the database a **`source`** record per ingested named file (uuid, absolute path, content md5,
+task count, timestamp) and stamp every task with its **`source`** (a native `UUID`) and a stable
+**`fingerprint`** — a canonical, order-independent md5 of pre-template `args` + `group` + `tags` (named
+`fingerprint`, mirroring `Source.fingerprint`; *not* `identity`, which reads too close to `id`).
+Submission consults these — cheaply, via an indexed `Source` lookup — to proceed, de-dup, or refuse.
+The schema is additive (fresh `hs initdb`, no backfill); the gate context rides **inside the `source`
+iterable** (a `GatedSource` wrapper) so it reaches the one stamping chokepoint (`Loader`/`Task.new`)
+without threading kwargs through the ~10 coupled-core constructors. Appetite is *big*, surface bounded:
+DB-layer groundwork, two model additions, one submit-flow seam, two CLI matrices, docs/completions/tests.
+
+## 2. Design
+
+### Database layer (`src/hypershell/data/core.py`) — Timescale groundwork
+
+- **New provider alias `timescale` / `timescaledb`** in the `providers` map (`data/core.py:173`) →
+  `'postgresql+psycopg'` (TimescaleDB *is* PostgreSQL). Wherever `config.provider == 'postgres'` is
+  special-cased (the `get_url` file-pop at `data/core.py:227`), accept the timescale aliases too;
+  `DATABASE_DIALECT` (`data/__init__.py:50`) already routes any non-sqlite provider to `'postgres'`, and
+  `set_sqlite_pragmas` is unaffected.
+- **`uuid7`-extra dependency gate, active only in timescale mode** — mirrors the existing turso import
+  gate (`data/core.py:207-212`) and psycopg gate: if `config.provider in ('timescale','timescaledb')`
+  and `import uuid_utils` fails, `display_critical(...)` + `sys.exit(exit_status.runtime_error)`. This
+  **guarantees the existing `uuid()` yields UUIDv7 in timescale mode** (it already prefers
+  `uuid_utils.uuid7`, `core/uuid.py:8-11`), giving the orderable `source` column that TimescaleDB's
+  compressed per-batch min/max prunes on. Also emit a one-line groundwork warning that Timescale-specific
+  management (e.g. an automatic post-`create_all` hypertable hook) is **not** in this feature.
+- **No change to `core/uuid.py`.** `Source.id` (and Task/Client ids) use the existing `uuid()`:
+  UUIDv7 when the `uuid7` extra is present (guaranteed in timescale mode; the default in the dev/full
+  install), plain `uuid4` otherwise — which is fine, because non-timescale deployments aren't hypertables
+  and rely on the B-tree, not min/max pruning.
+
+### Data model (`src/hypershell/data/model.py`)
+
+- **New `Source` entity** (mirrors `Client`): `id` `UUID` (pk, `uuid()`), `path` `TEXT`, `fingerprint`
+  `TEXT` (content md5 hex), `task_count` `INTEGER`, `created` `DATETIME`. Own `columns` dict, inner
+  `NotFound/NotDistinct/AlreadyExists`, `from_id`, `new(path, fingerprint, task_count)`
+  (`id=uuid()`, `created=now().astimezone()`), `reserved(<const-id>)` (lazy get-or-create),
+  `paths_for_ids(ids)` (presentation), + the query classmethods below. **No lineage pointer column** —
+  lineage = *all sources sharing `path`* (R9/R14).
+- **Reserved sources are real rows.** Module constants `DIRECT_SOURCE_ID`/`STDIN_SOURCE_ID` (fixed
+  well-known UUIDs) identify single lazily-created `Source` rows whose `path` holds `<direct>`/`<stdin>`.
+  Fixed constants ⇒ idempotent get-or-create by PK **and** a statically-excludable set for the partial
+  de-dup index. Gating exemption is decided at the **App layer** by submission mode, not by inspecting
+  `Task.source`.
+- **New `Task` columns** (append + add to `Task.columns` at `model.py:281` for wire round-trip):
+  - `source` **shared `UUID`** type (native on postgres), nullable — holds a real `Source.id` (or a
+    reserved-const id); NULL only for historical rows. Native UUID (not TEXT) is what carries the
+    orderable column stats Timescale compression prunes on.
+  - `fingerprint` `TEXT` nullable — the stable task fingerprint below (R2). NULL for historical rows.
+- **`Task.compute_fingerprint(raw_command, group, tags) -> str`** classmethod:
+  `md5(json.dumps({'args': raw_command, 'group': group, 'tags': {k:v for k,v in tags.items() if k!='part'}},
+  sort_keys=True, separators=(',',':'), ensure_ascii=False)).hexdigest()`. Called from `Task.new` after
+  tag/group assembly. `Task.new` gains `raw_args`, `fingerprint`, `source` kwargs;
+  `raw_command = split_argline(raw_args)[0]` (line) or `raw_args` (JSON, `parse_inline=False`), falling
+  back to `args` when `raw_args is None`. Retry minter `__schedule_next_failed_tasks` (`model.py:555`)
+  passes `fingerprint=task.fingerprint` **and** `source=task.source` so a chain keeps one fingerprint +
+  its source (R2/R3 for retries).
+- **Query classmethods** (all state/query logic stays in the model, invariant §1):
+  `Source.lookup(path) -> list[Source]` (same-path lineage, newest first),
+  `Source.matching(path, fingerprint)`, `Task.count_for_source(id) -> int` (R7),
+  `Task.fingerprints_for_sources(ids) -> set[str]` (R9/R12/R14 skip-set).
+- **Indices (R17):** `Index('index_source_lookup', Source.path, Source.fingerprint)` (btree) and
+  `Index('index_tasks_source', Task.source, Task.fingerprint)` — composite btree, **partial excluding
+  `DIRECT_SOURCE_ID`/`STDIN_SOURCE_ID`** (`postgresql_where` / `sqlite_where`). **No BRIN / no
+  TSDB-specific code** (maintainer decision): chunk pruning at scale comes from Timescale's compressed
+  per-batch min/max on the orderable UUIDv7 `source`; the btree satisfies R17 on its own (cost scales
+  with lineage matches + chunk count, not total rows).
+- `Entity.metadata.create_all` picks these up on a fresh `initdb`; existing `task` tables are never
+  ALTERed (no-backfill non-goal, no Alembic).
+
+### Submit-flow seam (`src/hypershell/submit.py`, `src/hypershell/data/__init__.py`)
+
+- **`GatedSource(iterable, source_id, skip_fingerprints=None, name=None)`** — small wrapper: `__iter__`
+  delegates, exposes `.source_id`/`.skip_fingerprints`/`.name`. `Loader.__init__` unwraps it (reads
+  `source_id`/`skip`, then `iter(inner)`); `SubmitThread`/`LiveSubmitThread.source_name` surface
+  `.name`. Everything between (`submit_from`, `SubmitThread`, `ServerThread`, `LocalCluster`,
+  `RemoteCluster`, `AutoScalingCluster`) passes `source` opaquely — **unchanged**.
+- **`Loader`** (`submit.py:164-205`): for each built `Task`, set `task.source = self.source_id`, pass
+  `raw_args` so the fingerprint is computed/stamped; if `self.skip and task.fingerprint in self.skip`,
+  skip (don't `put_task`, don't increment `count`) — logging the running "M present / L new" tally.
+- **Upfront read helper:** `source_fingerprint_and_count(path, template) -> (md5_hex, count)` — one
+  streaming pass: `hashlib.md5(raw bytes)` + count lines where
+  `bool(split_argline(template.expand(line.strip()))[0])`. The task-or-not predicate is factored into a
+  shared helper used by both this pass and the `Loader`. `<stdin>` is not seekable ⇒ exempt.
+- **`apply_source_gate(...)`** — shared decision function called by both apps (in `submit.py`, which
+  `cluster/__init__.py` already imports). Inputs: resolved `path`, `fingerprint`, `count`, flags
+  (`repeat`/`update`/`restart`). Returns the new `source_id` (fresh `Source` row, expected count written
+  first) and `skip_fingerprints` (`None`, or `Task.fingerprints_for_sources(lineage_ids)` for de-dup);
+  emits R18 logs + R7 count-warn; raises `ArgumentError` on refusal. Guarded by
+  `queue_config is None and not in_memory`.
+- **`SubmitApp`**: `check_source` captures `os.path.abspath(filepath)` for named files; stdin /
+  single-command resolve the reserved source via `Source.reserved(STDIN_SOURCE_ID)` /
+  `Source.reserved(DIRECT_SOURCE_ID)`. `run` builds the `GatedSource` from the gate result.
+- **`ClusterApp`**: `source`/`input_stream` become file-aware; `run` builds the `GatedSource` and passes
+  it as `source` to the launcher (opaque the rest of the way).
+
+### CLI surface
+
+- **`hs submit`**: add `--repeat`/`--update` (`store_true`). New `check_arguments`: `--update
+  --repeat` → `ArgumentError` (R10). Gate matrix R5–R9 via `apply_source_gate`. `-q`/`--no-db`/stdin/
+  single-cmd exempt.
+- **`hsx` / `hs cluster`**: add `--repeat`/`--update`. `check_arguments`: `--update` without
+  (`--restart`|`--repeat`) → R13; `--update --repeat` → R16; `--restart --repeat` → contradictory
+  (**human decision**); `--update` with `--no-db` → refuse. `--restart` becomes file-aware (R12/R14);
+  bare `--restart` (no file) unchanged. Keep existing `--forever`/`--no-db` + `--restart` refusals.
+- **Refusals** → `ArgumentError` → `exit_status.bad_argument` (2), uniform. Warnings via `log.warning`.
+- **`--from-json` is gated** (human decision): source `path = abspath(FILE)[+'@'+node]`, `fingerprint =
+  md5(FILE bytes)`, `count = len(records)`; records are already in memory (no 2nd pass). The
+  `--from-json`+`--restart` incompatibility (`cluster/__init__.py:341`) is **removed**. `--from-json -`
+  (stdin JSON) stays exempt.
+
+The authoritative refuse/warn/de-dup decision table (per prior-state × flags, both apps) is in
+[`research/05-cli-gate-matrix.md`](research/05-cli-gate-matrix.md).
+
+### Requirement → design map
+
+| R-ID | Design element(s) that satisfy it |
+|------|-----------------------------------|
+| R1 | `Source` entity (uuid/path/fingerprint/task_count/created); row written before tasks with expected count. |
+| R2 | `Task.fingerprint` + `Task.compute_fingerprint` (canonical md5 of pre-template `args`+`group`+`tags`−`part`); excludes uuid/attempt/timing/exit/template by construction. |
+| R3 | `Task.source` (native UUID) stamped in `Loader`/`Task.new`; reserved `<direct>`/`<stdin>` are real `Source` rows (fixed-const ids) via `Source.reserved(...)`; both exempt (App-layer, by mode); retries propagate `source`. |
+| R4 | `source_fingerprint_and_count` upfront read of named files (md5 + count); `<stdin>` streamed & exempt. |
+| R5 | `apply_source_gate`: `Source.matching(path,fp)` hit + no flag → `ArgumentError` naming prior. |
+| R6 | path seen (`Source.lookup`) + fp differs + no flag → `ArgumentError` suggesting `--update`. |
+| R7 | detection compares `Source.task_count` vs `Task.count_for_source` → `log.warning` if fewer landed. |
+| R8 | `--repeat` → new `Source`, `skip_fingerprints=None`, submit all. |
+| R9 | `--update` → new `Source`, `skip_fingerprints = Task.fingerprints_for_sources(lineage)`; Loader skips present. |
+| R10 | `hs submit` `check_arguments`: `--update`+`--repeat` → `ArgumentError`. |
+| R11 | `hsx` no-flag path reuses `apply_source_gate` (== R5–R7). |
+| R12 | `hsx --restart`: no refuse on seen; fp match → novel-only (skip-set) + rely on `revert_interrupted`; fp differs → `ArgumentError` suggest `--update`. |
+| R13 | `hsx` `check_arguments`: `--update` without `--restart`/`--repeat` → `ArgumentError`. |
+| R14 | `hsx --update --restart`: new `Source`, novel-only in same-path lineage. |
+| R15 | `hsx --repeat`: new `Source`, submit all even on match; new `-t` tags flow through unchanged. |
+| R16 | `hsx` `check_arguments`: `--update`+`--repeat` → `ArgumentError` (and `--restart`+`--repeat`). |
+| R17 | `index_source_lookup` + partial composite btree `index_tasks_source`; detection hits tiny `Source` table + per-source COUNT; de-dup scoped to lineage (not total tasks); UUIDv7 `source` (timescale mode) lets Timescale compression prune chunks (no BRIN/TSDB code). |
+| R18 | `apply_source_gate`/`Loader` log points: found N (md5) · prior source · incomplete-warn · M present/L new · refusal reasons. |
+
+## 3. Invariant gate (AGENTS.md constitution check)
+
+Checked against [`.agents/factory/invariants.md`](../../.agents/factory/invariants.md) before research
+and again after this design.
+
+- **§1 Task lifecycle** — `source`/`fingerprint` are additive and orthogonal to the nullable-column
+  state predicates; no query changes those predicates. All new query/state logic lives in
+  `Source`/`Task` classmethods. De-dup only *skips submission*; it never sets `schedule_time` without
+  `completion_time`.
+- **§3 Retry model** — the fingerprint excludes attempt/retry/uuid/`previous_id`/`next_id`, so a retry
+  shares its parent's fingerprint; `fingerprint`/`source` are non-unique columns independent of the
+  UNIQUE `previous_id`/`next_id` chain. Retry minter propagates both (change lands with the model change).
+- **§4 Server modes** — every source write/gate guarded by `queue_config is None and not in_memory`
+  (non-goal: no source tracking for `in_memory`; queue-mode writes no rows).
+- **§6 Shutdown/sentinel ordering** — `GatedSource` wraps only the *source* iterable; the stream
+  sentinel, bundle serialization, and thread-join order are untouched. Wrapper is never enqueued.
+- **§9 Queue transport** — `source`/`fingerprint` added to `Task.columns` so JSON `to_json`/`from_json`
+  round-trip over the remote queue; no wire-format or TLS change.
+- **§11 Cluster** — new flags are submit/server-side and are **not** added to any client argv builder;
+  the `GatedSource` seam specifically avoids replicating a kwarg across local/remote/ssh/autoscale.
+- **§12 Conventions** — refusals reuse `exit_status.bad_argument`; docs `_include` snippets + `share/`
+  completions updated in the CLI phases; md5/hashlib is stdlib (no new dep); the `timescale` provider
+  gates the existing `uuid7` extra (no new *runtime* dep, EPEL floors untouched); tests tagged
+  `@mark.unit`/`@mark.integration`.
+
+### Deviation justifications
+
+| Deviation | Why needed | Simpler alternative rejected because |
+|-----------|-----------|--------------------------------------|
+| `GatedSource` carries gate context *inside* the `source` object | Threading `source_id`+`skip` through `Loader`/`SubmitThread`/`ServerThread`/`LocalCluster`/`RemoteCluster`/`AutoScalingCluster`/`submit_from` = ~10 coupled-core signatures (the §11 replication footgun) | Explicit kwarg threading: wider, easy to miss one launcher, and mutates high-blast-radius `server.py` + all cluster classes for a value they only forward. The wrapper confines the change to `Loader`/`Task.new`. |
+| De-dup skip-set = **all** fingerprints in the same-path lineage (strategy (a)) loaded once | Single fingerprint-computation site (Loader), R17-compliant (scales with lineage via `index_tasks_source`, not total tasks); lineage is a *small* set of sources ⇒ a single small-`IN` query | Batched anti-join (c) / temp-table (d) need App-layer fingerprint recomputation = duplicating the stateful global-tag machine (§1 risk); with a small lineage they buy nothing. |
+
+Empty is the goal; these are deliberate and bounded, and none bends a CRITICAL invariant. (Reserved
+sources as real UUID rows, `Task.source` as native `UUID`, and using the existing `uuid()` gated by the
+`timescale` provider — rather than a forced hand-rolled `uuid7()` — are all *simplifications* per
+maintainer review, not deviations.)
+
+## 4. Rabbit holes (resolved)
+
+- **Where is "pre-template args"?** Template expansion happens in the `Loader` *before* `Task.new`, and
+  `Task.args` stores the expanded string → pre-template args isn't recoverable from the row. Resolved:
+  thread the raw line via `raw_args` and compute the fingerprint in `Task.compute_fingerprint`
+  ([`research/01`](research/01-identity-fingerprint.md)).
+- **Which tags feed the fingerprint?** Final tag dict minus `part`; group/resource knobs auto-excluded
+  by the existing pop. Re-tagging ⇒ new fingerprint (GOAL-accepted) ([`research/01`](research/01-identity-fingerprint.md)).
+- **Reserved sources on postgres.** Resolved by making them **real `Source` rows with fixed-const
+  UUIDs**, so `Task.source` stays a **native `UUID`** (no TEXT sentinel hack)
+  ([`research/07`](research/07-uuidv7-source-ids.md), [`research/09`](research/09-pruning-adversarial-check.md)).
+- **Fast at trillions of rows.** Detection touches the tiny `Source` table, not `task`; de-dup scoped
+  to a small lineage. A plain btree does **not** min/max-prune — the lever is Timescale compressed
+  per-batch min/max on the **orderable UUIDv7 `source`** (timescale mode, operator config, no BRIN/TSDB
+  code); the btree alone still meets R17 ([`research/09`](research/09-pruning-adversarial-check.md)).
+- **UUIDv7 without forcing it.** `uuid.uuid7()` is stdlib only in 3.14 and `uuid()` defaults to `uuid4`;
+  resolved by a `timescale` provider alias that **gates the `uuid7` extra** (bail like psycopg), so
+  `uuid()` yields v7 exactly where it matters — no forced hand-roll ([`research/07`](research/07-uuidv7-source-ids.md)).
+- **Coupled-core plumbing.** `GatedSource` rides inside `source` ([`research/04`](research/04-submit-flow.md) + planner analysis of `server.py`/`cluster/*`).
+- **Current `--restart` ignores the file** (`cluster/__init__.py:437`, `source==[]`). Made file-aware
+  while preserving bare `--restart` DB-resume ([`research/05`](research/05-cli-gate-matrix.md)).
+
+## 5. Risks & open questions
+
+- **TimescaleDB pruning is a timescale-mode property, not correctness.** Chunk pruning of `WHERE source
+  IN (lineage)` comes from **compressed per-batch min/max** on the orderable UUIDv7 `source` — which is
+  *guaranteed* in `timescale` mode (the `uuid7` extra is gated) and provided by the operator's
+  compression policy (HyperShell ships no TSDB code). A plain btree does **not** prune by min/max, and
+  `enable_chunk_skipping` can't index `uuid`. In non-timescale deployments `source` may be `uuid4` and
+  there's no hypertable — de-dup stays **correct** via the btree (R17 met — scales with lineage + chunk
+  count, not total rows). Fixed-const reserved ids cluster under `source`-ordered compression and are
+  excluded from the partial index.
+- **Timescale groundwork only:** this feature adds the provider alias + `uuid7` gate + a warning; the
+  automatic post-`create_all` hypertable hook (and other TSDB gates) are **deferred** to a future
+  feature.
+- **De-dup memory** = one file-history's fingerprints (small lineage). Fine for the requeue case;
+  **log** the lineage/skip-set size so large loads are visible.
+- **R7 test determinism:** how to construct an "incomplete prior submission" deterministically —
+  settled in the phase that tests R7 (delete/cancel a subset, or interrupt a run).
+- **`hs server FILE`** remains ungated (out of scope). Its tasks carry NULL source; a later `hs submit`
+  of the same file won't detect them. Acceptable for the advanced/direct entry.
+- **Presentation:** raw `source` UUID / `fingerprint` md5 appear in machine formats (json/csv/`-x`) —
+  the human `normal` view resolves `source` → path/`<direct>`/`<stdin>` and hides `fingerprint` (P6).
+- **`hs list --json/--csv` default columns grow by two** (additive) — confirm no downstream parser
+  assumes a fixed column count (GOAL-level call, not a bug).
+- **`--from-json` source key** uses the full `FILE[@node]` spec as `path` so different `@node` selections
+  of one file are distinct sources (avoids a false R5 match); shown opaque (never relativized).
+
+## 6. Verification strategy
+
+Prove it by driving the real CLI in a `temp_site` (each phase's `verify:` in [`TECH.md`](TECH.md)):
+
+- **Unit** (`tests/test_source.py`): the fingerprint is order-independent over tags, stable across
+  template change and uuid, and differs on args/group/tag change; `source_fingerprint_and_count` ==
+  expected on a crafted file (blank/comment/inline-tag-only lines excluded); `format_source` passes
+  `<direct>`/`<stdin>` through and shows real paths.
+- **Integration** (`temp_site`, `create_taskfile_echo`, `assert_output` on R18 logs): one case per
+  R5–R16 + R3 exempt (`<direct>`/`<stdin>` resubmit freely) + R7 count-warn + fresh-`initdb` (source
+  table/indices exist). Anchor flows:
+  - `hs submit -f f.in` twice → 2nd refuses (R5); rewrite `f.in`, submit → refuse suggest `--update` (R6).
+  - `hs submit -f f.in --repeat` → `hs list --count` doubles (R8); `--update` after edit → only novel
+    added (R9); `--update --repeat` → non-zero (R10).
+  - `hsx f.in --restart` twice → 2nd idempotent (R12); `hsx f.in --update` → non-zero (R13);
+    `hsx f.in --update --restart` after edit → novel added + run (R14); `hsx f.in --repeat` → all
+    resubmitted (R15); `--restart --repeat` → non-zero (contradictory).
+  - `hs submit --from-json spec.json` twice → refuse; `hsx --from-json spec.json --restart` idempotent.
+- **Presentation** (integration): after a gated submit, `hs list source` resolves to the path (or
+  `<direct>`/`<stdin>`) in normal view while `hs list --json` / `-x source` show the raw UUID.
+- **Docs/completions:** `uv run sphinx-build docs docs/_build` (no *new* warnings); `bash -n
+  share/bash_completion.d/hs`; `zsh -n share/zsh/site-functions/_hs`.
+- **Full sweep:** `uv run pytest -v` green on the supported matrix.
+
+---
+
+*Backing research: [`research/00-digest.md`](research/00-digest.md).*

--- a/spec/cli-cluster-restart-repeat-update/REVIEW.md
+++ b/spec/cli-cluster-restart-repeat-update/REVIEW.md
@@ -1,0 +1,142 @@
+# REVIEW — Safe re-submission: `--restart` / `--repeat` / `--update` source gating
+
+> Adversarial QA by `hs-review`, run via a fresh blind correctness subagent. The correctness pass
+> grades the branch diff against [`GOAL.md`](GOAL.md) + the AGENTS.md invariants **only** — it does
+> not see `PLAN.md`/`TECH.md` (avoids grading-its-own-homework / plan-sycophancy). Every finding
+> cites an **executed** command, not an assertion.
+
+- **Reviewed commit:** 93476f1  ·  **Base:** develop  ·  **Date:** 2026-07-11
+- **Verdict:** changes-requested
+- **Cycle:** 1 of ≤3 (escalate to human on non-convergence)
+
+## Verification run
+
+Commands actually executed by the blind reviewer (spot-verified by the orchestrator against source):
+
+- `uv run pytest -q` (full suite) → **352 passed** (~239s, exit 0).
+- Feature files (`test_source` / `test_restart` / `test_submit` / `test_submit_json` / `test_groups`)
+  → 98 passed; one **flaky** timing failure in `test_groups::test_group_failed_task_with_retries`
+  cleared on re-run + in isolation + in full-file run. That test is **not modified** by the branch
+  (the only test_groups change is distinct batch filenames, `batch1.in`/`batch2.in`, for R6) →
+  timing flake, not a regression.
+- `uv run hs initdb` + schema dump → `source(id,path,fingerprint,task_count,created)` table +
+  `task.source`/`task.fingerprint` columns + the two new indices present.
+- R2 fingerprint properties (11 Python assertions) → order-independent over tags; excludes
+  template/uuid/attempt/timing/exit_status/`part`/resource knobs; `args` is pre-template. All pass.
+- `hs submit` matrix on a fresh DB → R5 refuse (exit 2), R6 refuse-suggest-`--update` (exit 2), R8
+  repeat-all, R9 update-novel-only, R10 reject (exit 2). All correct.
+- Real local `hsx -N1` cluster → plain new file ran; R11 refuse (exit 2); **R12** idempotent restart
+  ("All previous tasks completed (3) - stopping", exit 0, no hang); R12 changed-content refuse
+  (exit 2); **R14** `--update --restart` ran only the novel task; bare `--restart` DB-resume (exit 0);
+  **R15** `--repeat` re-ran all. All correct.
+- in_memory guard → `hsx FILE --no-db` twice → both exit 0, **0 source rows, 0 task rows** persisted.
+- `--from-json` gating → R5/R8/R9 correct; `--from-json -` (stdin) twice both exit 0;
+  `hsx --from-json … --restart` exit 0 (removed incompat works).
+- Retry propagation → 3-row `false` chain carries identical fingerprint + identical non-null source
+  across the chain; links intact (spot-verified at `data/model.py:625-626`).
+- **R17 query plans on a 300k-row table** → `Source.matching` uses `index_source_lookup`;
+  `count_for_source` and `fingerprints_for_sources` → **`SCAN task`** (linear). Isolation proved the
+  cause: adding the reserved-exclusion predicate, or a non-partial `(source,fingerprint)` index,
+  flips the plan to `SEARCH … USING COVERING INDEX`.
+- `bash -n` / `zsh -n` completions clean; new flags present. `sphinx-build` → only 2 pre-existing
+  toctree warnings.
+
+## Requirement → evidence matrix
+
+| R-ID | Implemented by | Verified how | Status |
+|------|----------------|--------------|--------|
+| R1 | `Source` entity, `data/model.py` | schema dump: source table + rows on submit | ✅ |
+| R2 | `Task.compute_fingerprint`, `data/model.py` | 11-property Python test | ✅ |
+| R3 | reserved `<direct>`/`<stdin>`, `submit.py` | double-submit of both succeeds; reserved rows present | ✅ |
+| R4 | `source_fingerprint_and_count`, `submit.py` | upfront md5+count; stdin streamed/exempt | ✅ |
+| R5 | `apply_source_gate` (no-flag+match), `submit.py:240` | 2nd bare submit refuses, exit 2, count unchanged | ✅ |
+| R6 | `apply_source_gate` (no-flag+differs), `submit.py:244` | changed content refuses "pass --update", exit 2 | ✅ |
+| R7 | `_warn_if_incomplete`, `submit.py:175` | mechanism works, **but false-positives after dedup** | ⚠️ **F2** |
+| R8 | `apply_source_gate` (repeat), `submit.py:217` | `--repeat` doubles task count | ✅ |
+| R9 | `apply_source_gate` (update), `submit.py:221` | `--update` novel-only, same-path lineage | ✅ |
+| R10 | `SubmitApp.check_arguments` | `--update --repeat` exit 2 | ✅ |
+| R11 | `apply_source_gate` via `hsx` | `hsx FILE` seen → refuse exit 2 | ✅ |
+| R12 | `apply_source_gate` (restart), `submit.py:226` | idempotent restart; changed→refuse exit 2 | ✅ |
+| R13 | `ClusterApp.check_arguments` | `hsx --update` (no restart) exit 2 | ✅ |
+| R14 | `apply_source_gate` (update+restart) | only novel task ran | ✅ |
+| R15 | `apply_source_gate` (repeat) | all re-run, new source | ✅ |
+| R16 | `ClusterApp.check_arguments` | `hsx --update --repeat` exit 2 | ✅ |
+| R17 | `index_source_lookup` + `index_tasks_source` | lookup indexed ✓; **count-check + de-dup full-scan** | ❌ **F1** |
+| R18 | log lines in `apply_source_gate` | found/present/submitting/refusal logs observed | ✅ |
+
+**Unmapped changes (possible scope creep):**
+- TimescaleDB provider aliases + `uuid7` gate (`data/core.py`) — maps loosely to R17's TimescaleDB
+  target; **self-admittedly incomplete** ("hypertable management … not yet implemented"). Additive,
+  guarded, no correctness defect. Report, not a blocker.
+- `format_source(relative=…)` (`core/pretty_print.py`) — the `relative=True` branch is never called
+  (future use). Harmless; presentation maps to R18.
+- Regenerated man-page content for pre-existing `hs list` flags is legitimate §12 same-commit
+  doc catch-up, not new scope.
+- `server.py` scheduler-race fix (submitter ref + `submission_complete()` guard) — a deliberate,
+  disclosed amendment; reproduced as **correct** (schedules on plain runs, halts without hang on
+  idempotent restart, resumes on bare `--restart`, no early-exit; sentinel ordering preserved).
+
+## Findings
+
+### [HIGH / CONFIRMED] R17 unmet — count-check and de-dup full-scan the task table
+- **Where:** `src/hypershell/data/model.py:827` (`count_for_source`), `:840`
+  (`fingerprints_for_sources`), index `:850-854` (`index_tasks_source`).
+- **Failure scenario:** `index_tasks_source` is a **partial** index carrying
+  `WHERE source NOT IN (<direct>,<stdin>)`, but both queries filter plain `source == ?` /
+  `source.in_(?)` without that predicate. Neither SQLite nor PostgreSQL can prove a bound param is
+  non-reserved, so the partial-index predicate is not implied and the planner falls back to a full
+  `SCAN task` — linear in **total** row count. Every `--update`/`--restart` de-dup
+  (`fingerprints_for_sources`) and every seen-path submit's completeness check
+  (`_warn_if_incomplete` → `count_for_source`) therefore scans the whole table. This is exactly the
+  cost R17 forbids ("billions–trillions of rows … not materially slower than today"), and the
+  `fingerprints_for_sources` docstring (`:833-835`) falsely claims the scan is "bounded,
+  index-backed."
+- **Evidence:** 300k-row table, `EXPLAIN QUERY PLAN`:
+  `SELECT count(*) … WHERE source=?` → `SCAN task`; `SELECT DISTINCT fingerprint … WHERE source IN (?)`
+  → `SCAN task`; **the same query + `AND source NOT IN (reserved)`** → `SEARCH … USING COVERING INDEX
+  index_tasks_source`; a non-partial `(source,fingerprint)` index → `SEARCH … USING COVERING INDEX`.
+  (Verified on SQLite; the partial-index implication rule is identical on PostgreSQL/TimescaleDB,
+  R17's explicit target.)
+- **Touches:** R17. Lands in **`data/model.py`** (high-blast-radius core) → human gate.
+- **Fix direction (for `hs-build`):** either add `Task.source.not_in([DIRECT_SOURCE_ID,
+  STDIN_SOURCE_ID])` to both queries so the partial predicate is implied, or make
+  `index_tasks_source` a full (non-partial) index. Re-verify with `EXPLAIN QUERY PLAN` + the
+  reserved-id path.
+
+### [MEDIUM / CONFIRMED] R7 false-positive — a correctly de-duplicated `--update`/`--restart` is later reported "incomplete"
+- **Where:** `src/hypershell/submit.py:169` (`_new_source_id` records the **full** count), `:225`/`:231`
+  (dedup returns `skip`), `:180` (`_warn_if_incomplete`).
+- **Failure scenario:** `apply_source_gate` records `task_count = count` (the full file count) on the
+  new `--update`/`--restart` source, but the `Loader` stamps that new source id onto **only the novel
+  tasks** — skipped identities keep their prior source. So `count_for_source(new) < task_count` by
+  construction, and the next re-submission's `_warn_if_incomplete` emits a spurious "appears
+  incomplete" warning that misrepresents an intentional, correct dedup as a failed/partial ingest —
+  which could prompt a user to `--repeat` and double-submit.
+- **Evidence:** reproduced live — submit 3-line file; edit to 4 lines; `--update` (adds 1 novel,
+  records `task_count=4`); a second `--update` →
+  `WARNING [submit] Prior submission of …/tasks.in appears incomplete: 1 of 4 tasks present`.
+- **Secondary imprecision (same code, not separately reported):** retry rows inherit the parent's
+  `source`, so `count_for_source` also *over*-counts for retried sources — R7's "completeness"
+  arithmetic is inexact in both directions.
+- **Touches:** R7. Root cause in **`submit.py`** (not high-blast-radius core), but interacts with
+  `data/model.py` counting.
+- **Fix direction (for `hs-build`):** record the **stamped** (post-dedup) count on the new source, or
+  scope the completeness check to the lineage's expected-vs-landed rather than a single source row.
+
+*No other candidate survived refutation.* The `server.py` scheduler-race change, retry
+fingerprint/source propagation, all gate exit codes, the in_memory guard, and the JSON path were each
+reproduced as correct. No AGENTS.md invariant (§1 lifecycle predicates, §2 exit_status, §3 retry
+chain, §4 in_memory, §6 sentinel ordering) was found violated.
+
+## Human-gate triggers
+
+**TRIGGERED.** F1 (CONFIRMED) lands in **`data/model.py`**, a high-blast-radius core file. Per the
+review rubric, a human must sign off before any remediation (`hs-build`) or `hs-publish` proceeds —
+regardless of the auto-loop. F2's root cause is in `submit.py` (not core) but is part of the same
+remediation.
+
+## Optional completeness sub-pass (separate reviewer; may see TECH.md)
+
+Not run (plain `/hs-review` invocation). Available via `/hs-review completeness` if desired — but the
+requirement→evidence matrix above already shows all 18 R-IDs implemented, with R17 partial (F1) and
+R7 partial (F2).

--- a/spec/cli-cluster-restart-repeat-update/REVIEW.md
+++ b/spec/cli-cluster-restart-repeat-update/REVIEW.md
@@ -159,8 +159,16 @@ Full suite **354 passed** (was 352; net +2 regression guards). The mandatory cou
 (F1 touched `data/model.py`) is satisfied by the **maintainer's explicit sign-off** to publish, with
 the two judgment calls flagged and acknowledged: the F1 partial→full index **design change**, and the
 F2 refinement of R7's per-source wording to **lineage-scoped** (serves R7's intent under the dedup that
-R9/R12/R14 mandate; not a `GOAL` R-ID change). Scale validation (10M+ rows on Anvil/HPC, and the
-PostgreSQL/TimescaleDB query plans that SQLite-only plan checks can't cover) is being performed by the
-maintainer out-of-band.
+R9/R12/R14 mandate; not a `GOAL` R-ID change).
+
+**Scale validation — PASSED on Anvil (HPC), 2026-07-12:** every submission gate exercised end-to-end,
+plus DB performance at scale. On SQLite, `--update` against a **1M-task source** (one novel task
+appended) resolves in **~37s** — O(the same-path lineage): the unavoidable cost of loading that
+source's ~1M fingerprints and re-fingerprinting the file, *not* a function of total DB size. A
+**1k-task source resolves instantly with 1M unrelated rows already in the database**, confirming
+detection cost scales with the specific source lineage, not the whole table (R17 — the F1 full-index
+win; the pre-F1 partial index would have full-scanned even that case). The full covering index uses
+plain bound parameters on every engine, so the lineage-scoped behavior is engine-agnostic by
+construction (PostgreSQL/TimescaleDB).
 
 **Verdict: approved (human sign-off).**

--- a/spec/cli-cluster-restart-repeat-update/REVIEW.md
+++ b/spec/cli-cluster-restart-repeat-update/REVIEW.md
@@ -140,3 +140,27 @@ remediation.
 Not run (plain `/hs-review` invocation). Available via `/hs-review completeness` if desired — but the
 requirement→evidence matrix above already shows all 18 R-IDs implemented, with R17 partial (F1) and
 R7 partial (F2).
+
+## Review cycle 2 — remediation + human sign-off (2026-07-11)
+
+Both CONFIRMED cycle-1 findings were remediated on this branch (each its own commit):
+
+- **F1 (R17)** — `f876000`: `index_tasks_source` made **full covering, non-partial**. A partial
+  `WHERE source NOT IN (reserved)` predicate can't be honored for parameter-bound `source` lookups, so
+  `count_for_source`/`fingerprints_for_sources` were full-scanning; a full index is used with plain
+  bound params on every engine. Verified via `EXPLAIN QUERY PLAN` at 300k rows (`SCAN task` →
+  `SEARCH … USING COVERING INDEX`) + a structural and a query-plan regression test.
+- **F2 (R7)** — `698580a`: `_warn_if_incomplete` now measures completeness across the whole same-path
+  **lineage**, not a single source, so a de-duplicated `--update`/`--restart` is no longer misreported
+  as incomplete. Verified via CLI (false "1 of 4" gone; genuine "2 of 3" still warns) + an integration
+  regression test.
+
+Full suite **354 passed** (was 352; net +2 regression guards). The mandatory coupled-core human-gate
+(F1 touched `data/model.py`) is satisfied by the **maintainer's explicit sign-off** to publish, with
+the two judgment calls flagged and acknowledged: the F1 partial→full index **design change**, and the
+F2 refinement of R7's per-source wording to **lineage-scoped** (serves R7's intent under the dedup that
+R9/R12/R14 mandate; not a `GOAL` R-ID change). Scale validation (10M+ rows on Anvil/HPC, and the
+PostgreSQL/TimescaleDB query plans that SQLite-only plan checks can't cover) is being performed by the
+maintainer out-of-band.
+
+**Verdict: approved (human sign-off).**

--- a/spec/cli-cluster-restart-repeat-update/TECH.md
+++ b/spec/cli-cluster-restart-repeat-update/TECH.md
@@ -3,10 +3,10 @@ slug: cli-cluster-restart-repeat-update
 title: 'Safe re-submission: --restart / --repeat / --update source gating'
 kind: feature
 appetite: big
-status: blocked
+status: in_progress
 branch: feature/cli-cluster-restart-repeat-update
 base: develop
-current_phase: done
+current_phase: P3
 last_updated: '2026-07-11'
 phases:
 - id: P1
@@ -159,13 +159,23 @@ source/raw_args is supplied).
   `Source.reserved(const_id)` (lazy get-or-create by PK; `path` = sentinel), `Source.paths_for_ids(ids)`
   (presentation), `Task.count_for_source(id)`, `Task.fingerprints_for_sources(ids) -> set[str]`.
 - [x] Indices: `index_source_lookup(Source.path, Source.fingerprint)`;
-  `index_tasks_source(Task.source, Task.fingerprint)` — **partial excluding** `DIRECT_SOURCE_ID`/
-  `STDIN_SOURCE_ID` (`postgresql_where`/`sqlite_where`). **No BRIN** (lean on Timescale compression).
+  `index_tasks_source(Task.source, Task.fingerprint)` — **full covering, non-partial** (revised in F1
+  remediation: a partial predicate can't be honored for parameter-bound `source` lookups → silent full
+  scan). **No BRIN** (lean on Timescale compression).
 - [x] New `tests/test_source.py` (unit): fingerprint order-independent over tag order; stable across
   template change + differing uuid/attempt; differs on args/group/tag change; `part`/resource knobs
   excluded; fresh `initdb` yields the `source` table + indices (SQLAlchemy inspect).
 - **Verify:** `uv run pytest -v -m unit tests/test_source.py`.
 - **Touches:** `src/hypershell/data/core.py`, `src/hypershell/data/model.py`, `tests/test_source.py`.
+- **Remediation (review cycle 1 — F1, R17):** `index_tasks_source` was made **non-partial**. The
+  partial `WHERE source NOT IN (<direct>,<stdin>)` predicate is only honored when a query repeats it
+  with literals, but `count_for_source`/`fingerprints_for_sources` bind `source` as a parameter — which
+  neither SQLite nor PostgreSQL can prove satisfies a literal partial predicate, so the lookups
+  silently degraded to a full table `SCAN` (verified via `EXPLAIN QUERY PLAN` at 300k rows). A full
+  covering `(source, fingerprint)` index is used with plain bound parameters on every engine (the
+  reserved-source rows it also carries are a marginal cost — named-file sources dominate the target
+  workload). Added a structural test (index is full, not partial) + a query-plan regression test that
+  asserts the lookups reach the index, not a scan.
 
 ## Phase P2 — Submit-flow stamping seam
 **Satisfies:** R3, R4 · **Depends on:** P1

--- a/spec/cli-cluster-restart-repeat-update/TECH.md
+++ b/spec/cli-cluster-restart-repeat-update/TECH.md
@@ -6,7 +6,7 @@ appetite: big
 status: in_progress
 branch: feature/cli-cluster-restart-repeat-update
 base: develop
-current_phase: P3
+current_phase: P4
 last_updated: '2026-07-11'
 phases:
 - id: P1
@@ -37,7 +37,7 @@ phases:
   verify: uv run pytest -v -m integration -k source_stamp
 - id: P3
   name: hs submit gate matrix (R5-R10) + count-warn + logging + submit docs/completions
-  status: pending
+  status: done
   satisfies:
   - R5
   - R6
@@ -205,27 +205,30 @@ Reserved `<direct>`/`<stdin>` stamped (real rows) and exempt. No refuse/repeat/u
 **Satisfies:** R5, R6, R7, R8, R9, R10, R18 · **Depends on:** P2
 **Goal:** `hs submit` enforces the plain-file matrix and logs its reasoning.
 
-- [ ] Add `--repeat`/`--update` (`store_true`) to `SubmitApp`; add `check_arguments` rejecting
+- [x] Add `--repeat`/`--update` (`store_true`) to `SubmitApp`; add `check_arguments` rejecting
   `--update`+`--repeat` (R10). Register in usage/help interface strings.
-- [ ] Implement shared **`apply_source_gate(path, fingerprint, count, *, repeat, update, restart=False)`**
+- [x] Implement shared **`apply_source_gate(path, fingerprint, count, *, repeat, update, restart=False)`**
   in `submit.py`: returns `(source_id, skip_fingerprints)` and raises `ArgumentError` on refusal.
   Decisions: no-flag + match → refuse naming prior (R5); no-flag + path-seen-fp-differs → refuse suggest
   `--update` (R6); count-warn when `Task.count_for_source(prior) < prior.task_count` (R7); `--repeat` →
   new source, `skip=None` (R8); `--update` → new source,
   `skip=Task.fingerprints_for_sources(Source.lookup(path))` (R9). Create the `Source` row (expected count
   first). Emit R18 logs (found N + md5, prior source, present/new, refusal reason).
-- [ ] `SubmitApp.run` calls `apply_source_gate` for named files (DB path only), wraps source in
+- [x] `SubmitApp.run` calls `apply_source_gate` for named files (DB path only), wraps source in
   `GatedSource`. Exempt: `-q`, `--no-db`/in-memory sqlite, `<stdin>`, `<direct>`.
-- [ ] Docs + completions (submit): `docs/_include/submit_{help,usage,desc}.rst`;
+- [x] Docs + completions (submit): `docs/_include/submit_{help,usage,desc}.rst`;
   `share/bash_completion.d/hs` (`_hs_submit`), `share/zsh/site-functions/_hs` (`_hs_submit`) —
   add `--repeat`/`--update` (+ zsh mutual-exclusion pair). Keep interface strings + snippets in lockstep.
-- [ ] Integration tests (`test_submit.py`): R5 refuse, R6 suggest-update, R7 count-warn (mechanism:
+- [x] Integration tests (`test_submit.py`): R5 refuse, R6 suggest-update, R7 count-warn (mechanism:
   cancel/delete a subset then re-detect), R8 doubles, R9 novel-only, R10 non-zero; `assert_output` on
   the R18 logs; R3 exempt (`hs submit 'echo x'` twice both succeed; `seq 4 | hs submit -f -` twice both
   succeed).
 - **Verify:** `uv run pytest -v tests/test_submit.py -k gate`.
 - **Touches:** `src/hypershell/submit.py`, `docs/_include/submit_*.rst`,
-  `share/bash_completion.d/hs`, `share/zsh/site-functions/_hs`, `tests/test_submit.py`.
+  `share/bash_completion.d/hs`, `share/zsh/site-functions/_hs`, `tests/test_submit.py`,
+  `tests/test_groups.py` (R6 now refuses re-submitting changed content at a seen path — two batches
+  given distinct source filenames). **Build note:** `apply_source_gate` implements the full shared
+  matrix now, including the `restart` branches (R12/R14) that P4 wires into `ClusterApp`.
 
 ## Phase P4 — `hsx` gate matrix + file-aware restart
 **Satisfies:** R11, R12, R13, R14, R15, R16 · **Depends on:** P3

--- a/spec/cli-cluster-restart-repeat-update/TECH.md
+++ b/spec/cli-cluster-restart-repeat-update/TECH.md
@@ -98,8 +98,8 @@ phases:
   hill: uphill
   verify: uv run pytest -v && uv run sphinx-build docs docs/_build
 review:
-  last_reviewed_commit: 93476f1
-  verdict: none
+  last_reviewed_commit: 698580a
+  verdict: approved
   blocked_reason: ''
 ---
 # TECH.md — Safe re-submission: `--restart` / `--repeat` / `--update` source gating

--- a/spec/cli-cluster-restart-repeat-update/TECH.md
+++ b/spec/cli-cluster-restart-repeat-update/TECH.md
@@ -3,10 +3,10 @@ slug: cli-cluster-restart-repeat-update
 title: 'Safe re-submission: --restart / --repeat / --update source gating'
 kind: feature
 appetite: big
-status: in_progress
+status: in_review
 branch: feature/cli-cluster-restart-repeat-update
 base: develop
-current_phase: P6
+current_phase: done
 last_updated: '2026-07-11'
 phases:
 - id: P1
@@ -87,7 +87,7 @@ phases:
 - id: P6
   name: Presentation (source display) + man pages + full sphinx build + full pytest
     sweep
-  status: pending
+  status: done
   satisfies:
   - R18
   depends_on:
@@ -303,25 +303,40 @@ Reserved `<direct>`/`<stdin>` stamped (real rows) and exempt. No refuse/repeat/u
 **Satisfies:** R18 · **Depends on:** P4, P5
 **Goal:** resolve `source` for humans, finish the same-commit surface, prove the whole feature green.
 
-- [ ] Presentation: `format_source(path, *, relative=False)` in `core/pretty_print.py` (sentinels
-  `^<.*>$` pass through; real paths absolute; `@node` json specs opaque — never relativize); add a
-  resolved `source:` line to `NORMAL_MODE_TEMPLATE` (`task.py:1285`); resolve in module `print_normal`
-  (`task.py:1352`, single `Source.from_id`) and `TaskSearchApp.print_normal` (`task.py:777`, one batched
-  `Source.paths_for_ids` per page via a new optional `source_map` arg — avoid N+1). **Keep `fingerprint`
-  out** of the normal template (reachable via `-x`/json/csv). Machine formats keep the raw UUID.
-- [ ] Update man pages `share/man/man1/hs.1`, `share/man/man1/hsx.1` for `--repeat`/`--update` and the
-  revised `--restart`, **and add the pre-existing-missing `--from-json`** (same gap the ridealong `[fix]`
-  closed for completions — man pages carry no `--from-json` entry either). (CI list `tests.yml:95-112` +
-  `pyproject.toml` mapping unchanged — no new files.)
-- [ ] `uv run sphinx-build docs docs/_build` — confirm **no new** warnings vs. the pre-existing
-  `task_submit.rst`/`manual.rst` toctree warnings.
-- [ ] `bash -n share/bash_completion.d/hs`; `zsh -n share/zsh/site-functions/_hs` (both already carry
-  `--from-json` after the ridealong `[fix]` — re-confirm nothing regressed).
-- [ ] Full `uv run pytest -v` green; add any missing edge cases surfaced during the sweep (e.g. R7
-  determinism, `--update` on unseen path == submit-all).
-- **Verify:** `uv run pytest -v && uv run sphinx-build docs docs/_build`.
+- [x] Presentation: `format_source(path, *, relative=False)` in `core/pretty_print.py` (sentinels
+  `^<.*>$` pass through; real paths absolute; `@node` json specs opaque — never relativize); added a
+  resolved `source:` line to `NORMAL_MODE_TEMPLATE` (after `group`); resolve via a new module helper
+  `resolve_source(source, source_map=None)` used by module `print_normal` (single `Source.from_id`,
+  degrades to raw id on `NotFound`) and `TaskSearchApp.print_normal` (one batched `Source.paths_for_ids`
+  per page via the `source_map` arg — avoids N+1). **`fingerprint` kept out** of the normal template
+  (reachable via `-x`/json/csv). Machine formats keep the raw UUID. CLI-verified: named file → abspath,
+  `<direct>`/`<stdin>` sentinels pass through, `-x source`/explicit-field stay raw.
+- [x] Regenerated man pages from source via the Sphinx **man builder** (`sphinx-build -b man`, from
+  `docs/manual.rst` → the P3–P5-updated `_include` snippets) rather than hand-editing roff — the
+  committed pages were stale (zero mentions of `--repeat`/`--update`/`--from-json`). All three shipped +
+  CI-asserted pages regenerated (`hs.1`, `hyper-shell.1`; `hsx.1` kept a byte-copy of `hs.1` per the
+  existing convention — no `hsx` entry in `conf.py`). New flags + revised `--restart` narrative + the
+  pre-existing-missing `--from-json` now present. CI list + `pyproject.toml` mapping unchanged (no new
+  files); mandoc lint clean (only pre-existing >80-byte STYLE notes).
+- [x] `uv run sphinx-build docs docs/_build` — build succeeded; **only** the pre-existing
+  `task_submit.rst`/`manual.rst` toctree warnings (no new warnings).
+- [x] `bash -n share/bash_completion.d/hs`; `zsh -n share/zsh/site-functions/_hs` — both clean;
+  `--from-json`/`--repeat`/`--update` still present (ridealong + P3/P4), nothing regressed.
+- [x] Full `uv run pytest -v` green; added edge cases: `format_source` unit test + two presentation
+  integration tests (normal-view resolves single+batched, machine formats stay raw, `<direct>` sentinel)
+  in `test_source.py`, and `--update` on an unseen path == submit-all (R9 edge) in `test_submit.py`.
+- **Verify:** `uv run pytest -v && uv run sphinx-build docs docs/_build` — 351 passed; docs build clean
+  (2 pre-existing warnings only).
 - **Touches:** `src/hypershell/core/pretty_print.py`, `src/hypershell/task.py`,
-  `share/man/man1/hs.1`, `share/man/man1/hsx.1`, `docs/_include/*.rst`, `tests/`.
+  `share/man/man1/hs.1`, `share/man/man1/hsx.1`, `share/man/man1/hyper-shell.1`,
+  `tests/test_source.py`, `tests/test_submit.py`.
+- **Build note (amendment):** man pages are **generated artifacts** (Sphinx man builder, mapped in
+  `docs/conf.py:126`), not hand-maintained roff — the correct P6 action was to regenerate from the RST
+  source that P3–P5 already updated. Extended the checklist's `hs.1`/`hsx.1` to also cover the equally-
+  stale, equally-shipped `hyper-shell.1` (leaving it would ship an inconsistent legacy man page).
+  Research 08's "update `_include` normal-output examples" had **no applicable target**: no `_include`
+  snippet renders an `hs info` normal block (only dated blog release posts do, which are historical
+  records and must not be retro-edited).
 
 ---
 

--- a/spec/cli-cluster-restart-repeat-update/TECH.md
+++ b/spec/cli-cluster-restart-repeat-update/TECH.md
@@ -6,7 +6,7 @@ appetite: big
 status: in_progress
 branch: feature/cli-cluster-restart-repeat-update
 base: develop
-current_phase: P5
+current_phase: P6
 last_updated: '2026-07-11'
 phases:
 - id: P1
@@ -71,7 +71,7 @@ phases:
 - id: P5
   name: Gate --from-json in both apps (human decision) + remove --from-json/--restart
     incompat
-  status: pending
+  status: done
   satisfies:
   - R4
   - R5
@@ -273,18 +273,22 @@ Reserved `<direct>`/`<stdin>` stamped (real rows) and exempt. No refuse/repeat/u
 **Satisfies:** R4, R5, R8, R9 (as applied to `--from-json`) · **Depends on:** P3, P4
 **Goal:** extend the source gate to `--from-json` in both apps and remove its `--restart` incompatibility.
 
-- [ ] `--from-json` source key: `path = abspath(FILE)[+ '@' + node]`, `fingerprint = md5(FILE bytes)`,
-  `count = len(records)`. Capture md5 in/around `load_json_tasks` (records already in memory → no 2nd
-  pass). `--from-json -` (stdin JSON) stays exempt (`<stdin>`-like).
-- [ ] Feed the JSON source through `apply_source_gate` in both `SubmitApp` and `ClusterApp`; wrap the
-  records list in a `GatedSource` (dedup filters records by fingerprint — JSON fingerprint uses `base`
-  args, `parse_inline=False`, per research/01).
-- [ ] Remove the `--from-json`+`--restart` refusal (`cluster/__init__.py:341`); allow
-  `hsx --from-json … --restart` / `--update --restart` under the same matrix.
-- [ ] Docs: note `--from-json` participates in gating (submit + cluster desc snippets).
-- [ ] Integration tests: `hs submit --from-json spec.json` twice → refuse; edited spec + `--update` →
-  novel-only; `hsx --from-json spec.json --restart` idempotent.
-- **Verify:** `uv run pytest -v -k from_json_gate`.
+- [x] `--from-json` source key: `path = abspath(FILE)[+ '@' + node]` (new `json_source_key`),
+  `fingerprint = md5(FILE bytes)`, `count = len(records)`. **Amended (build):** md5 captured in a new
+  `load_json_source(spec) -> (records, md5)` (one byte read → md5 + `json.loads`, no 2nd pass);
+  `load_json_tasks` kept as a thin wrapper. `--from-json -` (stdin JSON) → `json_source_key`=None, exempt.
+- [x] Feed the JSON source through `apply_source_gate` in `SubmitApp.prepare_json_source` and
+  `ClusterApp.prepare_json_source`; wrap the records list in a `GatedSource` (dedup filters records by
+  fingerprint — JSON fingerprint uses `base` args, `parse_inline=False`, per research/01). Stdin JSON and
+  `--no-db`/non-persistent runs bypass the gate (reserved `<stdin>` source stamped where applicable).
+- [x] Remove the `--from-json`+`--restart` refusal (was `cluster/__init__.py:352-353`); `hsx --from-json …
+  --restart` / `--update --restart` / `--repeat` now flow through the same matrix (R11-R15).
+- [x] Docs: note `--from-json` participates in gating (`submit_desc.rst` + `cluster_desc.rst`).
+- [x] Integration tests (`tests/test_submit_json.py`): `hs submit --from-json` twice → refuse (R5);
+  `--repeat` → doubles (R8); edited spec + `--update` → novel-only (R9); `hsx --from-json … --restart`
+  idempotent (R12, also proves the removed incompat).
+- **Verify:** `uv run pytest -v -k from_json_gate` — 4 passed. JSON+restart+submit suites 73 passed;
+  cross-tool CLI drive confirmed (same md5 via `hs submit` and `hsx`; restart deduped to 0 new).
 - **Touches:** `src/hypershell/submit.py`, `src/hypershell/cluster/__init__.py`,
   `docs/_include/*_desc.rst`, `tests/`.
 

--- a/spec/cli-cluster-restart-repeat-update/TECH.md
+++ b/spec/cli-cluster-restart-repeat-update/TECH.md
@@ -6,7 +6,7 @@ appetite: big
 status: in_progress
 branch: feature/cli-cluster-restart-repeat-update
 base: develop
-current_phase: P2
+current_phase: P3
 last_updated: '2026-07-11'
 phases:
 - id: P1
@@ -25,7 +25,7 @@ phases:
 - id: P2
   name: Submit-flow stamping seam (GatedSource, Loader stamp+dedup mechanism, upfront
     read/count)
-  status: pending
+  status: done
   satisfies:
   - R3
   - R4
@@ -172,25 +172,31 @@ source/raw_args is supplied).
 `fingerprint`, via a seam that also supports de-dup — without threading kwargs through the cluster core.
 Reserved `<direct>`/`<stdin>` stamped (real rows) and exempt. No refuse/repeat/update decisions yet.
 
-- [ ] Add **`GatedSource(iterable, source_id, skip_fingerprints=None, name=None)`** in `submit.py`
+- [x] Add **`GatedSource(iterable, source_id, skip_fingerprints=None, name=None)`** in `submit.py`
   (`__iter__` delegates; exposes `.source_id`/`.skip_fingerprints`/`.name`).
-- [ ] `Loader.__init__` unwraps `GatedSource` (store `source_id`/`skip`, then `iter(inner)`). In
+- [x] `Loader.__init__` unwraps `GatedSource` (store `source_id`/`skip`, then `iter(inner)`). In
   `load_line_task`/`load_json_task` pass `raw_args`; set `task.source = self.source_id`; after build, if
   `self.skip and task.fingerprint in self.skip` → skip (`GET`, no `put_task`, no `count++`), logging the
-  running present/new tally. `SubmitThread`/`LiveSubmitThread.source_name` surface `GatedSource.name`.
-- [ ] `source_fingerprint_and_count(path, template) -> (md5_hex, count)`: one streaming pass —
-  `hashlib.md5` over raw bytes + count via a **shared task-or-not predicate**
-  (`bool(split_argline(template.expand(line.strip()))[0])`) reused by the `Loader`.
-- [ ] `SubmitApp.check_source`: capture `os.path.abspath(filepath)` for named files. For stdin /
+  running present/new tally (`Loader.skip_task`; tally logged in `finalize` when de-dup is active).
+  `SubmitThread`/`LiveSubmitThread.source_name` surface `GatedSource.name`.
+- [x] `source_fingerprint_and_count(path, template) -> (md5_hex, count)`. **Amended (review):** *two*
+  streaming reads, not one — `hashlib.md5` over raw bytes **plus** a separate **text-mode** count read so
+  the count uses the Loader's own universal-newline decoding (a single binary pass split only on `\n` and
+  mis-counted CR-only / mixed-newline files → wrong `task_count`). Count uses the shared `line_is_task`
+  predicate. Non-seekable named inputs (process substitution / FIFO / piped `/dev/stdin`) are **not**
+  routed here (a re-read would drain them) — `prepare_source` streams them as `<stdin>` instead.
+- [x] `SubmitApp.check_source`: capture `os.path.abspath(filepath)` for named files. For stdin /
   single-command, resolve the reserved source id via `Source.reserved(STDIN_SOURCE_ID)` /
   `Source.reserved(DIRECT_SOURCE_ID)` (get-or-create). `submit_one` stamps
-  `source=Source.reserved(DIRECT_SOURCE_ID)`.
-- [ ] Minimal wiring so a plain `hs submit -f FILE` (no new flags) creates a `Source` row (expected
+  `source=Source.reserved(DIRECT_SOURCE_ID)`. **Amended (review):** the seekable/non-seekable split lives
+  in the new `prepare_source` (non-seekable named input → reserved `<stdin>`, exempt & streamed).
+- [x] Minimal wiring so a plain `hs submit -f FILE` (no new flags) creates a `Source` row (expected
   count written **before** tasks; guarded by DB-mode) and hands a `GatedSource(source_id=<uuid>)` to
   `submit_from`. `<stdin>` → `GatedSource(source_id=Source.reserved(STDIN_SOURCE_ID))`.
-- [ ] Integration test (`test_submit.py` or `test_source.py`): after `hs submit -f f.in`, tasks carry
+- [x] Integration test (`test_submit.py` or `test_source.py`): after `hs submit -f f.in`, tasks carry
   a non-null `source`/`fingerprint`; a `source` row exists with `task_count` == parsed task count;
-  blank/comment/inline-tag-only lines excluded from the count.
+  blank/comment/inline-tag-only lines excluded from the count. Plus two review-driven regression tests:
+  non-seekable input streams all tasks (not drained); CR-only newline count matches submitted tasks.
 - **Verify:** `uv run pytest -v -m integration -k source_stamp`.
 - **Touches:** `src/hypershell/submit.py`, `src/hypershell/data/model.py` (helpers if needed),
   `tests/test_submit.py`.

--- a/spec/cli-cluster-restart-repeat-update/TECH.md
+++ b/spec/cli-cluster-restart-repeat-update/TECH.md
@@ -3,7 +3,7 @@ slug: cli-cluster-restart-repeat-update
 title: 'Safe re-submission: --restart / --repeat / --update source gating'
 kind: feature
 appetite: big
-status: in_review
+status: blocked
 branch: feature/cli-cluster-restart-repeat-update
 base: develop
 current_phase: done
@@ -98,9 +98,10 @@ phases:
   hill: uphill
   verify: uv run pytest -v && uv run sphinx-build docs docs/_build
 review:
-  last_reviewed_commit: ''
-  verdict: none
-  blocked_reason: ''
+  last_reviewed_commit: 93476f1
+  verdict: changes-requested
+  blocked_reason: 'R17: count/dedup full-scan in data/model.py (partial-index predicate
+    mismatch); R7: false-positive incomplete warning after dedup in submit.py'
 ---
 # TECH.md — Safe re-submission: `--restart` / `--repeat` / `--update` source gating
 

--- a/spec/cli-cluster-restart-repeat-update/TECH.md
+++ b/spec/cli-cluster-restart-repeat-update/TECH.md
@@ -3,10 +3,10 @@ slug: cli-cluster-restart-repeat-update
 title: 'Safe re-submission: --restart / --repeat / --update source gating'
 kind: feature
 appetite: big
-status: in_progress
+status: in_review
 branch: feature/cli-cluster-restart-repeat-update
 base: develop
-current_phase: P3
+current_phase: done
 last_updated: '2026-07-11'
 phases:
 - id: P1
@@ -99,9 +99,8 @@ phases:
   verify: uv run pytest -v && uv run sphinx-build docs docs/_build
 review:
   last_reviewed_commit: 93476f1
-  verdict: changes-requested
-  blocked_reason: 'R17: count/dedup full-scan in data/model.py (partial-index predicate
-    mismatch); R7: false-positive incomplete warning after dedup in submit.py'
+  verdict: none
+  blocked_reason: ''
 ---
 # TECH.md — Safe re-submission: `--restart` / `--repeat` / `--update` source gating
 
@@ -240,6 +239,17 @@ Reserved `<direct>`/`<stdin>` stamped (real rows) and exempt. No refuse/repeat/u
   `tests/test_groups.py` (R6 now refuses re-submitting changed content at a seen path — two batches
   given distinct source filenames). **Build note:** `apply_source_gate` implements the full shared
   matrix now, including the `restart` branches (R12/R14) that P4 wires into `ClusterApp`.
+- **Remediation (review cycle 1 — F2, R7):** `_warn_if_incomplete` now measures completeness across
+  the whole same-path **lineage** (sum of `count_for_source` over `Source.lookup(path)`), not the
+  single checked source. De-dup (R9/R12/R14) deliberately stamps a file version's tasks across the
+  lineage — the novel ones onto the newest source, the rest already present under earlier sources — so
+  the recorded full-file `task_count` on a de-dup source always exceeded the tasks stamped on *it*,
+  producing a false "appears incomplete" warning on the next detection (reproduced: `--update` twice →
+  "1 of 4"). The lineage sum is complete for a de-duplicated re-submission (no false positive) yet
+  still catches a genuinely interrupted ingest (single-source lineage is unchanged). This keeps R7's
+  intent — warn on incomplete prior submission — correct under the dedup that R9/R12/R14 mandate;
+  it refines R7's per-source wording (a locked-plan detail, not a `GOAL` R-ID change). Added an
+  integration regression test; `count_for_source` stays index-backed per F1, lineages are small.
 
 ## Phase P4 — `hsx` gate matrix + file-aware restart
 **Satisfies:** R11, R12, R13, R14, R15, R16 · **Depends on:** P3

--- a/spec/cli-cluster-restart-repeat-update/TECH.md
+++ b/spec/cli-cluster-restart-repeat-update/TECH.md
@@ -1,0 +1,266 @@
+---
+slug: cli-cluster-restart-repeat-update
+title: "Safe re-submission: --restart / --repeat / --update source gating"
+kind: feature
+appetite: big
+status: in_progress
+branch: feature/cli-cluster-restart-repeat-update
+base: develop
+current_phase: P1
+last_updated: "2026-07-11"
+phases:
+  - id: P1
+    name: "Schema + fingerprint core (Source entity, Task.source/fingerprint, timescale groundwork, indices)"
+    status: pending
+    satisfies: [R1, R2, R17]
+    depends_on: []
+    parallel: false
+    hammerable: false
+    hill: uphill
+    verify: "uv run pytest -v -m unit tests/test_source.py"
+  - id: P2
+    name: "Submit-flow stamping seam (GatedSource, Loader stamp+dedup mechanism, upfront read/count)"
+    status: pending
+    satisfies: [R3, R4]
+    depends_on: [P1]
+    parallel: false
+    hammerable: false
+    hill: uphill
+    verify: "uv run pytest -v -m integration -k source_stamp"
+  - id: P3
+    name: "hs submit gate matrix (R5-R10) + count-warn + logging + submit docs/completions"
+    status: pending
+    satisfies: [R5, R6, R7, R8, R9, R10, R18]
+    depends_on: [P2]
+    parallel: false
+    hammerable: false
+    hill: uphill
+    verify: "uv run pytest -v tests/test_submit.py -k gate"
+  - id: P4
+    name: "hsx gate matrix + file-aware restart (R11-R16) + cluster docs/completions"
+    status: pending
+    satisfies: [R11, R12, R13, R14, R15, R16]
+    depends_on: [P3]
+    parallel: false
+    hammerable: false
+    hill: uphill
+    verify: "uv run pytest -v tests/test_restart.py"
+  - id: P5
+    name: "Gate --from-json in both apps (human decision) + remove --from-json/--restart incompat"
+    status: pending
+    satisfies: [R4, R5, R8, R9]
+    depends_on: [P3, P4]
+    parallel: false
+    hammerable: false
+    hill: uphill
+    verify: "uv run pytest -v -k from_json_gate"
+  - id: P6
+    name: "Presentation (source display) + man pages + full sphinx build + full pytest sweep"
+    status: pending
+    satisfies: [R18]
+    depends_on: [P4, P5]
+    parallel: false
+    hammerable: false
+    hill: uphill
+    verify: "uv run pytest -v && uv run sphinx-build docs docs/_build"
+review:
+  last_reviewed_commit: ""
+  verdict: none
+  blocked_reason: ""
+---
+
+# TECH.md — Safe re-submission: `--restart` / `--repeat` / `--update` source gating
+
+The **context engine and finite-state machine** for building this feature. Frontmatter above is the
+resume ground-truth (`uv run python .agents/factory/bin/next_phase.py
+spec/cli-cluster-restart-repeat-update/TECH.md`); the per-phase checklists are the work.
+
+- **Vision / requirements (locked):** [`GOAL.md`](GOAL.md) — R-IDs are the contract.
+- **Authoritative design:** [`PLAN.md`](PLAN.md).
+- **Backing research:** [`research/00-digest.md`](research/00-digest.md) + briefs `01`–`09`.
+
+## Conventions (apply to every phase)
+
+- Invariants + commit/style rules come from [`AGENTS.md`](../../AGENTS.md); footgun checklist in
+  [`.agents/factory/invariants.md`](../../.agents/factory/invariants.md).
+- One phase per `hs-build` invocation; one atomic commit with **both** code and the `TECH.md` state
+  change; branch subjects `WIP: P<n> — …` (squashed at `hs-publish`, where the same-commit docs rule
+  resolves). **No `Co-Authored-By` trailer.**
+- Guard every source write / gate with `queue_config is None and not in_memory` (invariant §4).
+- Refusals raise `cmdkit.cli.ArgumentError` → `exit_status.bad_argument` (2); never invent literals.
+- The task fingerprint column is **`Task.fingerprint`** (not `identity` — too close to `id`), matching
+  `Source.fingerprint`. All new tests tagged `@mark.unit` or `@mark.integration`.
+
+---
+
+## Phase P1 — Schema + fingerprint core + Timescale groundwork
+**Satisfies:** R1, R2, R17 · **Depends on:** —
+**Goal:** the DB substrate — a `Source` entity, `Task.source`/`Task.fingerprint` columns, indices, the
+fingerprint computation, and the `timescale` provider alias/gate — landing on a fresh `hs initdb`, with
+unit-tested fingerprint semantics. No submit behavior change yet (columns populate only when a
+source/raw_args is supplied).
+
+- [ ] **Timescale groundwork (`data/core.py`):** add `'timescale'`/`'timescaledb'` → `'postgresql+psycopg'`
+  to `providers` (`:173`); accept the aliases wherever `config.provider == 'postgres'` is special-cased
+  (`get_url` file-pop, `:227`). Add a **`uuid7`-extra gate** (mirror the turso gate `:207-212`): if
+  provider ∈ timescale aliases and `import uuid_utils` fails → `display_critical(...)` +
+  `sys.exit(exit_status.runtime_error)`. Emit a one-line groundwork warning that Timescale hypertable
+  management (post-`create_all` hook) is not yet implemented. **Do not touch `core/uuid.py`.**
+- [ ] Module constants `DIRECT_SOURCE_ID` / `STDIN_SOURCE_ID` (fixed well-known UUIDs) in `data/model.py`.
+- [ ] Add **`Source`** entity (mirror `Client`): `id` `UUID` pk (value from `uuid()`), `path` `TEXT`,
+  `fingerprint` `TEXT`, `task_count` `INTEGER`, `created` `DATETIME`; `columns` dict; inner
+  `NotFound/NotDistinct/AlreadyExists`; `from_id`; `new(path, fingerprint, task_count)` →
+  `id=uuid()`, `created=datetime.now().astimezone()`. No lineage-pointer column (lineage = same `path`).
+- [ ] Add `Task.source` (shared **`UUID`** type, nullable — native on postgres, holds a real
+  `Source.id`/reserved-const id) and `Task.fingerprint` (`TEXT`, nullable); append both to `Task.columns`
+  (`model.py:281`) for wire round-trip. (Accept raw UUID/md5 auto-appearing in `hs list --json/csv` /
+  `-x`; human-readable resolution is P6.)
+- [ ] `Task.compute_fingerprint(raw_command, group, tags) -> str` (md5 of canonical JSON of
+  `{'args','group','tags'}` with `sort_keys`, `part` dropped from tags). Add `raw_args`, `fingerprint`,
+  `source` kwargs to `Task.new`; derive `raw_command` (`split_argline(raw_args)[0]` for line,
+  `raw_args` for JSON, fallback `args`); compute+set `fingerprint` when not supplied; pass `source`.
+- [ ] Propagate on retry: `__schedule_next_failed_tasks` (`model.py:555`) passes
+  `fingerprint=task.fingerprint` **and** `source=task.source`.
+- [ ] Classmethods: `Source.lookup(path)`, `Source.matching(path, fingerprint)`,
+  `Source.reserved(const_id)` (lazy get-or-create by PK; `path` = sentinel), `Source.paths_for_ids(ids)`
+  (presentation), `Task.count_for_source(id)`, `Task.fingerprints_for_sources(ids) -> set[str]`.
+- [ ] Indices: `index_source_lookup(Source.path, Source.fingerprint)`;
+  `index_tasks_source(Task.source, Task.fingerprint)` — **partial excluding** `DIRECT_SOURCE_ID`/
+  `STDIN_SOURCE_ID` (`postgresql_where`/`sqlite_where`). **No BRIN** (lean on Timescale compression).
+- [ ] New `tests/test_source.py` (unit): fingerprint order-independent over tag order; stable across
+  template change + differing uuid/attempt; differs on args/group/tag change; `part`/resource knobs
+  excluded; fresh `initdb` yields the `source` table + indices (SQLAlchemy inspect).
+- **Verify:** `uv run pytest -v -m unit tests/test_source.py`.
+- **Touches:** `src/hypershell/data/core.py`, `src/hypershell/data/model.py`, `tests/test_source.py`.
+
+## Phase P2 — Submit-flow stamping seam
+**Satisfies:** R3, R4 · **Depends on:** P1
+**Goal:** named-file submissions create a `Source` row and stamp every task with `source` +
+`fingerprint`, via a seam that also supports de-dup — without threading kwargs through the cluster core.
+Reserved `<direct>`/`<stdin>` stamped (real rows) and exempt. No refuse/repeat/update decisions yet.
+
+- [ ] Add **`GatedSource(iterable, source_id, skip_fingerprints=None, name=None)`** in `submit.py`
+  (`__iter__` delegates; exposes `.source_id`/`.skip_fingerprints`/`.name`).
+- [ ] `Loader.__init__` unwraps `GatedSource` (store `source_id`/`skip`, then `iter(inner)`). In
+  `load_line_task`/`load_json_task` pass `raw_args`; set `task.source = self.source_id`; after build, if
+  `self.skip and task.fingerprint in self.skip` → skip (`GET`, no `put_task`, no `count++`), logging the
+  running present/new tally. `SubmitThread`/`LiveSubmitThread.source_name` surface `GatedSource.name`.
+- [ ] `source_fingerprint_and_count(path, template) -> (md5_hex, count)`: one streaming pass —
+  `hashlib.md5` over raw bytes + count via a **shared task-or-not predicate**
+  (`bool(split_argline(template.expand(line.strip()))[0])`) reused by the `Loader`.
+- [ ] `SubmitApp.check_source`: capture `os.path.abspath(filepath)` for named files. For stdin /
+  single-command, resolve the reserved source id via `Source.reserved(STDIN_SOURCE_ID)` /
+  `Source.reserved(DIRECT_SOURCE_ID)` (get-or-create). `submit_one` stamps
+  `source=Source.reserved(DIRECT_SOURCE_ID)`.
+- [ ] Minimal wiring so a plain `hs submit -f FILE` (no new flags) creates a `Source` row (expected
+  count written **before** tasks; guarded by DB-mode) and hands a `GatedSource(source_id=<uuid>)` to
+  `submit_from`. `<stdin>` → `GatedSource(source_id=Source.reserved(STDIN_SOURCE_ID))`.
+- [ ] Integration test (`test_submit.py` or `test_source.py`): after `hs submit -f f.in`, tasks carry
+  a non-null `source`/`fingerprint`; a `source` row exists with `task_count` == parsed task count;
+  blank/comment/inline-tag-only lines excluded from the count.
+- **Verify:** `uv run pytest -v -m integration -k source_stamp`.
+- **Touches:** `src/hypershell/submit.py`, `src/hypershell/data/model.py` (helpers if needed),
+  `tests/test_submit.py`.
+
+## Phase P3 — `hs submit` gate matrix
+**Satisfies:** R5, R6, R7, R8, R9, R10, R18 · **Depends on:** P2
+**Goal:** `hs submit` enforces the plain-file matrix and logs its reasoning.
+
+- [ ] Add `--repeat`/`--update` (`store_true`) to `SubmitApp`; add `check_arguments` rejecting
+  `--update`+`--repeat` (R10). Register in usage/help interface strings.
+- [ ] Implement shared **`apply_source_gate(path, fingerprint, count, *, repeat, update, restart=False)`**
+  in `submit.py`: returns `(source_id, skip_fingerprints)` and raises `ArgumentError` on refusal.
+  Decisions: no-flag + match → refuse naming prior (R5); no-flag + path-seen-fp-differs → refuse suggest
+  `--update` (R6); count-warn when `Task.count_for_source(prior) < prior.task_count` (R7); `--repeat` →
+  new source, `skip=None` (R8); `--update` → new source,
+  `skip=Task.fingerprints_for_sources(Source.lookup(path))` (R9). Create the `Source` row (expected count
+  first). Emit R18 logs (found N + md5, prior source, present/new, refusal reason).
+- [ ] `SubmitApp.run` calls `apply_source_gate` for named files (DB path only), wraps source in
+  `GatedSource`. Exempt: `-q`, `--no-db`/in-memory sqlite, `<stdin>`, `<direct>`.
+- [ ] Docs + completions (submit): `docs/_include/submit_{help,usage,desc}.rst`;
+  `share/bash_completion.d/hs` (`_hs_submit`), `share/zsh/site-functions/_hs` (`_hs_submit`) —
+  add `--repeat`/`--update` (+ zsh mutual-exclusion pair). Keep interface strings + snippets in lockstep.
+- [ ] Integration tests (`test_submit.py`): R5 refuse, R6 suggest-update, R7 count-warn (mechanism:
+  cancel/delete a subset then re-detect), R8 doubles, R9 novel-only, R10 non-zero; `assert_output` on
+  the R18 logs; R3 exempt (`hs submit 'echo x'` twice both succeed; `seq 4 | hs submit -f -` twice both
+  succeed).
+- **Verify:** `uv run pytest -v tests/test_submit.py -k gate`.
+- **Touches:** `src/hypershell/submit.py`, `docs/_include/submit_*.rst`,
+  `share/bash_completion.d/hs`, `share/zsh/site-functions/_hs`, `tests/test_submit.py`.
+
+## Phase P4 — `hsx` gate matrix + file-aware restart
+**Satisfies:** R11, R12, R13, R14, R15, R16 · **Depends on:** P3
+**Goal:** `hsx`/`hs cluster` enforces the full matrix; `--restart` becomes file-aware and idempotent.
+
+- [ ] Add `--repeat`/`--update` to `ClusterApp`. `check_arguments`: `--update` without
+  (`--restart`|`--repeat`) → R13; `--update`+`--repeat` → R16; **`--restart`+`--repeat` → contradictory**
+  (human decision); `--update` with `--no-db` → refuse. Keep `--forever`+`--restart`,
+  `--no-db`+`--restart` refusals.
+- [ ] Make `ClusterApp.source`/`input_stream` (`cluster/__init__.py:422-441`) file-aware: bare
+  `--restart` (no filepath) → `source==[]` (legacy DB resume, unchanged); with a filepath under
+  restart/update/repeat → read+fingerprint and yield a `GatedSource` per `apply_source_gate` (restart
+  semantics: fp match → `skip=lineage fingerprints` (R12) relying on `revert_interrupted`; fp differs →
+  refuse suggest `--update`; `--update --restart` → new source + novel-only (R14); `--repeat` → new
+  source, all (R15)). No-flag hsx file reuses R5–R7 (R11).
+- [ ] Confirm new flags are **not** added to any client argv builder (`remote.py`, `ssh.py`).
+- [ ] Docs + completions (cluster): `docs/_include/cluster_{help,usage,desc}.rst`; `_hs_cluster` in
+  bash + zsh completions. Revise the `--restart` narrative (detection/dedup semantics).
+- [ ] New `tests/test_restart.py` (integration): R11 refuse; R12 idempotent restart (run twice; changed
+  fp → refuse); R13 ambiguous; R14 update+restart adds novel + runs; R15 repeat resubmits all;
+  `--restart --repeat` non-zero. Reuse `test_cluster.py` patterns (`hs list --count`).
+- **Verify:** `uv run pytest -v tests/test_restart.py`.
+- **Touches:** `src/hypershell/cluster/__init__.py`, `docs/_include/cluster_*.rst`,
+  `share/bash_completion.d/hs`, `share/zsh/site-functions/_hs`, `tests/test_restart.py`.
+
+## Phase P5 — Gate `--from-json` (human decision)
+**Satisfies:** R4, R5, R8, R9 (as applied to `--from-json`) · **Depends on:** P3, P4
+**Goal:** extend the source gate to `--from-json` in both apps and remove its `--restart` incompatibility.
+
+- [ ] `--from-json` source key: `path = abspath(FILE)[+ '@' + node]`, `fingerprint = md5(FILE bytes)`,
+  `count = len(records)`. Capture md5 in/around `load_json_tasks` (records already in memory → no 2nd
+  pass). `--from-json -` (stdin JSON) stays exempt (`<stdin>`-like).
+- [ ] Feed the JSON source through `apply_source_gate` in both `SubmitApp` and `ClusterApp`; wrap the
+  records list in a `GatedSource` (dedup filters records by fingerprint — JSON fingerprint uses `base`
+  args, `parse_inline=False`, per research/01).
+- [ ] Remove the `--from-json`+`--restart` refusal (`cluster/__init__.py:341`); allow
+  `hsx --from-json … --restart` / `--update --restart` under the same matrix.
+- [ ] Docs: note `--from-json` participates in gating (submit + cluster desc snippets).
+- [ ] Integration tests: `hs submit --from-json spec.json` twice → refuse; edited spec + `--update` →
+  novel-only; `hsx --from-json spec.json --restart` idempotent.
+- **Verify:** `uv run pytest -v -k from_json_gate`.
+- **Touches:** `src/hypershell/submit.py`, `src/hypershell/cluster/__init__.py`,
+  `docs/_include/*_desc.rst`, `tests/`.
+
+## Phase P6 — Presentation + man pages + full build + full sweep
+**Satisfies:** R18 · **Depends on:** P4, P5
+**Goal:** resolve `source` for humans, finish the same-commit surface, prove the whole feature green.
+
+- [ ] Presentation: `format_source(path, *, relative=False)` in `core/pretty_print.py` (sentinels
+  `^<.*>$` pass through; real paths absolute; `@node` json specs opaque — never relativize); add a
+  resolved `source:` line to `NORMAL_MODE_TEMPLATE` (`task.py:1285`); resolve in module `print_normal`
+  (`task.py:1352`, single `Source.from_id`) and `TaskSearchApp.print_normal` (`task.py:777`, one batched
+  `Source.paths_for_ids` per page via a new optional `source_map` arg — avoid N+1). **Keep `fingerprint`
+  out** of the normal template (reachable via `-x`/json/csv). Machine formats keep the raw UUID.
+- [ ] Update man pages `share/man/man1/hs.1`, `share/man/man1/hsx.1` for `--repeat`/`--update` and the
+  revised `--restart`. (CI list `tests.yml:95-112` + `pyproject.toml` mapping unchanged — no new files.)
+- [ ] `uv run sphinx-build docs docs/_build` — confirm **no new** warnings vs. the pre-existing
+  `task_submit.rst`/`manual.rst` toctree warnings.
+- [ ] `bash -n share/bash_completion.d/hs`; `zsh -n share/zsh/site-functions/_hs`.
+- [ ] Full `uv run pytest -v` green; add any missing edge cases surfaced during the sweep (e.g. R7
+  determinism, `--update` on unseen path == submit-all).
+- **Verify:** `uv run pytest -v && uv run sphinx-build docs docs/_build`.
+- **Touches:** `src/hypershell/core/pretty_print.py`, `src/hypershell/task.py`,
+  `share/man/man1/hs.1`, `share/man/man1/hsx.1`, `docs/_include/*.rst`, `tests/`.
+
+---
+
+## How `hs-build` drives this
+
+1. `next_phase.py` prints the next actionable phase (statuses authoritative; `current_phase`
+   reconciled).
+2. Pre-flight: clean tree, on `branch`, `base` reachable.
+3. Execute every `[ ]`; consult `PLAN.md` / `research/` for detail.
+4. Run the phase `verify:` — never advance on a checkbox alone.
+5. Amend this file if reality diverges (`set_phase.py`; note in commit body). STOP + escalate only on a
+   **`GOAL.md` contradiction**.
+6. Mark phase `done`, advance `current_phase`, `--touch`; one `WIP:` commit; stop and report.

--- a/spec/cli-cluster-restart-repeat-update/TECH.md
+++ b/spec/cli-cluster-restart-repeat-update/TECH.md
@@ -1,74 +1,107 @@
 ---
 slug: cli-cluster-restart-repeat-update
-title: "Safe re-submission: --restart / --repeat / --update source gating"
+title: 'Safe re-submission: --restart / --repeat / --update source gating'
 kind: feature
 appetite: big
 status: in_progress
 branch: feature/cli-cluster-restart-repeat-update
 base: develop
-current_phase: P1
-last_updated: "2026-07-11"
+current_phase: P2
+last_updated: '2026-07-11'
 phases:
-  - id: P1
-    name: "Schema + fingerprint core (Source entity, Task.source/fingerprint, timescale groundwork, indices)"
-    status: pending
-    satisfies: [R1, R2, R17]
-    depends_on: []
-    parallel: false
-    hammerable: false
-    hill: uphill
-    verify: "uv run pytest -v -m unit tests/test_source.py"
-  - id: P2
-    name: "Submit-flow stamping seam (GatedSource, Loader stamp+dedup mechanism, upfront read/count)"
-    status: pending
-    satisfies: [R3, R4]
-    depends_on: [P1]
-    parallel: false
-    hammerable: false
-    hill: uphill
-    verify: "uv run pytest -v -m integration -k source_stamp"
-  - id: P3
-    name: "hs submit gate matrix (R5-R10) + count-warn + logging + submit docs/completions"
-    status: pending
-    satisfies: [R5, R6, R7, R8, R9, R10, R18]
-    depends_on: [P2]
-    parallel: false
-    hammerable: false
-    hill: uphill
-    verify: "uv run pytest -v tests/test_submit.py -k gate"
-  - id: P4
-    name: "hsx gate matrix + file-aware restart (R11-R16) + cluster docs/completions"
-    status: pending
-    satisfies: [R11, R12, R13, R14, R15, R16]
-    depends_on: [P3]
-    parallel: false
-    hammerable: false
-    hill: uphill
-    verify: "uv run pytest -v tests/test_restart.py"
-  - id: P5
-    name: "Gate --from-json in both apps (human decision) + remove --from-json/--restart incompat"
-    status: pending
-    satisfies: [R4, R5, R8, R9]
-    depends_on: [P3, P4]
-    parallel: false
-    hammerable: false
-    hill: uphill
-    verify: "uv run pytest -v -k from_json_gate"
-  - id: P6
-    name: "Presentation (source display) + man pages + full sphinx build + full pytest sweep"
-    status: pending
-    satisfies: [R18]
-    depends_on: [P4, P5]
-    parallel: false
-    hammerable: false
-    hill: uphill
-    verify: "uv run pytest -v && uv run sphinx-build docs docs/_build"
+- id: P1
+  name: Schema + fingerprint core (Source entity, Task.source/fingerprint, timescale
+    groundwork, indices)
+  status: done
+  satisfies:
+  - R1
+  - R2
+  - R17
+  depends_on: []
+  parallel: false
+  hammerable: false
+  hill: uphill
+  verify: uv run pytest -v -m unit tests/test_source.py
+- id: P2
+  name: Submit-flow stamping seam (GatedSource, Loader stamp+dedup mechanism, upfront
+    read/count)
+  status: pending
+  satisfies:
+  - R3
+  - R4
+  depends_on:
+  - P1
+  parallel: false
+  hammerable: false
+  hill: uphill
+  verify: uv run pytest -v -m integration -k source_stamp
+- id: P3
+  name: hs submit gate matrix (R5-R10) + count-warn + logging + submit docs/completions
+  status: pending
+  satisfies:
+  - R5
+  - R6
+  - R7
+  - R8
+  - R9
+  - R10
+  - R18
+  depends_on:
+  - P2
+  parallel: false
+  hammerable: false
+  hill: uphill
+  verify: uv run pytest -v tests/test_submit.py -k gate
+- id: P4
+  name: hsx gate matrix + file-aware restart (R11-R16) + cluster docs/completions
+  status: pending
+  satisfies:
+  - R11
+  - R12
+  - R13
+  - R14
+  - R15
+  - R16
+  depends_on:
+  - P3
+  parallel: false
+  hammerable: false
+  hill: uphill
+  verify: uv run pytest -v tests/test_restart.py
+- id: P5
+  name: Gate --from-json in both apps (human decision) + remove --from-json/--restart
+    incompat
+  status: pending
+  satisfies:
+  - R4
+  - R5
+  - R8
+  - R9
+  depends_on:
+  - P3
+  - P4
+  parallel: false
+  hammerable: false
+  hill: uphill
+  verify: uv run pytest -v -k from_json_gate
+- id: P6
+  name: Presentation (source display) + man pages + full sphinx build + full pytest
+    sweep
+  status: pending
+  satisfies:
+  - R18
+  depends_on:
+  - P4
+  - P5
+  parallel: false
+  hammerable: false
+  hill: uphill
+  verify: uv run pytest -v && uv run sphinx-build docs docs/_build
 review:
-  last_reviewed_commit: ""
+  last_reviewed_commit: ''
   verdict: none
-  blocked_reason: ""
+  blocked_reason: ''
 ---
-
 # TECH.md — Safe re-submission: `--restart` / `--repeat` / `--update` source gating
 
 The **context engine and finite-state machine** for building this feature. Frontmatter above is the
@@ -100,34 +133,34 @@ fingerprint computation, and the `timescale` provider alias/gate — landing on 
 unit-tested fingerprint semantics. No submit behavior change yet (columns populate only when a
 source/raw_args is supplied).
 
-- [ ] **Timescale groundwork (`data/core.py`):** add `'timescale'`/`'timescaledb'` → `'postgresql+psycopg'`
+- [x] **Timescale groundwork (`data/core.py`):** add `'timescale'`/`'timescaledb'` → `'postgresql+psycopg'`
   to `providers` (`:173`); accept the aliases wherever `config.provider == 'postgres'` is special-cased
   (`get_url` file-pop, `:227`). Add a **`uuid7`-extra gate** (mirror the turso gate `:207-212`): if
   provider ∈ timescale aliases and `import uuid_utils` fails → `display_critical(...)` +
   `sys.exit(exit_status.runtime_error)`. Emit a one-line groundwork warning that Timescale hypertable
   management (post-`create_all` hook) is not yet implemented. **Do not touch `core/uuid.py`.**
-- [ ] Module constants `DIRECT_SOURCE_ID` / `STDIN_SOURCE_ID` (fixed well-known UUIDs) in `data/model.py`.
-- [ ] Add **`Source`** entity (mirror `Client`): `id` `UUID` pk (value from `uuid()`), `path` `TEXT`,
+- [x] Module constants `DIRECT_SOURCE_ID` / `STDIN_SOURCE_ID` (fixed well-known UUIDs) in `data/model.py`.
+- [x] Add **`Source`** entity (mirror `Client`): `id` `UUID` pk (value from `uuid()`), `path` `TEXT`,
   `fingerprint` `TEXT`, `task_count` `INTEGER`, `created` `DATETIME`; `columns` dict; inner
   `NotFound/NotDistinct/AlreadyExists`; `from_id`; `new(path, fingerprint, task_count)` →
   `id=uuid()`, `created=datetime.now().astimezone()`. No lineage-pointer column (lineage = same `path`).
-- [ ] Add `Task.source` (shared **`UUID`** type, nullable — native on postgres, holds a real
+- [x] Add `Task.source` (shared **`UUID`** type, nullable — native on postgres, holds a real
   `Source.id`/reserved-const id) and `Task.fingerprint` (`TEXT`, nullable); append both to `Task.columns`
   (`model.py:281`) for wire round-trip. (Accept raw UUID/md5 auto-appearing in `hs list --json/csv` /
   `-x`; human-readable resolution is P6.)
-- [ ] `Task.compute_fingerprint(raw_command, group, tags) -> str` (md5 of canonical JSON of
+- [x] `Task.compute_fingerprint(raw_command, group, tags) -> str` (md5 of canonical JSON of
   `{'args','group','tags'}` with `sort_keys`, `part` dropped from tags). Add `raw_args`, `fingerprint`,
   `source` kwargs to `Task.new`; derive `raw_command` (`split_argline(raw_args)[0]` for line,
   `raw_args` for JSON, fallback `args`); compute+set `fingerprint` when not supplied; pass `source`.
-- [ ] Propagate on retry: `__schedule_next_failed_tasks` (`model.py:555`) passes
+- [x] Propagate on retry: `__schedule_next_failed_tasks` (`model.py:555`) passes
   `fingerprint=task.fingerprint` **and** `source=task.source`.
-- [ ] Classmethods: `Source.lookup(path)`, `Source.matching(path, fingerprint)`,
+- [x] Classmethods: `Source.lookup(path)`, `Source.matching(path, fingerprint)`,
   `Source.reserved(const_id)` (lazy get-or-create by PK; `path` = sentinel), `Source.paths_for_ids(ids)`
   (presentation), `Task.count_for_source(id)`, `Task.fingerprints_for_sources(ids) -> set[str]`.
-- [ ] Indices: `index_source_lookup(Source.path, Source.fingerprint)`;
+- [x] Indices: `index_source_lookup(Source.path, Source.fingerprint)`;
   `index_tasks_source(Task.source, Task.fingerprint)` — **partial excluding** `DIRECT_SOURCE_ID`/
   `STDIN_SOURCE_ID` (`postgresql_where`/`sqlite_where`). **No BRIN** (lean on Timescale compression).
-- [ ] New `tests/test_source.py` (unit): fingerprint order-independent over tag order; stable across
+- [x] New `tests/test_source.py` (unit): fingerprint order-independent over tag order; stable across
   template change + differing uuid/attempt; differs on args/group/tag change; `part`/resource knobs
   excluded; fresh `initdb` yields the `source` table + indices (SQLAlchemy inspect).
 - **Verify:** `uv run pytest -v -m unit tests/test_source.py`.

--- a/spec/cli-cluster-restart-repeat-update/TECH.md
+++ b/spec/cli-cluster-restart-repeat-update/TECH.md
@@ -6,7 +6,7 @@ appetite: big
 status: in_progress
 branch: feature/cli-cluster-restart-repeat-update
 base: develop
-current_phase: P4
+current_phase: P5
 last_updated: '2026-07-11'
 phases:
 - id: P1
@@ -54,7 +54,7 @@ phases:
   verify: uv run pytest -v tests/test_submit.py -k gate
 - id: P4
   name: hsx gate matrix + file-aware restart (R11-R16) + cluster docs/completions
-  status: pending
+  status: done
   satisfies:
   - R11
   - R12
@@ -234,25 +234,40 @@ Reserved `<direct>`/`<stdin>` stamped (real rows) and exempt. No refuse/repeat/u
 **Satisfies:** R11, R12, R13, R14, R15, R16 · **Depends on:** P3
 **Goal:** `hsx`/`hs cluster` enforces the full matrix; `--restart` becomes file-aware and idempotent.
 
-- [ ] Add `--repeat`/`--update` to `ClusterApp`. `check_arguments`: `--update` without
+- [x] Add `--repeat`/`--update` to `ClusterApp`. `check_arguments`: `--update` without
   (`--restart`|`--repeat`) → R13; `--update`+`--repeat` → R16; **`--restart`+`--repeat` → contradictory**
   (human decision); `--update` with `--no-db` → refuse. Keep `--forever`+`--restart`,
   `--no-db`+`--restart` refusals.
-- [ ] Make `ClusterApp.source`/`input_stream` (`cluster/__init__.py:422-441`) file-aware: bare
+- [x] Make `ClusterApp.source`/`input_stream` (`cluster/__init__.py:422-441`) file-aware: bare
   `--restart` (no filepath) → `source==[]` (legacy DB resume, unchanged); with a filepath under
   restart/update/repeat → read+fingerprint and yield a `GatedSource` per `apply_source_gate` (restart
   semantics: fp match → `skip=lineage fingerprints` (R12) relying on `revert_interrupted`; fp differs →
   refuse suggest `--update`; `--update --restart` → new source + novel-only (R14); `--repeat` → new
-  source, all (R15)). No-flag hsx file reuses R5–R7 (R11).
-- [ ] Confirm new flags are **not** added to any client argv builder (`remote.py`, `ssh.py`).
-- [ ] Docs + completions (cluster): `docs/_include/cluster_{help,usage,desc}.rst`; `_hs_cluster` in
+  source, all (R15)). No-flag hsx file reuses R5–R7 (R11). New `ClusterApp.prepare_source` mirrors
+  `SubmitApp.prepare_source`; the upfront count uses `DEFAULT_TEMPLATE` (the server ingests raw lines —
+  it expands the user `--template` client-side, so the count must mirror that split, not `--template`).
+- [x] **Amendment (build): fix a pre-existing scheduler start-race in `server.py`** (see build note).
+- [x] Confirm new flags are **not** added to any client argv builder (`remote.py`, `ssh.py`) — verified
+  clean (only the existing server-side `restart_mode` plumbing is present).
+- [x] Docs + completions (cluster): `docs/_include/cluster_{help,usage,desc}.rst`; `_hs_cluster` in
   bash + zsh completions. Revise the `--restart` narrative (detection/dedup semantics).
-- [ ] New `tests/test_restart.py` (integration): R11 refuse; R12 idempotent restart (run twice; changed
+- [x] New `tests/test_restart.py` (integration): R11 refuse; R12 idempotent restart (run twice; changed
   fp → refuse); R13 ambiguous; R14 update+restart adds novel + runs; R15 repeat resubmits all;
-  `--restart --repeat` non-zero. Reuse `test_cluster.py` patterns (`hs list --count`).
-- **Verify:** `uv run pytest -v tests/test_restart.py`.
-- **Touches:** `src/hypershell/cluster/__init__.py`, `docs/_include/cluster_*.rst`,
-  `share/bash_completion.d/hs`, `share/zsh/site-functions/_hs`, `tests/test_restart.py`.
+  `--restart --repeat` non-zero; + a scheduler-race regression (new file runs against an all-completed DB).
+- **Verify:** `uv run pytest -v tests/test_restart.py` — 9 passed. Full suite 343 passed; docs build clean.
+- **Touches:** `src/hypershell/cluster/__init__.py`, `src/hypershell/server.py`,
+  `docs/_include/cluster_*.rst`, `share/bash_completion.d/hs`, `share/zsh/site-functions/_hs`,
+  `tests/test_restart.py`.
+- **Build note (amendment):** wiring a file-aware `--restart`/`--repeat`/`--update` into the cluster
+  gives the `ServerThread` **both** a live submitter *and* `restart_mode` — a combination the prior code
+  never produced (bare `--restart` had `source==[]`, no submitter). This exposed a pre-existing race:
+  `Scheduler.start()`/`load_bundle()` finalize as soon as the DB shows `total>0, remaining==0`, which is
+  exactly how a database of prior **completed** tasks reads right up until the submitter commits its
+  first novel row — so the scheduler could stop before R12/R14/R15 (and even a plain new-file `hsx`)
+  ever ran their tasks (confirmed by CLI: 4 novel tasks submitted, 0 run). Fix: `Scheduler` now takes a
+  `submitter` reference and a `submission_complete()` guard (`submitter is None or not is_alive()`); both
+  early-exit points defer while ingestion is in flight. Bounded, additive, and covered by the new
+  regression test; no lifecycle-predicate or retry change (invariants §1/§3 intact).
 
 ## Phase P5 — Gate `--from-json` (human decision)
 **Satisfies:** R4, R5, R8, R9 (as applied to `--from-json`) · **Depends on:** P3, P4

--- a/spec/cli-cluster-restart-repeat-update/TECH.md
+++ b/spec/cli-cluster-restart-repeat-update/TECH.md
@@ -291,6 +291,13 @@ Reserved `<direct>`/`<stdin>` stamped (real rows) and exempt. No refuse/repeat/u
   cross-tool CLI drive confirmed (same md5 via `hs submit` and `hsx`; restart deduped to 0 new).
 - **Touches:** `src/hypershell/submit.py`, `src/hypershell/cluster/__init__.py`,
   `docs/_include/*_desc.rst`, `tests/`.
+- **Ridealong fix (post-P5, separate `[fix]` commit):** `--from-json` was **never** listed in the
+  shell completions — a pre-existing gap (the flag predates this feature; P3/P4 added `--repeat`/
+  `--update` but not the already-missing `--from-json`), surfaced while closing the P5 surface. Fixed
+  now, riding along with the feature: `--from-json` added to `_hs_submit` and `_hs_cluster` in both
+  `share/bash_completion.d/hs` and `share/zsh/site-functions/_hs` (offered in the option list, completes
+  a file path/SPEC, mutually exclusive with `-f`/positional FILE per the CLI). Verified `bash -n`/`zsh -n`
+  clean + functional bash-completion drive. **The man-page instance of the same gap is folded into P6.**
 
 ## Phase P6 — Presentation + man pages + full build + full sweep
 **Satisfies:** R18 · **Depends on:** P4, P5
@@ -303,10 +310,13 @@ Reserved `<direct>`/`<stdin>` stamped (real rows) and exempt. No refuse/repeat/u
   `Source.paths_for_ids` per page via a new optional `source_map` arg — avoid N+1). **Keep `fingerprint`
   out** of the normal template (reachable via `-x`/json/csv). Machine formats keep the raw UUID.
 - [ ] Update man pages `share/man/man1/hs.1`, `share/man/man1/hsx.1` for `--repeat`/`--update` and the
-  revised `--restart`. (CI list `tests.yml:95-112` + `pyproject.toml` mapping unchanged — no new files.)
+  revised `--restart`, **and add the pre-existing-missing `--from-json`** (same gap the ridealong `[fix]`
+  closed for completions — man pages carry no `--from-json` entry either). (CI list `tests.yml:95-112` +
+  `pyproject.toml` mapping unchanged — no new files.)
 - [ ] `uv run sphinx-build docs docs/_build` — confirm **no new** warnings vs. the pre-existing
   `task_submit.rst`/`manual.rst` toctree warnings.
-- [ ] `bash -n share/bash_completion.d/hs`; `zsh -n share/zsh/site-functions/_hs`.
+- [ ] `bash -n share/bash_completion.d/hs`; `zsh -n share/zsh/site-functions/_hs` (both already carry
+  `--from-json` after the ridealong `[fix]` — re-confirm nothing regressed).
 - [ ] Full `uv run pytest -v` green; add any missing edge cases surfaced during the sweep (e.g. R7
   determinism, `--update` on unseen path == submit-all).
 - **Verify:** `uv run pytest -v && uv run sphinx-build docs docs/_build`.

--- a/spec/cli-cluster-restart-repeat-update/research/00-digest.md
+++ b/spec/cli-cluster-restart-repeat-update/research/00-digest.md
@@ -1,0 +1,156 @@
+# Research digest — consolidated decisions
+
+Synthesis of briefs [01](01-identity-fingerprint.md)–[09](09-pruning-adversarial-check.md) plus the
+planner's first-hand read of `submit.py`, `server.py`, `data/model.py`, `data/core.py`, `cluster/*`,
+`core/uuid.py`. Each row below is a **single locked decision**; PLAN.md builds from these. Where a brief
+conflicts, this digest (and the maintainer decisions) win — briefs 01/02/03/07 carry supersession
+banners.
+
+## Human decisions (maintainer, across review rounds)
+
+- **`hsx --restart --repeat` → REJECT as contradictory** (exit non-zero, like R10/R16).
+- **Gate `--from-json` too.** The JSON spec is a source: `path = abspath(FILE)[+ '@' + node]`,
+  `fingerprint = md5(FILE bytes)`, `count = len(records)`. This **removes** the current
+  `--from-json`+`--restart` incompatibility (`cluster/__init__.py:341`). `--from-json -` exempt.
+- **Reserved sources are real `Source` rows** (fixed constant UUIDs), not TEXT sentinels: `Task.source`
+  stays a **native `UUID`**; presentation resolves the UUID → path/`<direct>`/`<stdin>`.
+- **No BRIN / no TSDB-specific code — "lean on Timescale compression."** The orderable UUIDv7 `source`
+  feeds the operator's compressed-chunk per-batch min/max; the model ships only the composite btree
+  (partial, excluding reserved consts).
+- **No forced `uuid7()`.** Keep `core/uuid.py` as-is (default `uuid4`; `uuid7` when the `uuid-utils`
+  extra is present). Add a **`timescale`/`timescaledb` provider alias** in `data/core.py` that maps to
+  the postgres backend and **gates the `uuid7` extra** (bail like missing `psycopg`); in that mode
+  `uuid()` yields v7 automatically. Groundwork for future Timescale gates (hypertable auto-create) —
+  a warning only in this feature.
+- **Column is named `Task.fingerprint`** (not `identity` — too close to `id`), matching
+  `Source.fingerprint`.
+
+## Task fingerprint (R2) — brief 01 (formula unchanged; renamed `identity` → `fingerprint`)
+
+- **Formula:** `fingerprint = md5(json.dumps({'args': raw_command, 'group': group, 'tags': tags_ex},
+  sort_keys=True, separators=(',',':'), ensure_ascii=False)).hexdigest()` → 32-hex TEXT. `sort_keys`
+  gives R2's order-independence; MD5 matches the R1 source fingerprint.
+- **`raw_command` = pre-template args, comment-stripped:** line task → `split_argline(raw_line)[0]`;
+  JSON record → `base = record.get('args','')` verbatim. Threaded to `Task.new` via a new `raw_args`
+  kwarg; falls back to stored `args` when absent (direct/retry — harmless, exempt).
+- **`tags_ex` = final tag dict minus `part`** (post-pop). Automatically excludes
+  `group`/`cores`/`memory`/`timeout` (popped to columns) and the rotation-mutated `part` tag; leaves
+  only true user tags. **All** tags participate (R2) → re-tagging ⇒ new fingerprint under `--update`.
+- **Computed in `Task.compute_fingerprint` classmethod, called from `Task.new`** (invariant §1).
+- **Retries copy the parent fingerprint + source:** `__schedule_next_failed_tasks` (`model.py:555`)
+  passes `fingerprint=task.fingerprint` and `source=task.source` (a chain shares one fingerprint).
+
+## Schema (R1, R3) — briefs 02/07/09 + maintainer
+
+- **New `Source` entity** (mirrors `Client`): `id` `UUID` (pk, from `uuid()`), `path` `TEXT`,
+  `fingerprint` `TEXT` (content md5), `task_count` `INTEGER`, `created` `DATETIME`. Own `columns` dict +
+  `NotFound/NotDistinct/AlreadyExists` + `from_id`/`new`. **No `previous_id`** — lineage = *all sources
+  sharing `path`*.
+- **`Task.source` is the shared native `UUID` type** (`model.py:75`), nullable (historical = NULL). Only
+  ever holds a real `Source.id` (or a reserved-const id) — native UUID is what carries the orderable
+  column stats Timescale compression prunes on. `Task.fingerprint` is `TEXT`, nullable.
+- **Reserved sources `<direct>`/`<stdin>` = REAL `Source` rows with fixed constant UUIDs** (module
+  constants `DIRECT_SOURCE_ID`/`STDIN_SOURCE_ID`), lazily get-or-created by PK; their `path` holds the
+  sentinel string. Fixed constants ⇒ idempotent by PK + statically excludable from the partial de-dup
+  index. Gating exemption is decided at the **App layer** by submission mode.
+- **Timescale groundwork, not a forced `uuid7()`** (`data/core.py`): add `timescale`/`timescaledb` →
+  `postgresql+psycopg` in the `providers` map; treat as postgres wherever `provider == 'postgres'` is
+  special-cased (`get_url` file-pop; `DATABASE_DIALECT` already routes non-sqlite → postgres). Gate the
+  `uuid7` extra in timescale mode (mirror the turso/psycopg gate: `display_critical` + `sys.exit`), so
+  the existing `uuid()` yields v7. Warn that hypertable auto-create is deferred. **`core/uuid.py`
+  untouched.**
+- **Wire plumbing:** add `'source'`/`'fingerprint'` to `Task.columns` (`model.py:281`) or they won't
+  round-trip through `serialize_tasks`/`deserialize_tasks` or `server.py:436` writeback. Give `Source`
+  its own `columns` dict. (They surface *raw* in machine formats — see Presentation.)
+- **No migration/backfill for free:** `Entity.metadata.create_all` (`data/__init__.py:65`) creates the
+  new table + columns on a **fresh** `initdb` and never ALTERs an existing `task` table. No Alembic.
+
+## Indices & scale (R17) — brief 03/09 + maintainer
+
+- `Index('index_source_lookup', Source.path, Source.fingerprint)` — btree, both dialects (R5/R6).
+- `Index('index_tasks_source', Task.source, Task.fingerprint)` — composite btree, **partial excluding
+  the two reserved constant source ids**. Serves R7 count-by-source (leading col) + exact de-dup seek +
+  sqlite.
+- **No BRIN in the object model (maintainer: "lean on Timescale compression").** A plain btree does
+  **not** prune by min/max, and `enable_chunk_skipping` can't index `uuid`; the pruning lever at scale is
+  TimescaleDB's implicit compressed-chunk per-batch min/max, made effective by the **orderable UUIDv7
+  `source`** (guaranteed in timescale mode via the `uuid7` gate). R17 is satisfied by the btree alone
+  regardless (cost scales with lineage matches + chunk count, **not** total rows).
+- **Bare `hs submit` stays fast:** detection is an indexed lookup on the tiny `Source` table (one row
+  per file ingest) + one per-source `COUNT` — never a scan of the trillion-row `task`. Added latency is
+  dominated by reading+md5'ing the file.
+- **De-dup = single small-`IN` query (strategy (a), locked):** lineage ids = `Source.lookup(path)` (a
+  *handful* of rows), then `Task.fingerprints_for_sources(lineage_ids)` = `SELECT fingerprint FROM task
+  WHERE source IN (:lineage)`. Small `IN` list (no batching / no `SQLITE_MAX_VARIABLE_NUMBER` issue); the
+  Loader computes each task's fingerprint anyway and skips membership hits — **no App-layer
+  recomputation** (avoids duplicating the stateful global-tag machine). **Brief-03's (c)/(d) and the
+  150 MB note are dropped.**
+
+## Submit-flow seam (R4, R7, R8, R9, R18) — brief 04 + planner plumbing analysis
+
+- **The `Loader` FSM is the single stamping chokepoint** for both `hs submit` and `hsx`
+  (`submit.py:164-198`). Source stamping + fingerprint + de-dup live there / in `Task.new`.
+- **`GatedSource` wrapper (minimizes coupled-core churn):** the App wraps its source iterable in a small
+  object carrying `source_id` + optional `skip_fingerprints`. It flows through
+  `submit_from`→`SubmitThread`→`ServerThread`→cluster launchers **unchanged**; only `Loader.__init__`
+  unwraps it and `SubmitThread/LiveSubmitThread.source_name` surface its label. Avoids threading kwargs
+  through ~10 constructors (invariant §11). Bare-restart source stays a plain `[]`.
+- **Count semantics:** a line is a task iff `bool(split_argline(template.expand(line.strip()))[0])` —
+  **stateless per line**, so the upfront count pass needs **no** tag-state duplication. Factor this
+  predicate into one helper shared by the count pass and the Loader. Skips: blank, comment-only,
+  inline-tag-only lines.
+- **Two streaming passes over a named file** (seekable): pass 1 = md5 + count; gate + create Source;
+  pass 2 = existing Loader submits. `<stdin>` isn't seekable ⇒ exempt. `--from-json` records are already
+  a list in memory ⇒ md5 the FILE, `count=len`.
+- **Writeback order: create the `Source` row with the *expected* count BEFORE the tasks.** Makes R7
+  meaningful — a crash mid-bundle leaves `live COUNT(source) < recorded`, which a later run detects and
+  `--restart` resumes. R7 = `Source.task_count` vs `Task.count_for_source(id)` at detection time.
+- Guard all source writes with `queue_config is None and not in_memory` (invariant §4).
+
+## CLI gate matrix (R5–R16) — brief 05 (authoritative table there)
+
+- **Exit code:** every loud refusal raises `cmdkit.cli.ArgumentError` → `exit_status.bad_argument` (2).
+  Warnings (R7/R18) via `log.warning`, exit 0.
+- **`hs submit`:** add `--repeat`/`--update` (no `--restart`); `check_arguments` rejecting `--update
+  --repeat` (R10). DB path only; `-q`, `--no-db`, `<stdin>`, `<direct>` exempt.
+- **`hsx`/`hs cluster`:** add `--repeat`/`--update`; reject `--update` alone (R13), `--update --repeat`
+  (R16), **`--restart --repeat`** (human), `--update` with `--no-db`. `source`/`input_stream` become
+  file-aware; bare `--restart` (no file) keeps `source==[]`. Keep `--forever`/`--no-db` + `--restart`
+  refusals.
+- **New flags are NOT forwarded to launched clients** (invariant §11); `restart_mode` reaches
+  `ServerThread` only.
+- **`hs server` out of scope** (advanced/direct entry); its ingested tasks carry NULL source.
+
+## Presentation — resolve `Task.source` UUID → path/sentinel (brief 08)
+
+- Adding `source`/`fingerprint` to `Task.columns` makes them appear **raw** in machine formats (`hs info
+  -f json/yaml`, `-x`, `hs list --json/--csv` default all-fields, explicit-field) — **correct** there.
+  They do **not** appear in the fixed `NORMAL_MODE_TEMPLATE` (`task.py:1285`).
+- **Human resolution (normal view only):** `Source.paths_for_ids(ids) -> dict` (batch, tiny IN) +
+  `format_source(path, *, relative=False)` in `core/pretty_print.py` (sentinels `^<.*>$` pass through;
+  real paths absolute; `@node` json specs opaque). Add a resolved `source:` line to the normal template;
+  `hs list` resolves one `paths_for_ids` per page (avoid N+1), `hs info` a single `from_id`. **Keep
+  `fingerprint` out** of the normal view. Lands in **P6**; columns land in P1.
+
+## Docs / completions / tests (R18, §12) — brief 06
+
+- **Docs (`docs/_include/`):** `submit_{help,usage,desc}.rst`, `cluster_{help,usage,desc}.rst`. Build
+  check `uv run sphinx-build docs docs/_build` (no *new* warnings).
+- **Completions (`share/`):** bash `share/bash_completion.d/hs`; zsh `share/zsh/site-functions/_hs`; man
+  pages `hs.1`/`hsx.1`. **No new `share/` files** ⇒ CI list + `pyproject.toml` mapping unchanged.
+- **Tests:** new `tests/test_source.py` (unit: fingerprint order-independence/stability/exclusions;
+  source md5+count helper; `format_source`). Integration across `test_submit.py`, `test_cluster.py`, new
+  `test_restart.py`, `test_initdb.py` — one case per R5–R16 + R3 exempt + R7 warn + fresh-initdb, in
+  `temp_site` with `create_taskfile_echo` + `assert_output` on R18 logs.
+
+## Residual risks (carried to PLAN)
+
+- **Timescale pruning is a timescale-mode property, not correctness.** Compressed per-batch min/max on
+  the orderable UUIDv7 `source` (guaranteed by the `uuid7` gate in timescale mode; operator's compression
+  policy). Non-timescale deployments use `uuid4`/no hypertable → btree seek (R17 still met). Fixed-const
+  reserved ids cluster under `source`-ordered compression and are excluded from the partial index.
+- **Timescale groundwork only:** provider alias + `uuid7` gate + warning; hypertable auto-create deferred.
+- **De-dup memory** = one file-history's fingerprints (lineage). Fine for the requeue case; log the size.
+- **R7 test determinism:** how to fabricate an "incomplete prior submission" — settle in the R7 phase.
+- **`hs list --json/--csv` default columns grow** by two (additive) — confirm no downstream parser
+  assumes a fixed column count.

--- a/spec/cli-cluster-restart-repeat-update/research/01-identity-fingerprint.md
+++ b/spec/cli-cluster-restart-repeat-update/research/01-identity-fingerprint.md
@@ -1,0 +1,125 @@
+# Research 01 — Stable task IDENTITY fingerprint (GOAL R2)
+
+> **NAMING UPDATE (2026-07-11, maintainer):** the column is named **`Task.fingerprint`** (not
+> `identity` — too close to `id`), matching `Source.fingerprint`. Read "identity" below as the
+> **`Task.fingerprint`** value; the classmethod is `Task.compute_fingerprint`. Formula/seam unchanged.
+> See [`00-digest.md`](00-digest.md).
+
+Resolves the formula and the exact code seam for a per-task IDENTITY: a canonical,
+order-independent hash of **pre-template args + group + tags**, used by `--restart` /
+`--update` gating to detect which tasks already landed. All claims grounded in source.
+
+## Where template expansion happens vs. Task creation
+
+Expansion happens in the **Loader FSM**, one step *before* `Task.new`:
+
+- **Line tasks** — `Loader.load_line_task` (`submit.py:164-167`):
+  ```
+  args = self.template.expand(str(line).strip())          # 166  (expanded)
+  self.task = Task.new(args=args, ..., tag=self.tags)     # 167
+  ```
+  The raw pre-expansion line is `str(line).strip()` — **available at line 166**, but it is
+  *not* passed to `Task.new`. Note the raw line still contains any inline `# HYPERSHELL:`
+  comment; the comment is stripped later by `Task.split_argline` (`model.py:363-379`), which
+  currently runs *inside* `Task.new` on the **already-expanded** string.
+- **JSON records** — `Loader.load_json_task` (`submit.py:190-196`):
+  ```
+  base = str(record.get('args', ''))                     # 190  (pre-expansion command)
+  args = self.template.expand(base, context=record)      # 191  (expanded)
+  ...
+  Task.new(args=args, ..., tag=tags, strict_tag=False, parse_inline=False)  # 195
+  ```
+  Pre-template args for a JSON record = **`base`** (the raw `args` field). `parse_inline=False`,
+  so no inline-comment splitting for JSON.
+
+`Task.new` (`model.py:333-361`) stores the **already-expanded** string in `Task.args`
+(`model.py:359`). So R2's "args before template expansion" is **not** recoverable from the
+persisted row — the raw string must be threaded through the seam at submit time.
+
+## How tags/group/resources are assembled (`Task.new`, `model.py:349-361`)
+
+1. `split_argline(args)` → `(args, inline_tags)` when `parse_inline` (line 351); else verbatim.
+2. Final tag dict = `{**(tag or {}), **inline_tags, **{'part': 0}}` (line 354) — global tags +
+   inline tags + a **bookkeeping `part:0`** tag.
+3. `group/cores/memory/timeout` are **popped out of the tag dict** into columns
+   (`model.py:355-358`), so they do **not** remain in the stored `tag`.
+4. `part` is later **mutated** by `rotatedb` (`data/__init__.py:139`, `json_set($.part, N)`).
+
+Consequences for identity membership:
+- **Exclude `part`** — it is injected bookkeeping and is rewritten on rotation; including it
+  would make identity unstable across `hs initdb --rotate`.
+- **Exclude `cores`/`memory`/`timeout`/`group` from the tags portion** — they are popped from
+  the tag dict anyway; `group` is a *separate* identity input per R2. Resource knobs describe
+  *how* a task runs, not *what* it is; keep them out.
+- Net: if identity is computed from the **final** `tag` dict (post-pop) minus `part`, exclusion
+  is automatic — the only keys left are true user tags (global + inline + JSON record keys).
+
+## JSON-record stability
+
+For JSON, `record_tags` (`submit.py:192-193`) are the record keys (≠`args`), nested values
+JSON-serialized with `json.dumps(..., separators=(',',':'))`, merged over global tags
+(`submit.py:194`). Identity over `base` + `group` + these tags is stable because the named
+`{key}` context expansion (line 191) does **not** touch `base`. That is exactly the point:
+identity keys off pre-expansion `base`, so re-running the same JSON file yields identical
+identities regardless of template.
+
+## RECOMMENDATION
+
+**Formula.** For each task compute:
+```python
+payload = json.dumps(
+    {'args': raw_command, 'group': group, 'tags': identity_tags},
+    sort_keys=True, separators=(',', ':'), ensure_ascii=False,
+)
+identity = hashlib.md5(payload.encode()).hexdigest()   # text, 32 hex chars
+```
+where
+- `raw_command` = **pre-expansion** command with inline comment removed:
+  - line task: `Task.split_argline(raw_line)[0]` (run on the *raw* line);
+  - JSON: `base` verbatim (no inline parsing).
+- `group` = the resolved group int (`other['group']` after the pop).
+- `identity_tags` = `{k: v for k, v in final_tag.items() if k != 'part'}` (post-pop dict).
+
+`sort_keys=True` gives the order-independence R2 requires (both across tag insertion order and
+JSON key order). MD5 is fine here (non-security fingerprint) and is **consistent with the SOURCE
+content-md5** the GOAL already specifies. Store in a new nullable `Task.identity` TEXT column
+(`UUID`-style `TEXT`; add to `columns` dict + consider an index for gating lookups).
+
+**Where to compute — `Task.new`, not the Loader.** Invariant #1 ("task-state/identity logic
+belongs in `Task` classmethods", `invariants.md:33`) says the canonicalization+hash should be a
+`Task` classmethod (e.g. `Task.compute_identity(raw_command, group, tags)`), called from
+`Task.new` right after the tag/group assembly (`model.py:358`) and before the return.
+
+**Threading the raw line through.** Add an optional `raw_args: str = None` kwarg to `Task.new`.
+- `load_line_task`: `Task.new(args=args, raw_args=str(line).strip(), ...)`.
+- `load_json_task`: `Task.new(args=args, raw_args=base, ...)`.
+- Inside `Task.new`: `raw_command = Task.split_argline(raw_args)[0] if parse_inline else
+  str(raw_args).strip()`; fall back to the stored `args` when `raw_args is None` (direct/retry
+  paths — harmless since those are gating-exempt).
+
+**Retry chain.** `__schedule_next_failed_tasks` (`model.py:555`) calls `cls.new(args=task.args,
+...)` with the *stored expanded* args and no raw line. Retries are the *same* logical task, so
+**copy the parent's identity**: add `identity=` kwarg to `Task.new` and pass
+`identity=task.identity` here so the whole `previous_id`/`next_id` chain shares one identity
+(gating must count a retried task as "landed"). Do not recompute from expanded args there.
+
+**Reserved sources.** `<direct>` (`submit_one`, `submit.py:1101`) and `<stdin>` are exempt from
+gating (GOAL). Identity may still be populated uniformly (cheap) — exemption is enforced by the
+SOURCE record (separate brief), not by nulling identity.
+
+## Flag: tags-in-identity consequence (GOAL clarification)
+
+Because tags feed identity, **re-tagging an otherwise-identical command changes its identity**.
+Under `--update` the re-tagged task therefore reads as *novel* and is resubmitted; under
+`--restart` it will not match a prior landing. This is the intended semantics per the GOAL
+("`--update` submits only novel tasks after the file changes") but should be called out in
+PLAN/docs: changing `-t`/global tags or inline `# HYPERSHELL:` tags == a new task identity.
+
+## Open questions
+
+- Hash choice: MD5 (matches SOURCE md5, non-crypto) vs SHA-256. Recommend MD5 for consistency
+  unless the maintainer prefers SHA-256 collision margin.
+- Should global `-t` tags be part of identity at all, or only inline/record tags? R2 says "tags"
+  (all of them) — recommend all, but this is the sharpest UX edge (re-`-t` ⇒ novel).
+- `cores/memory/timeout`: confirmed excluded (popped before identity). Verify the maintainer
+  agrees these are not identity-bearing.

--- a/spec/cli-cluster-restart-repeat-update/research/02-source-schema.md
+++ b/spec/cli-cluster-restart-repeat-update/research/02-source-schema.md
@@ -1,0 +1,117 @@
+# Brief 02 — SOURCE entity + Task association schema (R1, R3)
+
+> **PARTIALLY SUPERSEDED (2026-07-11)** by maintainer corrections + [`07`](07-uuidv7-source-ids.md)
+> / [`09`](09-pruning-adversarial-check.md): `Task.source` is a **native `UUID`** (not TEXT); reserved
+> `<direct>`/`<stdin>` are **real `Source` rows with fixed constant UUIDs** (not string sentinels in
+> `Task.source`); `Source.id` is **UUIDv7**. See [`00-digest.md`](00-digest.md) for the current schema.
+
+Scope: model a `Source` entity and add `source`/`identity` columns to `Task`, following the
+existing conventions in `data/model.py`, and confirm `create_all` picks them up on a fresh
+`initdb` without altering an existing task table (aligns with the no-backfill non-goal). Grounded
+in the current source; every anchor is a real file:line.
+
+## Conventions to follow (verified)
+
+- **Entity base** `data/model.py:85`. Declarative; `__tablename__` = lowercased class name
+  (`:91`) → a `Source` class yields table `source`. `__table_args__` injects `{'schema': schema}`
+  (`:96`). (`source` is a non-reserved word in both SQLite and PostgreSQL; no quoting needed,
+  unlike `group` which is quoted at `:241`.)
+- **Pre-defined column types** `data/model.py:74-82`: `UUID` (`Text().with_variant(POSTGRES_UUID(as_uuid=False),'postgresql')`),
+  `TEXT`, `INTEGER`, `SMALL_INTEGER`, `FLOAT`, `DATETIME` (=`DateTime(timezone=True)`), `BOOLEAN`,
+  `JSON` (JSON_TEXT with JSONB postgres variant). Reuse these — do not hand-roll types.
+- **Plain-UUID columns, NOT ForeignKeys** — confirmed: `Task.server_id`/`client_id`/`previous_id`/`next_id`
+  are all `mapped_column(UUID, ...)` with no `ForeignKey` (`:254,:258,:276,:277`); `Client.server_id`
+  is the same (`:769`). Follow this: `source` is a bare uuid-bearing column, no relationship/FK.
+- **Second-entity example** `Client` (`:763-828`): id (UUID pk) + typed columns + a `columns`
+  dict (`:776`) + inner `NotFound/NotDistinct/AlreadyExists` + `from_id`/`new` classmethods +
+  a module-level `Index` (`:831`). Mirror this shape for `Source`.
+- **The `columns` dict is load-bearing wire plumbing** (`:281-312`). `Entity.to_tuple/to_dict/
+  to_json` iterate it (`:105-115`); `from_json`→`from_dict`→`cls(**data)` reconstructs from it
+  (`:118-125`). `serialize_tasks`/`deserialize_tasks` (`:218-226`) are just `to_json`/`from_json`
+  per task. **Any new Task column MUST be added to `Task.columns` or it will not cross the wire**
+  and won't round-trip on the remote queue. `Source` needs its own `columns` dict too.
+
+## `create_all` on fresh vs existing DB (verified)
+
+- `initdb()` = `Entity.metadata.create_all(engine)` (`data/__init__.py:65`); `checkdb` only tests
+  for the `task` table (`:84`). SQLite auto-inits on submit (`submit.py:1111-1112`).
+- SQLAlchemy `create_all` issues `CREATE TABLE IF NOT EXISTS` per table and **never ALTERs an
+  existing table**. So on a **fresh** init the new `source` table + new `task` columns are created;
+  on an **existing** DB, a new `source` table is created but the existing `task` table is left
+  untouched (old rows keep NULL `source`/`identity`). This matches the "require fresh `hs initdb`,
+  no migration/backfill" non-goal exactly — no code change needed to get that behavior.
+- Dialect variants are already handled by the pre-defined types (postgres UUID/JSONB vs sqlite
+  TEXT/JSON); reusing `UUID`/`DATETIME`/etc. inherits them for free.
+
+## Key decision: `Task.source` must be TEXT, not UUID
+
+Reserved sources `<direct>` / `<stdin>` are best represented as **sentinel strings** stored
+directly in `Task.source` with **no `Source` row** (mirrors the existing `<auto>`/`<none>`
+sentinel idiom and the `<stdin>`/`<direct>` naming already used at `submit.py:437-442` and
+`client.py`-level source naming). **But** the shared `UUID` type is `POSTGRES_UUID(as_uuid=False)`
+on postgres (`model.py:75`) — inserting `'<direct>'` into a postgres uuid column raises. Therefore
+`Task.source` should be typed **`TEXT`**, not `UUID`, so it can hold either a 32-hex uuid or a
+`<...>` sentinel. (The sqlite variant is TEXT either way, so this only bites on postgres — but it
+bites hard.) `Source.id` itself stays `UUID` (only ever real uuids).
+
+## Retry-propagation gotcha (flag for planner / topic 01)
+
+Retry rows are minted by `Task.new(args=…, attempt+1, previous_id=…, tag=…, group=…)` inside
+`__schedule_next_failed_tasks` (`model.py:555-560`) — it does **not** pass `source`. `Task.new`
+(`:333-361`) forwards `**other` to the `Task(...)` ctor (`:359`), so `source` will be `NULL` on
+retries unless explicitly propagated. `identity` (topic 01) is recomputed from args+group+tags and
+would come out identical, but **`source` must be copied from the parent row** in that retry path,
+or retried tasks lose their source association (breaking R3 for retries). Loader ingest
+(`submit.py:167,195`) is the other `Task.new` call site that must pass the fresh `source`.
+
+## RECOMMENDATION
+
+### `Source` entity (new, after `Task`, before/after `Client`)
+| column | type | null | notes |
+|--------|------|------|-------|
+| `id` | `UUID` | no (pk) | `uuid()` default via `new()` |
+| `path` | `TEXT` | no | absolute file path (R1) |
+| `fingerprint` | `TEXT` | no | content md5 hex (R1) |
+| `task_count` | `INTEGER` | no | ingested count (R1) |
+| `created` | `DATETIME` | no | creation timestamp (R1); set in `new()` like `Task.submit_time` |
+| `previous_id` | `UUID` | yes | lineage pointer to the prior same-path source superseded by `--update` (R14). Plain uuid, **not** FK, **not** unique (a path may be updated repeatedly). |
+
+Plus: `columns` dict (all six), inner `NotFound/NotDistinct/AlreadyExists`, `from_id` and a
+`new(...)` classmethod that fills `id=uuid()` and `created=datetime.now().astimezone()`.
+
+### `Task` new columns (append to model + `columns` dict at `:281`)
+| column | type | null | notes |
+|--------|------|------|-------|
+| `source` | **`TEXT`** | yes | holds a `Source.id` uuid **or** the sentinel strings `<direct>`/`<stdin>`; NULL only for pre-existing/historical rows. TEXT (not UUID) so postgres accepts sentinels. |
+| `identity` | `TEXT` | yes | stable identity fingerprint from topic 01 (hex digest); NULL for historical rows. |
+
+Add `'source': str` and `'identity': str` to `Task.columns` (drives wire round-trip + makes them
+appear in `hs list/search/update`/`info`, which read `Task.columns` — `task.py:434,548,944,1225`,
+additive/no breakage).
+
+### Reserved-source representation
+Sentinel STRINGS in `Task.source` (`<direct>`, `<stdin>`), **no `Source` row**. Gating logic
+(topics 04+) treats a `Task.source` matching `^<.*>$` (or an explicit set) as exempt (R3/R7).
+
+### Index list (hand to topic 03, R17)
+- `Index('index_source_path', Source.path)` — source lookup by path (+ consider composite
+  `(path, fingerprint)` for the R5/R12 same-path/same-fingerprint check).
+- `Index('index_tasks_identity', Task.identity)` — de-dup "identity already present" (R9/R12/R14).
+- Consider composite `Index('index_tasks_source_identity', Task.source, Task.identity)` if de-dup
+  is scoped per source/prior-source set; topic 03 to decide single vs composite against the exact
+  de-dup query shape.
+
+### Wire/plumbing checklist (must-update)
+- `Task.columns` (`model.py:281`) += `source`, `identity` — required for `serialize_tasks`/
+  `deserialize_tasks` round-trip (`:218-226`) and `server.py:436` `to_dict()` writeback.
+- `Source.columns` dict on the new entity.
+- Both `Task.new` call sites must pass `source`: loader ingest (`submit.py:167,195`) and the retry
+  minter (`model.py:555`, propagate parent's `source`).
+
+## Open questions
+1. Topic 01 owns the exact `identity` digest algorithm/length; this brief assumes a hex TEXT
+   column and does not fix the width.
+2. Should `Source.previous_id` be UNIQUE (task-style chain) or free (non-unique)? Recommend
+   non-unique unless the planner wants a strict single-successor lineage invariant.
+3. De-dup scope for the identity index: global-per-DB vs per-source — decides single vs composite
+   index (R17). Depends on topics 04/05 gating semantics (R9 "prior submission of the same file").

--- a/spec/cli-cluster-restart-repeat-update/research/03-scale-indexing.md
+++ b/spec/cli-cluster-restart-repeat-update/research/03-scale-indexing.md
@@ -1,0 +1,120 @@
+# 03 — Scale & indexing strategy (GOAL R17)
+
+> **PARTIALLY SUPERSEDED (2026-07-11)** by maintainer corrections + [`09`](09-pruning-adversarial-check.md):
+> `Task.source`/`Source.id` are **native `UUID`** (not TEXT); de-dup is a **single small-`IN` query**
+> (strategies (c) batched anti-join / (d) temp-table and the 150 MB note are dropped); the pruning
+> lever is **TimescaleDB compressed per-batch min/max** enabled by an orderable **UUIDv7** `source`
+> (no BRIN, no TSDB-specific code). See [`00-digest.md`](00-digest.md).
+
+**Question:** make source-detection, count-checks, and de-dup cheap even at billions–trillions of
+`task` rows, without making a bare `hs submit <file>` materially slower than today.
+
+## Existing index patterns (ground truth)
+
+Indices are plain module-level `Index(...)` objects declared after the model, no FKs anywhere in the
+schema:
+
+- `index_tasks_unscheduled = Index('index_tasks_unscheduled', Task.group, Task.schedule_time)` — `data/model.py:759`
+- `index_tasks_retries = Index('index_tasks_retries', Task.exit_status, Task.retried)` — `data/model.py:760`
+- `index_client_disconnect` — `data/model.py:831`
+
+They are created by `Entity.metadata.create_all(engine)` in `initdb()` (`data/__init__.py:63-68`) —
+a new `Source` model + new `Task` columns are picked up automatically on a fresh `hs initdb` (the
+GOAL's no-backfill non-goal). `previous_id`/`next_id` show the house style for "relationship without
+FK": a bare `mapped_column(UUID, unique=True, nullable=True)` (`data/model.py:276-277`).
+
+Dialect-variant types are pre-defined at `data/model.py:74-82`: `UUID` = `Text` on sqlite / native
+`POSTGRES_UUID` on pg; `JSON` = `JSON_TEXT` / `JSONB`. Providers at `data/core.py:173-178`
+(sqlite/turso/postgres). `schema` is configurable (`data/core.py:189`).
+
+## Key structural insight — detection touches `Source`, not `Task`
+
+The gate's existence check (R5/R6/R11) is a lookup on the **new `Source` table**, whose cardinality
+is *one row per named-file ingestion* — thousands, maybe low millions at a huge site, i.e. many
+orders of magnitude smaller than a trillion-row `task`. So the expensive predicate never scans
+`task`. That is the whole R17 argument.
+
+Bare `hs submit <file>` today already touches `task`: `check_database()` then
+`Task.current_group()` (`submit.py:1077-1080`), an indexed order-by on `schedule_time`
+(`data/model.py:426-431`). The new work adds only: (1) one B-tree descent on a `Source` index
+(~2–4 page reads over a tiny table), and (2) the R7 count, which is an **index range aggregate
+bounded by one source's rows** (one file's worth), never the whole table. Net: no new
+linear-in-total-tasks cost; the added latency is dominated by reading+md5'ing the file (R4), not the DB.
+
+## Column typing that constrains the indices
+
+- **Reserved sources `<direct>`/`<stdin>` (R3) are sentinel strings, not UUIDs.** If `Task.source`
+  used the `UUID` type it would reject `'<direct>'` on postgres (native `uuid` cast fails). Declare
+  **`Task.source` as `TEXT`** (holds either a uuid-string or a sentinel, mirroring the `'<auto>'`
+  sentinel idiom) and **`Source.id` as `TEXT`** too, so joins/`IN` don't need a text↔uuid cast on pg.
+- **`identity` is a precomputed scalar hex string (md5/sha), declared `TEXT`** — *not* JSONB. The
+  tags that feed identity are JSON/JSONB, but the canonical order-independent hash is computed in
+  Python at submit time and stored as a plain scalar. This is what keeps indexing dialect-uniform
+  and B-tree-friendly: **no JSONB GIN / expression index is needed**, and no per-query JSON parsing.
+- New tasks always have non-null `source` and `identity` (reserved sources included), so the index
+  has no NULL-sparsity problem; a partial index for NULLs is unnecessary.
+
+## Recommended indices
+
+```python
+# On the new Source table — serves R5 (path+fingerprint exact) AND R6 (path-seen? via leading col)
+index_source_lookup = Index('index_source_lookup', Source.path, Source.fingerprint)
+
+# On Task — serves R7 (count-by-source: leading column) AND R9/R12/R14 de-dup (seek lineage, filter identity)
+index_tasks_source = Index('index_tasks_source', Task.source, Task.identity)
+```
+
+One composite per table. `(path, fingerprint)` covers both path-only prefix scans and exact matches.
+`(source, identity)` is the workhorse: leading `source` gives R7's `COUNT(*) WHERE source=:uuid`
+directly, and restricts de-dup to one lineage's rows before filtering `identity` (index-only scan on
+pg).
+
+*Optional shrink:* a partial index `postgresql_where=Task.source.notin_(('<direct>','<stdin>'))`
+(sqlite supports the same via `sqlite_where`) keeps the two high-volume reserved-source ranges out of
+the index — those values are never queried (R3 exemption), so excluding them is free. Nice-to-have,
+not required.
+
+## De-dup strategy (R9/R12/R14) at scale
+
+Lineage = all prior sources at the same abs path: `SELECT id FROM source WHERE path=:abspath` (uses
+`index_source_lookup`, returns a handful of uuids). Then find which of the file's freshly-computed
+identities already exist under those sources. The file's full identity set is already in memory
+because R4 reads the whole file upfront to fingerprint+count it.
+
+Strategy comparison:
+
+- **(b) per-task existence query — rejected.** Millions of round-trips.
+- **(a) load lineage identity set into a Python `set`, diff in memory.** One indexed query
+  (`WHERE source IN (lineage)` on `index_tasks_source`), simplest. Memory ≈ *cumulative* lineage
+  tasks (grows with every `--update` generation): ~150 MB per 1M identities (32-char md5 + set
+  overhead), ~1.5 GB per 10M. Fine for a few file-generations; unbounded across many.
+- **(c) batched anti-join driven by the file's own identities — RECOMMEND as default.**
+  For each batch of the file's identities: `SELECT identity FROM task WHERE source IN (lineage) AND
+  identity IN (:batch)`. Returns only the intersection, so memory is bounded by the file (already
+  required) plus one batch — independent of how large the lineage grew. Batch size ~**900** to stay
+  under sqlite's `SQLITE_MAX_VARIABLE_NUMBER` (999 on old builds; 32766 modern); postgres tolerates
+  much larger but ~1–10k keeps planning cheap. Each query is an index range on `(source, identity)`.
+- **(d) temp-table + indexed join — fallback for pathologically huge files** (tens of millions of
+  lines): bulk-insert the file's identities into a temp table, `JOIN` on `task`. One bulk load + one
+  join beats thousands of `IN` batches. Dialect-specific temp-table DDL and must run on the same
+  `scoped_session` connection; only reach for it past a size threshold.
+
+**Recommendation:** default **(c)** (bounded memory, no version-cap, dialect-uniform); optionally use
+**(a)** as a fast path when the lineage is small; document **(d)** as the escape hatch for extreme
+files. All three ride the single `index_tasks_source`.
+
+## Caveats / open questions
+
+- **TimescaleDB hypertable:** if `task` is partitioned by time (e.g. `submit_time`), a de-dup query
+  with no time predicate (`WHERE source IN (lineage)`) cannot use chunk exclusion and touches every
+  chunk's `(source, identity)` index. Each chunk scan is still bounded to matching rows, but chunk
+  count itself scales with history. Out of scope to fully solve; a future mitigation is storing a
+  submit-time window per source and adding a time bound. Flag for the planner.
+- **R7 semantics:** the recorded count lives in `Source` (R1), but R7 compares it to the *actual* DB
+  landed count, so an index-backed `COUNT(*) WHERE source=:uuid` is genuinely needed (can't just read
+  the stored number). Cheap via `index_tasks_source` leading column.
+- Confirm the identity hash width (md5=32 vs sha256=64 hex chars) — affects index size at trillion
+  scale but not the strategy; md5 is sufficient for non-adversarial content identity and matches the
+  fingerprint example in R1.
+</content>
+</invoke>

--- a/spec/cli-cluster-restart-repeat-update/research/04-submit-flow.md
+++ b/spec/cli-cluster-restart-repeat-update/research/04-submit-flow.md
@@ -1,0 +1,139 @@
+# Brief 04 — Submit flow integration (R4, R7, R8, R9, R18)
+
+Where a NAMED file gets read, how tasks are counted, where the Source row + task
+stamping/dedup must hook in, the writeback ordering that makes R7 meaningful, and the
+log points for R18. Scope: the DB-writing submit path only (queue mode is exempt —
+see final section).
+
+## The one shared seam: the `Loader` FSM
+
+Both `hs submit <file>` and `hsx <file>` funnel every command line through the **same**
+`Loader.load_line_task` (`submit.py:164-198`), which is the *only* place a line becomes a
+`Task` via `Task.new` (`submit.py:167`). Path:
+
+- `hs submit`: `SubmitApp.run` → `check_source()` → `submit_all()` → `submit_from()` →
+  `SubmitThread`/`LiveSubmitThread` → `LoaderThread` → `Loader` (`submit.py:1063-1091, 697-792, 216-241`).
+- `hsx`/cluster: `ClusterApp.run` → `ServerThread(source=...)` (`server.py:799-806`) → same
+  `SubmitThread`/`LiveSubmitThread` → same `Loader`. `ClusterApp.source` currently returns
+  the raw stream, or `[]` when `--restart` (`cluster/__init__.py:435-441`; `input_stream`
+  returns `None` for restart at `:424`).
+
+⇒ **Source stamping + identity dedup belong in `Task.new`/`Loader`, not duplicated per
+entrypoint.** The gate decision (refuse / new-source / dedup) belongs upfront in each app;
+the *mechanism* (stamp `source_id` + identity, skip already-present identities) belongs in
+`Loader`/`Task.new` so both paths inherit it. This matches invariant §1 ("state/identity
+logic in `Task` classmethods").
+
+## Where a NAMED file is opened today
+
+`SubmitApp.check_source` (`submit.py:1124-1162`) resolves the mode and **opens the file but
+discards the path**: `-f FILE` → `open()` at `:1141`; implicit non-exec file arg → `open()`
+at `:1153`. `<stdin>` → `sys.stdin` (`:1138/1144/1149`); single command → `self.source = None`
+(`:1156/1159/1162`, the `<direct>` case). So "named file" ≡ `self.source` is an opened
+stream that is **not** `sys.stdin` and **not** `None`. The seam must **capture the abs path**
+here (e.g. set `self.source_path = os.path.abspath(filepath)` in the two file branches;
+`None` for stdin/direct) — R1 needs the absolute path and R5/R6 key on it.
+
+## Count semantics — NOT one-line-per-task
+
+`Loader.count` is incremented **only in `put_task`** on a successful enqueue (`submit.py:200-205`),
+and surfaced as `SubmitThread.task_count` → returned by `submit_from` (`submit.py:452-455,
+691-694, 786-792`) → logged at `submit.py:1091`. A line is a task **iff**, after
+`template.expand(line.strip())` then `Task.split_argline` comment-strip, `args` is non-empty
+(`submit.py:166-183`). Non-tasks:
+
+- empty / whitespace-only lines (`:182`),
+- comment-only lines (`#...` stripped to empty by `split_argline`, `model.py:375-377`),
+- **inline-tag-only lines** (`# HYPERSHELL: k:v`) — these set *global* tags for subsequent
+  tasks and produce **no task** (`submit.py:172-180`).
+
+**Template subtlety (load-bearing for counting):** emptiness is judged *after* template
+expansion. With `DEFAULT_TEMPLATE` (`"{}"`) a blank line → empty → not a task; but with e.g.
+`--template 'echo {}'` a blank line expands to `"echo "` → **is** a task. So any upfront
+count MUST apply the *same template*. ⇒ Factor the "line → task?" predicate into one helper
+(taking the `Template`) used by both the count pass and `Loader`, or the counts will diverge.
+
+`md5` is over **raw file bytes** (R1), independent of parsing — a plain
+`hashlib.md5(f.read())` streaming pass.
+
+### Pass strategy — recommend TWO streaming passes over the path
+
+Named files are seekable; `<stdin>` is not — which is *exactly* why stdin is exempt (R3/R4).
+
+1. **Pass 1 (upfront, O(1) memory):** stream the file → md5 **and** count real tasks
+   (replay the shared predicate). Yields `(md5, expected_count)` with no `Task` objects, no DB.
+2. Gate + create `Source` row.
+3. **Pass 2:** the existing `Loader`/`SubmitThread` streams the file *again* and submits.
+
+Prefer this over "read whole file into a list" (`ClusterApp.source`/`input_stream` are
+streamed today; going in-memory would regress huge-file memory). Reading a local text file
+twice is negligible against R17's billions-of-rows target. `hs submit` must reopen by path
+in pass 2 (it currently keeps one open handle) — trivial since we now store `source_path`.
+
+## Source writeback ordering — write the Source row BEFORE the tasks
+
+**Recommendation: create the `Source` row with the *expected* count (pass-1 count) and
+commit it BEFORE the task bundles.** Rationale — this is what makes R7 meaningful:
+
+- `DatabaseCommitter` commits in **bundles** (`submit.py:313-320`); a crash mid-stream leaves
+  a *partial* set of tasks. If `source.task_count` is the expected N (written first) but only
+  k<N task rows carry that `source_id`, a later run detects `live COUNT(source_id) < N` →
+  **R7 warn "incomplete prior submission"**, and `--restart` (R12) resumes by submitting the
+  missing N−k via identity dedup (R9). This is the resume story.
+- If instead you wrote the Source *after* with the *actual* count, `recorded == actual`
+  always and R7 can never fire. So **expected-first is required, not a style choice.**
+
+R7 compute: `expected = source.task_count` (recorded) vs `actual = COUNT(task WHERE source_id
+= …)` (live, indexed per R17). Warn when `actual < expected`. Note per-source count sidesteps
+the whole-table scan.
+
+Guard the Source write with the DB-mode / not-`in_memory` check (invariant §4; non-goal
+"no source tracking for in_memory").
+
+## R8 (`--repeat`) and R9 (`--update`) at this seam
+
+- **R8 `--repeat`:** always mint a **new** `Source` (fresh uuid, even if an identical prior
+  source exists) and submit *all* tasks — i.e. run pass-1→create-source→pass-2 with dedup
+  **off**. New tags (R15) flow through the existing `tags`/`Task.new` path unchanged.
+- **R9 `--update`:** create a new `Source`, but the `Loader` **skips** tasks whose identity
+  fingerprint already exists in the prior same-path source lineage. Give `Loader` an optional
+  dedup handle (a pre-loaded identity `set` for that lineage, or an indexed existence check —
+  scale tradeoff is a model.py decision). Skipped lines must **not** increment `count`, so
+  the dedup check sits in `Loader` before `put_task` and the "K submitted / L skipped" tallies
+  come from there.
+- **R10/R16 contradiction (`--update`+`--repeat`)** and **R13 (`--update` w/o `--restart` on
+  hsx)** are pure arg-validation → `SubmitApp` (no `check_arguments` today; add one) and
+  `ClusterApp.check_arguments` (`cluster/__init__.py:335`, which already houses the
+  restart/forever/no-db refusals at `:346-361`). Raise `ArgumentError` (cmdkit maps to a
+  non-zero exit) — do not invent literals (invariant §12).
+
+## R18 log points to add (levels are suggestions)
+
+Existing: JSON load count (`submit.py:1131`), `Submitted N tasks` (`:1091`), per-task
+(`:1104`), bundle debug (`:317`). Add:
+
+- upfront ingest: `info` — `Found N tasks in <abspath> (md5=<hex>)`.
+- detection hit: `info` — `Source already submitted <uuid> at <ts> (N tasks)`.
+- R7 warn: `warning` — `Incomplete prior submission: k of N tasks landed`.
+- dedup (R9/R14): `info` — `M tasks already present; submitting L new tasks`.
+- refusals: R5 `error` — `Refusing: file already submitted; use --repeat to resubmit`;
+  R6/R12-mismatch `error` — `Refusing: <path> seen with different content; use --update`.
+
+## Queue-mode asymmetry (call out explicitly)
+
+`hs submit -q` / `LiveSubmitThread` uses `QueueCommitter` (`submit.py:468-554`) which pushes
+bundles to a live server's `scheduled` queue and **never writes Task rows** — same class as
+the "queue mode ignores DB / ignores `-t`" asymmetry (invariant §11; `cluster` §11.132).
+There is nothing to gate against, so **source tracking does not apply to queue-mode submit**.
+`hsx` *with* a DB uses `SubmitThread` (DB path) → gating applies; `hsx --no-db` (`in_memory`)
+is exempt by non-goal. Gate the whole feature on `queue_config is None and not in_memory`.
+
+## Open questions for PLAN
+
+- Dedup carrier into `Loader`: pre-loaded identity `set` (bounded by one lineage's task
+  count — could be large) vs per-task/per-bundle indexed `EXISTS` query? R17 scale call —
+  belongs to the model brief but the `Loader` signature depends on it.
+- Should `hs submit` grow a `check_arguments()` (it has none today) or fold the R10 check
+  into `check_source`? Recommend a dedicated `check_arguments` for symmetry with `ClusterApp`.
+- Confirm `<direct>`/single-cmd (`self.source is None`, `submit_one` at `:1093`) and `<stdin>`
+  bypass Source creation entirely (R3 reserved sources) — yes per this analysis.

--- a/spec/cli-cluster-restart-repeat-update/research/05-cli-gate-matrix.md
+++ b/spec/cli-cluster-restart-repeat-update/research/05-cli-gate-matrix.md
@@ -1,0 +1,136 @@
+# 05 — CLI flag / gate decision matrix (both entry points)
+
+Scope: the full flag surface and refusal/de-dup gate for `hs submit` (SubmitApp) and `hsx`/`hs cluster`
+(ClusterApp), covering GOAL R5–R16. Grounded in current source; recommends the argument + validation
+changes and the authoritative decision table. Read-only research — no edits made.
+
+## Entry-point argument surfaces today
+
+**`hs submit`** (`src/hypershell/submit.py:993`): NO `--restart`. Relevant flags: positional `task_args`,
+`-f/--task-file` (`:1004`), `--from-json` (`:1005`), `-q/--queue` (`:1035`), `-g/--group` (`:1025`),
+`-t/--tag` (`:1052`). Validation is inline (no `check_arguments`): `check_source` (`:1124`) picks
+stdin/file/single-cmd mode; `check_database` (`:1106`) refuses in-memory sqlite. Queue-mode (`-q`) submits
+via `LiveSubmitThread` straight to the server, **bypassing the DB** (`run`, `:1063-1073`).
+
+**`hsx`/`hs cluster`** (`src/hypershell/cluster/__init__.py:122`): HAS `--restart` (`restart_mode`, `:171`).
+Positional `filepath` (`:129`), `--from-json` (`:132`), `--forever` (`:168`), `--no-db` (`in_memory`,
+`:158`). All validation is centralized in `check_arguments` (`:335`), run from `__enter__` (`:445`).
+
+Both apps use `**get_shared_exception_mapping` (submit `:1054`, cluster `:257`).
+
+## How refusals map to exit codes (verified)
+
+cmdkit `Application.main` catches `ArgumentError` → returns **`exit_status.bad_argument` (== 2)** and
+logs it critical; `ConfigurationError` → `bad_config` (3) via the shared mapping
+(`core/exceptions.py:135`); generic `RuntimeError` → `runtime_error` (5). `exit_status` values:
+`success=0, usage=1, bad_argument=2, bad_config=3, keyboard_interrupt=4, runtime_error=5`.
+
+**Recommendation:** raise `cmdkit.cli.ArgumentError` for every loud refusal (contradictory/ambiguous flag
+combos AND DB-state gate refusals). It is already wired, prints an actionable critical message, and yields
+a single consistent non-zero code (`bad_argument`=2), satisfying invariant §12 "reuse `exit_status`
+constants, don't invent literals." (Semantic nit: R5/R6/R12-differs are runtime DB-state refusals, not
+strictly argument errors — but `bad_argument`/2 is the cleanest reuse and keeps all refusals uniform. If a
+distinct code is wanted for "source already exists," use `runtime_error`/5 via a dedicated exception in the
+mapping; flagged as an open question below.)
+
+## Current `--restart` behavior (file is IGNORED today) — exact
+
+- `--restart` sets `restart_mode` (`cluster/__init__.py:171`).
+- `check_arguments:344`: `elif self.filepath is None and not self.restart_mode: self.filepath = '-'` — with
+  `--restart`, filepath is NOT defaulted to stdin.
+- `input_stream` (`:422-427`): `if self.restart_mode or self.from_json: return None`.
+- `source` (`:434-441`): `if self.restart_mode: return []` → **empty source; the file is silently
+  discarded**. If a user passes `hsx file.txt --restart` today, `file.txt` is ignored entirely.
+- `restart_mode` flows to `ServerThread` (`server.py:151` `startup_phase = not restart_mode`; `:179`
+  `Task.revert_interrupted()`), so restart today = revert interrupted + schedule whatever pending rows
+  already exist in the DB. (Contrast: `hs server` *refuses* FILE+`--restart` at `server.py:1380`; ClusterApp
+  does not refuse — it just ignores.)
+
+**New behavior:** `--restart` becomes **file-aware**. `source`/`input_stream` must stop hard-returning
+`[]`/`None` when a filepath is present. Preserve the legacy **bare** `hsx --restart` (no file) as a pure DB
+resume (`source == []`), but when a file is given, read it, compute source fingerprint + per-task identities
+(R2), and yield only novel task lines (R12/R14). The revert-interrupted flow (`server.py:179`) is unchanged
+(non-goal: no retry/revert change).
+
+## Authoritative decision table
+
+Prior state for a **named file** at path `P` with content fingerprint `F` (vs the `SOURCE` table):
+`none` = no source row for `P`; `match` = row with `path==P AND md5==F`; `differs` = row with `path==P AND
+md5!=F`. "novel-only" = submit only tasks whose identity fingerprint (R2: order-independent hash of
+pre-expansion `args`+`group`+`tags`) is absent from the **same-path (`P`) source lineage**. R7 count-warn
+(warn if landed task count < recorded source count) is an informational log (R18) emitted whenever a prior
+`P` source exists — orthogonal to the submit/refuse decision; it fires in the match/differs rows and in the
+`--restart`/`--update` paths.
+
+### `hs submit` (no `--restart`)
+
+| flags | none | match (P,F seen) | differs (P seen, F changed) |
+|---|---|---|---|
+| (no flag) | submit all, new source | **REFUSE** (2), identify prior — **R5** (+count-warn R7) | **REFUSE** (2), suggest `--update` — **R6** |
+| `--repeat` | new source, submit all | new source, submit all — **R8** | new source, submit all — **R8** |
+| `--update` | new source, submit all (nothing to skip) | new source, **novel-only** (≈0 new) — **R9** | new source, **novel-only** in P-lineage — **R9** |
+| `--update --repeat` | **REFUSE** (2) contradictory — **R10** | REFUSE (2) — R10 | REFUSE (2) — R10 |
+
+### `hsx` / `hs cluster` (has `--restart`)
+
+| flags | none | match (P,F seen) | differs (P seen, F changed) |
+|---|---|---|---|
+| (no flag) | submit all, new source | **REFUSE** (2), identify prior — **R11=R5** (+R7) | **REFUSE** (2), suggest `--update` — **R11=R6** |
+| `--restart` | new source, submit all (nothing prior) | **novel-only**; rely on revert-interrupted — **R12** | **ALERT + REFUSE** (2), suggest `--update` — **R12** |
+| `--update` (no `--restart`/`--repeat`) | **REFUSE** (2) ambiguous — **R13** | REFUSE (2) — R13 | REFUSE (2) — R13 |
+| `--update --restart` | new source, submit all | new source, novel-only — **R14** | new source, **novel-only** in P-lineage — **R14** |
+| `--repeat` | new source, submit all | new source, submit all even if match; MAY add tags — **R15** | new source, submit all — **R15** |
+| `--update --repeat` | **REFUSE** (2) contradictory — **R16** | REFUSE (2) — R16 | REFUSE (2) — R16 |
+
+Note R12/match "novel-only" against the same-path lineage yields exactly "the tasks that never landed,"
+which is the requeue-Slurm outcome; the revert flow re-runs anything mid-flight (no double work).
+
+## Two plan-time assumptions — SETTLED
+
+- **(a) `--update` de-dup scope = same-path (`P`) source lineage** for BOTH `hs submit --update` (R9) and
+  `hsx --update --restart` (R14). Confirmed consistent with GOAL Clarifications and R9's explicit wording;
+  requires an identity-fingerprint lookup filtered to sources sharing path `P` (R17 index). Both forms use
+  the identical predicate.
+- **(b) tags participate in identity (R2)** → re-tagging a line between file versions makes it a **new**
+  task under `--update` (re-submitted). Confirmed as intended (the cost of letting `--repeat` re-tag a
+  phase). Task identity excludes UUID/attempt/timing/exit_status/template.
+
+## RECOMMENDATION
+
+**SubmitApp** (`submit.py`): add `--repeat` (`store_true`, `dest='repeat_mode'`, default False) and
+`--update` (`store_true`, `dest='update_mode'`). No `--restart`. Add a `check_arguments` (or extend
+`check_source`) that: rejects `--update --repeat` (R10, `ArgumentError`→2); wires the DB-state gate (R5/R6
+refuse, R7 warn, R8/R9 submit) in the DB path only. **Gating applies only to the DB submit path** — `-q`
+queue-mode (`LiveSubmitThread`, no DB) and in-memory sqlite (`check_database:1106`) have no source table, so
+they are exempt (analogous to the `in_memory` non-goal); `<stdin>`/single-cmd (`<direct>`) are exempt by R3.
+
+**ClusterApp** (`cluster/__init__.py`): add `--repeat` (`dest='repeat_mode'`) and `--update`
+(`dest='update_mode'`). In `check_arguments` (`:335`): reject `--update` without (`--restart` or `--repeat`)
+(R13, →2); reject `--update --repeat` (R16, →2); reject `--update` with `--no-db` (in_memory has no lineage);
+treat `--repeat` with `--no-db` as redundant (warn). Make `source`/`input_stream` (`:422-441`) file-aware:
+bare `--restart` (no filepath) keeps `source==[]` (legacy DB resume); `--restart`/`--update`/`--repeat` with a
+filepath must read + fingerprint the file and yield the gated task subset. Existing rejections to keep:
+`--forever`+`--restart` (`:361`), `--from-json`+`--restart` (`:341`), `--no-db`+`--restart` (`:359`).
+
+**Exit codes:** all refusals via `ArgumentError` → `exit_status.bad_argument` (2). Warnings (R7/R18) via
+`log.warning`, exit 0.
+
+**Not forwarded to clients (invariant §11 confirmed):** `--restart`/`--repeat`/`--update` are submit/server
+-side only. Client argv builders (`ssh.py:296-298`, `remote.py:303-305`, `remote.py:833`) construct the
+`client` subcommand and carry none of these; `restart_mode` reaches `ServerThread` (`server.py:151`), never
+the client launcher. New flags follow the same path — do not add them to any client argv builder.
+
+## Open questions
+
+- **`--restart --repeat` (hsx)** is not enumerated in R11–R16. Recommend rejecting as contradictory (resume
+  vs. fresh full run) for safety; alternative is "repeat wins." Needs a decision.
+- **DB-state refusal exit code:** uniform `bad_argument`(2) recommended, but R5/R6/R12-differs are runtime
+  conditions — confirm whether a distinct code (e.g. `runtime_error`/5 via a dedicated `SubmitRefused`
+  exception in the mapping) is preferred for scripting/telemetry.
+- **`--from-json` participation:** a `--from-json` SPEC references a named file but is currently
+  incompatible with `--restart` (`:341`). Does source gating apply to `--from-json` sources, or are they
+  exempt for now? GOAL centers on the plain taskfile; recommend deferring/exempting `--from-json` unless the
+  plan says otherwise.
+- **`hs submit -f -` / stdin:** confirm stdin (`check_source:1136-1144`) maps to the reserved `<stdin>`
+  source and is exempt (R3/R4) even when `--update`/`--repeat` are also passed (recommend: flags are no-ops
+  on stdin, possibly warn).

--- a/spec/cli-cluster-restart-repeat-update/research/06-docs-completions-tests.md
+++ b/spec/cli-cluster-restart-repeat-update/research/06-docs-completions-tests.md
@@ -1,0 +1,151 @@
+# Brief 06 — Same-commit surface: docs snippets, shell completions, test plan
+
+Scope: what must change **in the same commit** as the `--repeat`/`--update` (+ `--restart` doc
+edits) CLI work (GOAL R18, invariants §12), and a concrete test plan driving the R4–R16 gate matrix.
+Read-only investigation; all anchors verified against source.
+
+## 1. Docs snippets (`docs/_include/*.rst`)
+
+These are **hand-maintained RST mirrors** of the cmdkit `interface` help/usage strings — there is
+**no generator script** (grep for `_include` in `docs/conf.py` finds nothing; snippets are literal
+`.. include::` targets). The source-of-truth CLI strings live in the app `__doc__`/interface in
+`src/hypershell/submit.py` and `src/hypershell/cluster/__init__.py:53-88`; the `test_*_help`/
+`test_*_usage` tests compare `main(...)` stdout against `App.interface.help_text`/`usage_text`, so the
+interface strings and these snippets must be edited together (snippets are not auto-checked, but drift
+is a doc bug).
+
+Files to touch for this feature:
+- `docs/_include/submit_help.rst` — add `--repeat`, `--update` option blocks (Options section).
+- `docs/_include/submit_usage.rst` — add `[--repeat | --update]` to the usage line.
+- `docs/_include/submit_desc.rst` — describe re-submission gating (optional but recommended).
+- `docs/_include/cluster_help.rst` — add `--repeat`/`--update`; revise `--restart` block (its
+  "mutually exclusive to --forever" text and new interplay with `--update`).
+- `docs/_include/cluster_usage.rst:1` — the `[FILE | --from-json SPEC | --restart | --forever]`
+  group must gain `--repeat`/`--update`.
+- `docs/_include/cluster_desc.rst` — the `--restart` narrative (mentions restart-where-left-off)
+  should note the new detection/dedup semantics.
+
+Consumers of these includes (no separate edits needed — they transclude): `docs/cli/submit.rst`,
+`docs/cli/cluster.rst`, and `docs/manual.rst:64-94` (which also has abbreviated hand-written
+usage lines `manual.rst:10-11,22` using `...` — likely fine to leave, but confirm).
+
+Toctree caveat: `task_submit.rst`/`manual.rst` already emit pre-existing "not in any toctree"
+warnings (AGENTS.md); adding option blocks introduces **no new** warnings. Build check:
+`uv run sphinx-build docs docs/_build` and diff the warning set.
+
+## 2. Man pages (also under `share/`, hand-maintained)
+
+`share/man/man1/hs.1` and `share/man/man1/hsx.1` embed the **full help text** (both already carry
+`--restart`/`--forever` blocks, e.g. `hsx.1:91,242,251`). Invariant §12 / AGENTS.md scopes the
+same-commit rule to `docs/_include` + `share/` completions, but the man pages are `share/` files that
+mirror the same help — update them for `--repeat`/`--update` for consistency. CI asserts only that
+they *ship*, not their content, so this is a completeness item, not a gate.
+
+## 3. Shell completions (`share/`)
+
+- **bash** — `share/bash_completion.d/hs`:
+  - `_hs_submit` `all_opts` string at **`:518-519`** — add `--repeat --update`.
+  - `_hs_cluster` `all_opts` string at **`:654-661`** — add `--repeat --update` (this same function
+    backs `hsx`). No new value-completion `case` arms needed (both are boolean flags).
+- **zsh** — `share/zsh/site-functions/_hs`:
+  - `_hs_submit` `_arguments` block at **`:461-484`** — add `'--repeat[...]'` and
+    `'(--repeat)--update[...]'` / `'(--update)--repeat[...]'` mutual-exclusion pair (mirror how
+    `--no-tls` uses `(--no-tls)` exclusion groups).
+  - `_hs_cluster` `_arguments` block starting **`:552`** (after `--forever`/`--restart` at
+    `:573-574`) — add the same two flags with appropriate exclusions.
+
+## 4. CI metadata job (keep in lockstep — but no change needed here)
+
+`.github/workflows/tests.yml:95-112` ("Assert completions & man pages ship in the wheel") checks the
+wheel `namelist` contains the six shared-data paths (`share/bash-completion/completions/hs`+`hsx`,
+`share/zsh/site-functions/_hs`, three man pages). The repo→wheel mapping is
+`pyproject.toml:118-124` (`[tool.hatch.build.targets.wheel.shared-data]`; repo path
+`share/bash_completion.d/hs` maps to wheel `share/bash-completion/completions/hs`, and the same
+source file is mapped twice to install under both `hs` and `hsx`). **This feature adds no new
+`share/` files**, so the CI list and the pyproject mapping stay as-is — only edit the file *contents*.
+(Flag only if a new completion file is introduced.)
+
+## 5. Test infrastructure (verified)
+
+- `tests/conftest.py`: `isolate_environment()` at import + autouse `clean_env` blanks
+  `HYPERSHELL_*`, sets `HYPERSHELL_CONFIG_FILE=''`, binds `HYPERSHELL_SERVER_PORT` to `free_port()`.
+  `temp_site` fixture sets `HYPERSHELL_SITE`, `HYPERSHELL_DATABASE_FILE`, `LOGGING_LEVEL=DEBUG` — use
+  it for anything touching the DB (which is everything here).
+- `tests/__init__.py`: `main(argv)→(rc,out,err)`, `main_lines`, `assert_output(pat,out,count=)`
+  (regex line-count over stderr logs, DEBUG-level), `create_taskfile(temp_site, lines)`,
+  `create_taskfile_echo(temp_site, count, tags=)`, `create_json_taskfile`, `NO_OUTPUT`,
+  `UUID_PATTERN`, `exit_status` from `cmdkit.app`.
+- Established patterns to copy: `test_cluster.py:152` (`test_cluster_database` — DB assertions via
+  `hs list --count` and `hs list <field> -f plain -s submit_time`) and `:200` (`test_cluster_backfill`
+  — pre-`hs submit` then `hsx --restart`, count checks). `test_submit.py` mixed-input/refusal
+  patterns (`main_lines(...) == (exit_status.bad_argument, NO_OUTPUT, ['CRITICAL ...'])`).
+- **Markers: only `@mark.unit` / `@mark.integration`** (`--strict-markers`); use `@mark.parametrize`.
+  `client.py` has no dedicated test file — gating logic lives in `submit.py`/`data/model.py`, so
+  coverage should target `test_submit.py`, a new `test_source.py`/`test_restart.py`, and
+  `test_cluster.py`. `test_initdb.py` exists for the fresh-initdb non-goal.
+
+## 6. Test plan (unit vs integration, per requirement)
+
+**Unit** (`@mark.unit`, import `Task`/`SubmitApp` directly, no subprocess) — new `test_source.py`:
+- R2: identity fingerprint is order-independent over tags, stable across template change, and
+  excludes uuid/attempt/timing/exit_status. Assert two tasks (args+group+tags equal, different
+  template/uuid) hash equal; reordered tags hash equal; different args/group/tags hash differ.
+- R1/R4: source record md5 + task-count computed from file content (recompute helper == expected).
+
+**Integration** (`@mark.integration`, `temp_site`, shell out) — extend `test_submit.py` +
+new `test_restart.py`; each seeds `create_taskfile_echo`:
+- R3 exempt: `hs submit 'echo x'` twice → both succeed (source `<direct>`); stdin (`seq 4 | hs
+  submit -f -`) twice → both succeed.
+- R5: submit file, submit again no flag → non-zero, `assert_output` refusal naming prior source.
+- R6: submit, rewrite file (same path, changed content), submit no flag → refuse, message suggests
+  `--update`.
+- R7: incomplete-prior warning — submit file, remove/cancel some rows (or interrupt), re-detect →
+  count-warning log (mechanism TBD — see open question).
+- R8: `hs submit <file> --repeat` after identical prior → `hs list --count` doubles.
+- R9: `hs submit <file> --update` after edited file → only novel-identity tasks added (count == old
+  + new-unique); unchanged lines skipped.
+- R10: `hs submit <file> --update --repeat` → non-zero contradictory.
+- R11: `hsx <file>` (no flag) on seen file → refuse (same as R5).
+- R12: `hsx <file> --restart` same fingerprint → submits only not-present, completes; run twice →
+  second is idempotent (nothing to do, halts). Changed fingerprint → refuse, suggest `--update`.
+- R13: `hsx <file> --update` (no `--restart`) → non-zero ambiguous.
+- R14: `hsx <file> --update --restart` after edit → new source, only novel tasks added + run.
+- R15: `hsx <file> --repeat` → all tasks resubmitted (count grows).
+- R16: `hsx <file> --update --repeat` → non-zero contradictory.
+- R18: throughout, `assert_output` on ingest/detection logs (found N / existed M / submitting K /
+  refusal reason). Logs are DEBUG in `temp_site`, matched against stderr.
+- non-goal (fresh initdb): extend `test_initdb.py` — after `hs initdb` the source table/indices
+  exist; `hs list --count` == 0.
+
+## RECOMMENDATION
+
+Same-commit edit set:
+- **Docs:** `docs/_include/{submit_help,submit_usage,submit_desc,cluster_help,cluster_usage,cluster_desc}.rst`
+  — kept in lockstep with the interface strings in `submit.py` + `cluster/__init__.py`.
+- **Completions:** `share/bash_completion.d/hs` (`_hs_submit` `all_opts` `:518`, `_hs_cluster`
+  `all_opts` `:654`) and `share/zsh/site-functions/_hs` (`_hs_submit` `:461`, `_hs_cluster` `:552`).
+- **Man pages (completeness):** `share/man/man1/hs.1`, `share/man/man1/hsx.1`.
+- **CI:** `.github/workflows/tests.yml:95-112` and `pyproject.toml:118-124` need **no change** (no
+  new `share/` files).
+- **Tests:** unit `test_source.py` (R1/R2/R4); integration additions to `test_submit.py`,
+  `test_cluster.py`, new `test_restart.py`, `test_initdb.py` per the R-mapped list above.
+
+`verify:` commands to seed TECH.md phases (run in a `temp_site`, `uv sync` first):
+- `uv run hs initdb`
+- `printf 'echo a\necho b\n' > f.in; uv run hs submit -f f.in` (expect success) `; uv run hs submit
+  -f f.in` (expect refuse) `; uv run hs list --count`
+- `uv run hs submit -f f.in --repeat; uv run hs list --count` (doubled)
+- edit `f.in`; `uv run hs submit -f f.in --update; uv run hs list --count` (only novel added)
+- `uv run hsx f.in --restart` twice (second idempotent); `uv run hsx f.in --update` (ambiguous fail);
+  `uv run hs submit -f f.in --update --repeat` (contradictory fail)
+- doc/completion sanity: `uv run sphinx-build docs docs/_build` (no new warnings);
+  `bash -n share/bash_completion.d/hs`; `zsh -n share/zsh/site-functions/_hs`.
+
+## Open questions
+- R7 count-warning: how to construct an "incomplete prior submission" deterministically in an
+  integration test (cancel rows? kill mid-run? directly delete)? Depends on the source→count storage
+  chosen in PLAN — coordinate with the model/schema brief.
+- Do the hand-written abbreviated usage lines in `docs/manual.rst:10-11,22` need the new flags, or do
+  their `...` ellipses suffice? (Recommend leaving; confirm at plan time.)
+- Whether a new `test_restart.py` is preferred vs folding cluster gating into `test_cluster.py`
+  (stylistic; both fit existing conventions).

--- a/spec/cli-cluster-restart-repeat-update/research/07-uuidv7-source-ids.md
+++ b/spec/cli-cluster-restart-repeat-update/research/07-uuidv7-source-ids.md
@@ -1,0 +1,109 @@
+# Research 07 — UUIDv7 for `Source.id` (stdlib-only, 3.11–3.14)
+
+> **SUPERSEDED (2026-07-11, maintainer):** do **not** add a forced/hand-rolled `uuid7()` to
+> `core/uuid.py`. The default stays `uuid4` via the existing `uuid()` (which already prefers
+> `uuid_utils.uuid7` when the `uuid7` extra is installed). Instead, add a **`timescale`/`timescaledb`
+> provider alias** in `data/core.py` that maps to the postgres backend and **gates the `uuid7` extra**
+> (bail like missing `psycopg`); in that mode `uuid()` yields v7 automatically. This brief's finding
+> that `uuid()` degrades to `uuid4` without the extra, and that `Source.id` change is isolated, still
+> holds. See [`00-digest.md`](00-digest.md).
+
+**Revises** PLAN.md per maintainer correction (1): reserved sources are **real rows** with real
+UUIDs, and `Task.source` becomes the **native shared UUID type** (not TEXT). Correction (2): no
+TimescaleDB-specific code — the only lever is making `Source.id` a **time-ordered UUIDv7** so
+per-chunk min/max stats on `task.source` let PostgreSQL/TimescaleDB prune the de-dup query.
+
+This brief resolves how to generate a guaranteed v7 UUID on every supported Python with **no new
+hard dependency**.
+
+## Findings
+
+### `uuid()` today is *conditionally* v7 — unsafe for the pruning lever
+`src/hypershell/core/uuid.py:8-19`: `uuid()` tries `from uuid_utils import uuid7` and **falls back
+to `uuid.uuid4`** on ImportError. But `uuid-utils` is only the optional `uuid7` extra
+(`pyproject.toml:59`) and the `dev` group — it is **not** in core `dependencies`
+(`pyproject.toml:30-38`). So a plain `pip install hypershell` (no extra) makes `uuid()` return
+**uuid4** (random, not time-ordered). Relying on `uuid()` for `Source.id` would silently defeat
+chunk pruning on any base install. A dedicated, always-v7 generator is required.
+
+### Changing only `Source.id` is fully isolated
+`uuid()` has exactly three call sites, all unaffected:
+- `core/logging.py:57` — `INSTANCE` (per-process server/client id).
+- `data/model.py:359` — `Task(id=uuid())` in `Task.new`.
+- `data/model.py:817` — `Client(id=(id or uuid()))` in `Client.new`.
+
+`previous_id`/`next_id` are **not** freshly generated — the retry minter
+`__schedule_next_failed_tasks` (`data/model.py:555-560`) sets `previous_id=task.id` from the parent
+and mints the new id via `cls.new(...)` → `uuid()`. So Task/Client ids stay on `uuid()`; `Source`
+is a brand-new entity. **Adding a separate `uuid7()` for `Source.new` touches nothing else.**
+
+### `uuid.uuid7()` is stdlib only on 3.14
+Confirmed against the official docs (external fact): CPython added `uuid6/7/8` in **Python 3.14**
+(`uuid.html` "Changed in version 3.14: Added UUID versions 6, 7 and 8"; RFC 9562 §5.7 — the RFC that
+obsoletes RFC 4122 and formally defines v7). The supported floor is **3.11** (`requires-python =
+">=3.11"`), so `uuid.uuid7` is **absent on 3.11/3.12/3.13**. A hand-rolled fallback is needed.
+
+### Native UUID column stores v7 cleanly
+`UUID = Text().with_variant(POSTGRES_UUID(as_uuid=False), 'postgresql')` (`data/model.py:75`). A v7
+value is a canonical 36-char UUID string, valid input to the postgres native `uuid` type and
+trivially stored as TEXT on sqlite. `as_uuid=False` keeps the Python side as `str` (matching
+`Client.id`/`Task.id`). Per correction (1), `Task.source` should use this **shared `UUID` type** (it
+now only ever holds a real `Source.id` v7 value, or NULL for historical rows) — the native uuid
+ordering is exactly what feeds the planner's per-chunk min/max pruning. `Source.id` uses the same
+`UUID` type as PK, mirroring `Client.id` (`data/model.py:766`).
+
+### Reserved rows should also be v7 (uniform column) — and it's harmless
+`<direct>`/`<stdin>` become real `Source` rows (PATH holds the sentinel) created **once, lazily**,
+reused forever → their v7 ids carry an *ancient* timestamp (low-sorting). This does **not** hurt
+pruning: a v7's timestamp lands in the *min* side of a chunk's `task.source` range, and de-dup
+queries prune old chunks via `chunk_max < lineage_value`. A low min never raises max, so old chunks
+are still pruned. Reserved sources are also gate-exempt, so they never appear in a lineage IN-list.
+Keep the column uniform: give them v7 ids like any other source.
+
+## RECOMMENDATION
+
+Add a dedicated, always-v7 `uuid7()` to `core/uuid.py` (keep `uuid()` untouched). Prefer a library
+impl when present, else a ~10-line stdlib hand-roll — never degrade to uuid4:
+
+```python
+import os, time
+from uuid import UUID
+
+try:                                   # 3.14+ stdlib, or the uuid7 extra
+    from uuid_utils import uuid7 as _uuid7
+except ImportError:
+    try:
+        from uuid import uuid7 as _uuid7        # CPython >= 3.14
+    except ImportError:
+        def _uuid7() -> UUID:                    # RFC 9562 §5.7 fallback (3.11–3.13)
+            b = bytearray(os.urandom(16))
+            b[0:6] = int(time.time() * 1000).to_bytes(6, 'big')  # 48-bit unix-ms
+            b[6] = (b[6] & 0x0F) | 0x70                          # version 7
+            b[8] = (b[8] & 0x3F) | 0x80                          # variant 10
+            return UUID(bytes=bytes(b))
+
+def uuid7() -> str:
+    """Generate a time-ordered UUIDv7 (RFC 9562 §5.7)."""
+    return str(_uuid7())
+```
+
+- Export it (`__all__ = ['uuid', 'uuid7']`).
+- `Source.new(...)` (new entity in `data/model.py`) fills `id=uuid7()` (parallel to `Task.new`'s
+  `id=uuid()`), and the lazy get-or-create of the `<direct>`/`<stdin>` rows uses the same `uuid7()`.
+- `Task.source` column: change from the plan's TEXT to the shared `UUID` type
+  (`mapped_column(UUID, nullable=True)`); `Source.id` PK is `UUID` too. The v7 values are valid
+  RFC 9562 UUIDs and store natively on postgres / as TEXT on sqlite.
+- No dependency change: the hand-roll is pure stdlib, honoring the EPEL/RHEL low-floor philosophy
+  (`AGENTS.md` "md5/hashlib is stdlib (no new dep)"). The optional `uuid7` extra remains a
+  performance nicety, not a correctness requirement.
+
+## Open questions
+
+- **Monotonicity within a millisecond:** the hand-roll uses fully random `rand_a`/`rand_b` (no
+  intra-ms counter, unlike stdlib 3.14 / uuid_utils). Fine for chunk-pruning (ms granularity is
+  enough) and de-dup correctness (ids only need to be unique + roughly time-sorted). Only relevant
+  if strict per-ms ordering is ever required — it is not here.
+- **Timestamp source:** `time.time()` (wall clock) matches v7 semantics; a backward clock step could
+  produce a slightly out-of-order id but never a collision (62 random bits). Acceptable.
+- Confirm the plan's `index_tasks_source` (`Task.source, Task.identity`) is still wanted now that
+  `Task.source` is native UUID — it still serves the R7 count-by-source and de-dup lineage scan.

--- a/spec/cli-cluster-restart-repeat-update/research/08-presentation-source-display.md
+++ b/spec/cli-cluster-restart-repeat-update/research/08-presentation-source-display.md
@@ -1,0 +1,134 @@
+# Research 08 — Presentation of `Task.source` (UUID → path / `<direct>` / `<stdin>`)
+
+Revises PLAN/digest under **maintainer correction 1**: reserved sources are now **real `Source`
+rows** (a normal row whose `path` field holds the `<direct>`/`<stdin>` sentinel, each with a real
+UUID). `Task.source` becomes a **native UUID** column (`UUID` type at `model.py:74`, i.e.
+`POSTGRES_UUID(as_uuid=False)` on postgres, `Text` elsewhere), nullable only for historical rows.
+So `Task.source` no longer *is* the display string — every human-facing surface must resolve the
+UUID back to `Source.path`. This brief maps today's presentation, designs that resolution, and
+recommends where it lands.
+
+## How Task rows are presented today
+
+- **Field list is derived from `Task.columns`.** `ALL_FIELDS = list(Task.columns)` (`task.py:434`)
+  is the default field set for `hs list`/`hs search`. `--fields` prints `' '.join(Task.columns)`
+  (`task.py:605`). `-x/--extract` choices are `Task.columns` (`task.py:169`). Field-name validation
+  is `name in Task.columns` (`task.py:548`).
+- **`hs info` (single task):**
+  - default/normal → `print_normal(task)` (`task.py:202`, module fn `task.py:1352`) renders a
+    **fixed** `NORMAL_MODE_TEMPLATE` (`task.py:1285`). It formats `task.to_dict()` values but only
+    the keys named in the template appear; **extra columns are silently ignored** by `str.format`.
+  - `-f json|yaml` → `print_formatted` formats `task.to_json()` (**all** columns) → new columns
+    **auto-appear as raw values** (`task.py:222-231`, `format_method` `task.py:250`).
+  - `-x FIELD` → `json.dumps(task.to_json().get(field))` (`task.py:209`) → new columns become
+    extractable, **raw value**.
+- **`hs list`/`hs search` (many):** query selects the chosen columns as positional tuples
+  (`fields` = `getattr(Task, name)`, `task.py:541`/`759`). Format handling in `check_output_format`
+  (`task.py:811`): all-fields ⇒ `normal`; a field subset ⇒ `plain`; `normal`+subset is rejected.
+  - `normal` → `print_normal(Task.from_dict(dict(zip(Task.columns, record))))` (`task.py:781`) →
+    same fixed template, extra columns ignored.
+  - `plain`/`table` → `format_json(value)` per selected field (`task.py:769`,`785`) — only shows a
+    column if the user names it; raw value.
+  - `json` → `{field: to_json_type(value) ...}` over `field_names` (`task.py:793`); default
+    field_names = ALL_FIELDS ⇒ **new columns auto-appear raw**.
+  - `csv` → header = `field_names`, rows = `to_json_type(value)` (`task.py:803`) ⇒ **auto-appear**.
+
+**Net auto-appearance when `source`/`identity` are added to `Task.columns` (required anyway for the
+wire round-trip via `serialize_tasks`/`server.py` writeback):** they surface **automatically and
+raw** in `hs info -f json/yaml`, `hs info -x source|identity`, `hs list --json/--csv` (default all
+fields), `hs list source ...` (explicit), and `--fields`. They do **not** appear in the `normal`
+template for either `hs info` or `hs list` unless the template is edited.
+
+## The problem the correction creates
+
+Raw auto-display now prints an **opaque UUID** for `source` (the `Source.id`) and a 32-hex md5 for
+`identity`. A `<direct>`/`<stdin>` task shows some UUID, **not** the sentinel — because the sentinel
+now lives in `Source.path`, one indirection away. Raw is acceptable for machine formats (json/csv/
+`-x`) but useless to a human scanning `hs list`/`hs info`.
+
+## Design — resolution layer (additive, no format breakage)
+
+**Resolver in the model (invariant: query logic lives on entities).** Add a batch classmethod to
+`Source`:
+`Source.paths_for_ids(ids: set[str]) -> dict[str, str]` — one `SELECT id, path FROM source WHERE
+id IN (:ids)`. The id-set is tiny (distinct sources on a page of results, or one for `hs info`), so
+no batching/temp-table needed — consistent with correction 2 (small IN-lists). A single-id
+convenience (`Source.from_id(id).path`) already fits the `Client`-mirrored `from_id` pattern.
+
+**Display formatting** — the resolved value is either:
+- a filesystem path (absolute, as stored via `os.path.abspath`; PLAN §2), or
+- a reserved sentinel matching `^<.*>$` (`<direct>`/`<stdin>`) → pass through unchanged.
+
+A small helper `format_source(path, *, relative=False) -> str`: sentinels pass through; real paths
+return `os.path.relpath(path)` when `relative` else `path`. Natural home is
+`core/pretty_print.py` (alongside `format_tag`/`format_bytes`/`format_json`), keeping `task.py`
+import-light. NULL `source` (historical rows) → display `null`, exactly as other nullable columns
+render today.
+
+**`hs info` (one task):** resolve the single id and inject a `source` line into
+`NORMAL_MODE_TEMPLATE`. In `print_normal` (`task.py:1352`) set
+`task_data['source'] = format_source(Source.from_id(task.source).path)` when `task.source` else
+`'null'`, and add a `      source: {source}` line to the template (`task.py:1285`). One extra
+lookup per `hs info` call — negligible.
+
+**`hs list` normal (many):** avoid N+1. `TaskSearchApp.print_normal` (`task.py:777`) already
+materializes the full page; before the loop, collect distinct non-null `source` values and call
+`Source.paths_for_ids(...)` once, then pass the map into `print_normal`. Minimal signature change:
+`print_normal(task, source_map=None)` — resolve from the map, else fall back to a single `from_id`
+(so `hs info`'s call site needs no map). This is the only touch to a shared helper.
+
+**Should raw `identity`/`source` be shown vs hidden?**
+- **`identity`** — an internal fingerprint (md5), noise for humans. **Do not** add it to the normal
+  template; leave it reachable via `hs info -x identity`, `hs list identity`, and json/csv for power
+  users/scripts. Zero extra work (auto-flows from `Task.columns`).
+- **`source`** — **resolve** it in the normal template (path/sentinel). Keep the **raw UUID** in
+  json/csv/`-x source`/explicit-field selection — those are machine surfaces where a stable UUID is
+  the correct value and resolving would break scriptability and column/type expectations. This is
+  additive: existing columns, orders, and `-f plain/json/csv` semantics are untouched; we only add
+  one `normal`-template line plus a resolver.
+
+**Relative-path option:** cheap to offer via `format_source(relative=True)`, but it needs a flag
+(`hs info`/`hs list --source-relative` or similar) and a completion/docs update. Recommend
+**defer the flag**; ship absolute-path display now (matches how `outpath`/`errpath`/`csvpath` show
+absolute paths). Expose `relative=` in the helper so a later flag is a one-line wire-up.
+
+## Scope / phase placement
+
+Presentation is **adjacent** to R18 (logging/ergonomics), not a distinct R-ID. The `Task.columns`
+additions land in **P1** (schema core) and immediately make `source`/`identity` visible-raw in
+json/csv/`-x` — so P1 must at minimum accept that raw exposure (it's harmless and expected). The
+**human-readable resolution** (normal-template `source` line + `Source.paths_for_ids` +
+`format_source`) is small and self-contained; it belongs in **P6** (the "polish" + full-sweep
+phase, `TECH.md:60`, which already owns R18 and docs). It has no dependency on the gate matrices,
+so it could equally ride P1, but P6 keeps P1 tightly scoped to schema/identity and lets the display
+be verified against real rows produced by P2–P4.
+
+## RECOMMENDATION
+
+1. **P1:** add `source` (native `UUID`, nullable) + `identity` (`TEXT`, nullable) to the `Task`
+   model and `Task.columns` (`model.py:281`); add `Source.paths_for_ids` classmethod. Accept that
+   json/csv/`-x`/explicit-field surfaces now show raw UUID/md5 — correct for machine output.
+2. **P6 (owner of presentation):** add `format_source(path, *, relative=False)` to
+   `core/pretty_print.py`; add a resolved `source:` line to `NORMAL_MODE_TEMPLATE` (`task.py:1285`);
+   resolve in module `print_normal` (`task.py:1352`, single `from_id`) and in
+   `TaskSearchApp.print_normal` (`task.py:777`, one batched `paths_for_ids` per page passed via a
+   new optional `source_map` arg). **Do not** add `identity` to the normal template.
+3. Update the `docs/_include/*.rst` normal-output examples and any completion notes for the new
+   `source` line in the same P6 commit (§12 doc/completion lockstep).
+
+**Touchpoints (exact):** `src/hypershell/data/model.py:281` (columns) + new `Source.paths_for_ids`;
+`src/hypershell/core/pretty_print.py` (`format_source`, add to `__all__`);
+`src/hypershell/task.py:1285` (template line), `:1352` (module `print_normal`), `:777`
+(`TaskSearchApp.print_normal` batch resolve). No change to `print_json`/`print_csv`/`print_plain`/
+`print_table`/`print_field` — raw is intended there.
+
+## Open questions
+
+- **Relative-path flag now or later?** Recommend later; helper is ready either way.
+- **`--from-json` source `path = FILE[@node]`** (digest): `format_source` shows it verbatim; a real
+  path with an `@node` suffix isn't a normal filesystem path — confirm it reads acceptably (it does
+  not match `^<.*>$`, so it prints as-is; `relative=True` would misfire on the `@node` — treat
+  `@`-suffixed specs as opaque, i.e. never relativize).
+- **CSV/JSON default column growth:** adding two columns to `ALL_FIELDS` changes the default
+  `hs list --json/--csv` column set (additive keys/columns). Confirm no downstream parser assumes a
+  fixed column count; if it's a concern, that's a GOAL-level call, not a display bug.

--- a/spec/cli-cluster-restart-repeat-update/research/09-pruning-adversarial-check.md
+++ b/spec/cli-cluster-restart-repeat-update/research/09-pruning-adversarial-check.md
@@ -1,0 +1,139 @@
+# 09 — Adversarial check: UUIDv7 pruning + native-UUID schema + reserved-source rows
+
+Skeptical validation of the two maintainer corrections: (1) reserved `<direct>`/`<stdin>` become
+**real Source rows** and `Task.source` becomes a **native UUID** column; (2) **no TimescaleDB-specific
+code** — rely on a UUIDv7 `Source.id` so per-chunk/column min/max lets the planner prune the de-dup
+query. Verdict up front: **corrections 1 and 2 are the right shape, but the pruning argument as stated
+is only partially realizable and rests on preconditions the current code does not guarantee.** Native
+UUID is correct; the single small-IN de-dup is correct; the "skip most of the hypertable" claim needs
+softening and one dependency fix.
+
+## 1. Does native UUIDv7 + min/max stats prune `WHERE source IN (:lineage)` with no time predicate?
+
+Three candidate mechanisms; only one is clean-PG *and* UUID-capable:
+
+- **TimescaleDB native chunk exclusion** works only on the **partitioning (time) dimension** via each
+  chunk's CHECK constraint, and only when the query carries a predicate on that dimension. The de-dup
+  query has **no time predicate**, so native chunk exclusion never fires on `source`. (Mechanism does
+  not apply.)
+- **`enable_chunk_skipping()`** (TimescaleDB per-chunk min/max range stats for a *non*-partitioning
+  column) is exactly the mechanism the maintainer describes — **but it does NOT support `uuid`**. Per
+  the API docs it tracks min/max only for `smallint, int, bigint, serial, bigserial, date, timestamp,
+  timestamptz`; it applies **only to compressed/columnstore chunks**; and it is TimescaleDB-specific
+  DDL (forbidden here). So it **cannot** be the mechanism for a UUID `source`. (Verified: TigerData/
+  Timescale `enable_chunk_skipping` API reference, fetched 2026-07-11.)
+- **PostgreSQL BRIN** *does* have core operator classes for uuid — `uuid_minmax_ops`,
+  `uuid_minmax_multi_ops`, `uuid_bloom_ops` (verified: PG16 `brin-builtin-opclasses`, Table 71.1).
+  A BRIN `minmax`/`minmax_multi` index on `source` gives per-block-range min/max pruning of
+  `source = X` / `IN (...)` on a plain table **and on each TimescaleDB chunk** (a chunk is an ordinary
+  table). This is the only clean-PostgreSQL realization of the maintainer's min/max lever for a UUID
+  column, and it fires **without a time predicate**. TimescaleDB compressed chunks *also* keep implicit
+  per-batch (segment) min/max on ordered columns — same idea, config-only, no code.
+
+**What must be true for the lever to work:** (a) an actual min/max structure exists (BRIN index, or
+compressed per-batch stats) — a **plain B-tree does not prune by min/max**; and (b) physical/insert
+order is **correlated** with `Source.id` order, i.e. `Source.id` is genuinely time-ordered (UUIDv7)
+and tasks are appended in submission order. Under those two conditions the maintainer's "a source from
+this week sorts into recent heap ranges → old ranges have `max < X` → skipped" argument is **sound**.
+
+**Precondition gap (critical).** `core/uuid.py:8-11` uses `uuid_utils.uuid7` *only if importable*, else
+falls back to **`uuid.uuid4`** (random) — it does **not** even try stdlib `uuid.uuid7` (added in Python
+**3.14**; verified py3.14 `uuid` docs). And `uuid-utils` is **not** a runtime dependency — it lives only
+in the optional `uuid7` extra and the dev group (`pyproject.toml:59,67`; runtime `dependencies`
+`:30-38` omit it). So a default `pip install hypershell` on Python 3.11–3.13 mints **UUIDv4**, and the
+entire pruning premise silently degrades to random ids (no correlation → no min/max pruning). The
+de-dup query stays **correct** (a B-tree/BRIN still seeks by value) — only the optimization is lost.
+
+## 2. Reserved-source min-pinning concern — evaluated
+
+The concern is **real, but only under a min/max mechanism (BRIN or compressed per-batch stats), and
+only for the rare "query an ancient source" case.** Pruning `source = X` skips a range iff `X < min`
+OR `X > max`:
+
+- Ranges **older** than X (`max < X`): pruned via `X > max`. Reserved rows lower `min`, never `max`, so
+  **old ranges stay pruned regardless.** No harm.
+- Ranges **newer** than X (`min > X`): pruned via `X < min`. A range containing any `<direct>`/`<stdin>`
+  task has `min` pinned to the ancient reserved id `<< X`, so `X < min` is false → **newer range NOT
+  pruned.** This is the maintainer's concern, and it is **correct.**
+
+**When it bites:** querying an **old** source in a DB with much newer data — many newer chunks each
+carry a reserved-source task → most aren't pruned → near-full scan. **When harmless:** the actual
+use case (`--restart`/`--update`/requeue) queries a **recent** source, so there are **few chunks newer
+than X** — the un-pruned set is tiny. Note the reserved rows are **not the only** min-polluter: retries
+(new rows with an *old* `source`, `model.py:555`) and interleaved concurrent submissions pollute the
+same way. So this is an inherent property of correlation pruning, not a reserved-row-specific bug.
+
+**Mitigation decision: accept + one cheap object-model change; do NOT add TSDB code.** Recommend the
+de-dup index be **partial, excluding the two reserved sources** — reserved tasks are de-dup-exempt
+(never queried) and high-volume, so excluding them shrinks the index *and* removes their min-pollution
+if BRIN is ever used. **But** a static partial predicate can only name the reserved ids if they are
+**deterministic constants** — random `uuid7()` reserved ids are unknown at class-definition time.
+Therefore: **give the two reserved Source rows fixed, well-known UUID constants** (e.g. hardcoded
+`0000…0001`/`0000…0002` or `uuid5` in a hypershell namespace) rather than random uuid7. This also makes
+lazy get-or-create idempotent by primary key (`Source.from_id(DIRECT_ID)` else create) with no path
+lookup, and takes reserved rows out of the min/max discussion entirely. If BRIN is adopted, prefer
+`uuid_minmax_multi_ops` (multi-range — designed to tolerate a handful of outlier values). Otherwise
+document an operator note: de-dup is optimized for re-submitting *recent* files; de-dup against an
+ancient source is a rare full-history scan.
+
+## 3. Schema / strategy confirmations
+
+- **`Task.source` = native `UUID` (the shared `UUID` type at `model.py:75`), NOT TEXT — CONFIRMED.**
+  Now that reserved sources are real rows with real UUIDs, no sentinel string is ever stored, so
+  `POSTGRES_UUID(as_uuid=False)` is correct. Nullable for historical rows. `Source.id` likewise `UUID`
+  (uuid7 for real files, fixed const for reserved). The shared `uuid()` returns `str`, matching the
+  `as_uuid=False` (string-valued) convention of every existing UUID column (`model.py:240,244,254,…`).
+  A python `list[str]` binds cleanly into `source IN (...)` on both sqlite (TEXT) and pg (native) — no
+  text↔uuid cast issue (this retires brief-03's cast worry).
+- **`index_tasks_source (source, identity)` — still right** as the primary de-dup/R7 index (B-tree).
+  It already makes de-dup cost scale with **lineage matches + chunk count, not total rows** (one value
+  seek per chunk) → **R17 is satisfied by the B-tree alone**, independent of uuid7. UUIDv7 adds
+  right-edge insert locality (less page-split/WAL) and *enables* the optional BRIN/compressed pruning
+  lever; it does not change the B-tree plan shape. Make this index **partial excluding the reserved
+  UUIDs** (now possible with fixed consts).
+- **De-dup = single small-IN query (strategy a) — CONFIRMED; drop batching/temp-table.** Lineage =
+  the small set of Source rows sharing a path (prior submissions of one file, typically < 100), so the
+  IN-list is small; `SELECT identity FROM task WHERE source IN (:lineage)` returns one file-history's
+  identities, held in memory. Brief-03 strategies (c) batched anti-join / (d) temp-table and the
+  "~150 MB/1M ids, grows every generation" hardening are **no longer needed** — remove them.
+
+## 4. Stale items to edit (corrections 1 + 2)
+
+**PLAN.md:** §2 `Task.source` TEXT→`UUID` native; drop the "sentinel/TEXT" rationale (`:29-31`).
+`Source` + reserved: real rows via lazy get-or-create with **fixed const UUIDs** holding
+`<direct>`/`<stdin>` in `path` (`:23-27`); R3 map row (`:100`) reserved-row not string-sentinel.
+Deviation table: **delete** the "Task.source typed TEXT not UUID" row (`:146`) — it is reversed; drop
+the "(c)/(d) deferred" deviation (`:147`). Rabbit hole "Sentinel sources on postgres → must be TEXT"
+(`:159`) reversed. Risks (`:171-176`): rewrite TSDB bullet per §1/§2 here (enable_chunk_skipping ≠ uuid;
+BRIN/compressed as the real lever; reserved-source pollution accepted+documented) and reframe de-dup
+memory (lineage-bounded, no c/d). **Add** a presentation-layer element: `hs list/info/search` must
+resolve `Task.source` UUID → `Source.path` (abs/rel) or the reserved sentinel (`task.py`
+`ALL_FIELDS`/field rendering `:169,:206-209,:434,:541-548`).
+
+**00-digest.md:** Schema section (`:39-44`) — native UUID; reserved = real rows w/ fixed uuids; gating
+tests membership in the two reserved ids (not `^<.*>$` on a string). De-dup (`:59-65`) — single small-IN,
+delete c/d + 150 MB note. Residual risks (`:124-130`) — rewrite TSDB + memory bullets; add
+presentation-resolution decision.
+
+**02-source-schema.md:** reverse the whole "must be TEXT" decision (`:41-50`,`:80`) and reserved-source
+representation (`:87-89`) to native UUID + real rows; `Source.id` uuid7/reserved-const note.
+
+**03-scale-indexing.md:** reverse "declare `Task.source`/`Source.id` as TEXT" (`:41-44`) to native UUID;
+partial-index predicate (`:66`) must use the fixed reserved UUIDs, not strings; rewrite the de-dup
+recommendation (`:78-98`) to lock strategy (a) single small-IN (drop the "RECOMMEND (c)"); rewrite the
+TSDB caveat (`:100-106`) per §1 (enable_chunk_skipping/uuid limits + BRIN uuid_minmax_multi_ops).
+
+**Also flag (new):** the uuid7 precondition. Either (a) improve `core/uuid.py` fallback to prefer
+stdlib `uuid.uuid7` on py3.14 before uuid4, and/or (b) promote `uuid-utils` from the `uuid7` extra to a
+runtime dep (weigh against EPEL floor policy — uuid-utils is a Rust/maturin wheel, unlikely in EPEL).
+Until then, treat time-ordering (hence min/max pruning) as **best-effort optimization**, never a
+correctness requirement — the B-tree de-dup is correct under uuid4.
+
+## Open questions
+
+1. Adopt an explicit **BRIN `uuid_minmax_multi_ops`** index on `source` to make the pruning lever real
+   in plain PostgreSQL, or lean solely on TimescaleDB's implicit compressed per-batch min/max? (BRIN is
+   standard PG, not TSDB code, but adds an index + correlation dependency.)
+2. Reserved UUIDs: hardcoded constants vs `uuid5(namespace, '<direct>')`? Either is deterministic; both
+   enable the partial index.
+3. uuid7 dependency decision (extra vs runtime vs stdlib-preferring fallback) — owner: packaging.

--- a/src/hypershell/cluster/__init__.py
+++ b/src/hypershell/cluster/__init__.py
@@ -369,13 +369,13 @@ class ClusterApp(Application):
         if self.forever_mode and self.restart_mode:
             raise ArgumentError('Using --forever with --restart is invalid')
         if self.update_mode and self.repeat_mode:
-            raise ArgumentError('Cannot combine --update with --repeat')  # R16
+            raise ArgumentError('Cannot combine --update with --repeat')
         if self.restart_mode and self.repeat_mode:
             raise ArgumentError('Cannot combine --restart with --repeat')  # resume vs. fresh full run
         if self.update_mode and self.in_memory:
             raise ArgumentError('Using --update with --no-db is invalid')
         if self.update_mode and not (self.restart_mode or self.repeat_mode):
-            raise ArgumentError('Using --update requires --restart')  # R13 (ambiguous on its own)
+            raise ArgumentError('Using --update requires --restart')  # --update alone is ambiguous.
         if self.ssh_args and not self.ssh_mode:
             raise ArgumentError('Unexpected --ssh-args when not in --ssh mode')
         if self.ssh_group and self.ssh_mode != '<default>':
@@ -477,17 +477,17 @@ class ClusterApp(Application):
         """Resolve the task Source, apply the re-submission gate, and wrap the stream.
 
         Mirrors :meth:`hypershell.submit.SubmitApp.prepare_source` for the cluster entry
-        point. A named file passes through :func:`~hypershell.submit.apply_source_gate`
-        (matrix R11-R15): a duplicate or changed-content re-submission is refused unless
+        point. A named file passes through :func:`~hypershell.submit.apply_source_gate`:
+        a duplicate or changed-content re-submission is refused unless
         ``--restart``/``--repeat``/``--update`` relaxes it, and the resolved :class:`Source`
-        records the upfront-counted expectation *before* any task is scheduled (R1/R7).
+        records the upfront-counted expectation *before* any task is scheduled.
         Explicit ``<stdin>`` and non-seekable inputs carry the reserved ``<stdin>`` source and
-        are exempt (R3); ``--no-db``/non-persistent runs gate nothing (invariant §4).
+        are exempt; ``--no-db``/non-persistent runs gate nothing (invariant §4).
 
         The upfront count uses ``DEFAULT_TEMPLATE`` (not ``--template``): the cluster expands
         the user template client-side, so the server ingests raw lines verbatim and the
         count must mirror that split (see :class:`~hypershell.server.ServerThread`). The
-        stable per-task fingerprint is template-independent by construction (R2), so the
+        stable per-task fingerprint is template-independent by construction, so the
         de-dup set matches whether tasks were first ingested by ``hs submit`` or ``hsx``.
         """
         if self.in_memory or not DATABASE_ENABLED:
@@ -495,7 +495,7 @@ class ClusterApp(Application):
         if stream is sys.stdin or not stream.seekable():
             # Explicit <stdin> and non-seekable named inputs (process substitution, FIFOs,
             # a piped /dev/stdin) cannot be re-read for an upfront count — stream them under
-            # the reserved <stdin> source, exempt from gating (R3). A re-read would drain them.
+            # the reserved <stdin> source, exempt from gating. A re-read would drain them.
             self.warn_gating_no_effect('<stdin>')
             source_id = Source.reserved(STDIN_SOURCE_ID).id
             name = '<stdin>' if stream is sys.stdin else os.path.abspath(self.filepath)
@@ -510,12 +510,12 @@ class ClusterApp(Application):
     def prepare_json_source(self: ClusterApp) -> Iterable[dict]:
         """Resolve the Source and apply the re-submission gate to a ``--from-json`` source.
 
-        The JSON analogue of :meth:`prepare_source` (matrix R11-R15): the file's content md5
+        The JSON analogue of :meth:`prepare_source`: the file's content md5
         and record count feed :func:`~hypershell.submit.apply_source_gate`, keyed by
         ``abspath(FILE)[@node]`` so distinct node selections are distinct sources. The
-        per-task fingerprint keys off the pre-template ``args``/tags (R2), so de-dup matches
+        per-task fingerprint keys off the pre-template ``args``/tags, so de-dup matches
         whether the tasks were first ingested by ``hs submit`` or ``hsx``. ``--from-json -``
-        (stdin JSON) carries the reserved ``<stdin>`` source and is exempt (R3);
+        (stdin JSON) carries the reserved ``<stdin>`` source and is exempt;
         ``--no-db``/non-persistent runs gate nothing (invariant §4).
         """
         records, fingerprint = self.json_source
@@ -532,7 +532,7 @@ class ClusterApp(Application):
         return GatedSource(records, source_id, skip_fingerprints=skip, name=key)
 
     def warn_gating_no_effect(self: ClusterApp, kind: str) -> None:
-        """Note that re-submission gating flags are inert for exempt sources (R3)."""
+        """Note that re-submission gating flags are inert for exempt sources."""
         if self.repeat_mode or self.update_mode:
             log.warning(f'--repeat/--update have no effect for {kind} submissions')
 

--- a/src/hypershell/cluster/__init__.py
+++ b/src/hypershell/cluster/__init__.py
@@ -10,6 +10,7 @@ from typing import Dict, IO, Optional, Iterable, Callable, Type
 from types import TracebackType
 
 # Standard libs
+import os
 import sys
 import shlex
 from functools import cached_property
@@ -25,10 +26,12 @@ from hypershell.core.types import parse_bytes
 from hypershell.core.logging import Logger
 from hypershell.core.template import DEFAULT_TEMPLATE
 from hypershell.core.exceptions import get_shared_exception_mapping
-from hypershell.data import initdb, checkdb, DATABASE_DIALECT
+from hypershell.data import initdb, checkdb, DATABASE_DIALECT, DATABASE_ENABLED
+from hypershell.data.model import Source, STDIN_SOURCE_ID
 from hypershell.client import DEFAULT_NUM_THREADS, DEFAULT_DELAY, DEFAULT_SIGNALWAIT
 from hypershell.server import DEFAULT_BUNDLESIZE, DEFAULT_ATTEMPTS, DEFAULT_SERVER_POLL, DEFAULT_PORT
-from hypershell.submit import DEFAULT_BUNDLEWAIT, load_json_tasks, validate_json_expansion
+from hypershell.submit import (DEFAULT_BUNDLEWAIT, load_json_tasks, validate_json_expansion,
+                               GatedSource, source_fingerprint_and_count, apply_source_gate)
 from hypershell.cluster.ssh import run_ssh, SSHCluster, NodeList, DEFAULT_REMOTE_EXE
 from hypershell.cluster.local import run_local, LocalCluster
 from hypershell.cluster.remote import (run_cluster, RemoteCluster, AutoScalingCluster,
@@ -50,8 +53,8 @@ log = Logger.with_name(__name__)
 APP_NAME = 'hs cluster'
 APP_USAGE = """\
 Usage:
-  hs cluster [-h] [FILE | --from-json SPEC | --restart | --forever] [-N NUM] [-t CMD] [-b SIZE] [-w SEC] [-c NUM] [-m MEM] [-W SEC]
-             [--initdb | --no-db [--no-confirm]] [-d SEC] [-T SEC] [-C NUM] [-M MEM] [-S SEC] [-R NUM] [-Q NUM]
+  hs cluster [-h] [FILE | --from-json SPEC | --restart | --forever] [--repeat | --update] [-N NUM] [-t CMD] [-b SIZE] [-w SEC]
+             [-c NUM] [-m MEM] [-W SEC] [--initdb | --no-db [--no-confirm]] [-d SEC] [-T SEC] [-C NUM] [-M MEM] [-S SEC] [-R NUM] [-Q NUM]
              [-H ADDR] [-p PORT] [-r NUM [--eager]] [-f PATH] [--capture | [-o PATH] [-e PATH]] [--monitor]
              [--ssh [HOST... | --ssh-group NAME] [--env] | --mpi | --launcher=ARGS...]
              [--autoscaling [MODE] [-P SEC] [-F VALUE] [-I NUM] [-X NUM] [-Y NUM]]
@@ -86,6 +89,8 @@ Options:
       --no-confirm              Disable client confirmation of task bundle received.
       --forever                 Schedule forever.
       --restart                 Start scheduling from last completed task.
+      --repeat                  Re-submit a known file's tasks again as a new source.
+      --update                  Submit only tasks not already present from a known file.
       --ssh-args       ARGS     Command-line arguments for SSH.
       --ssh-group      NAME     SSH nodelist group in config.
   -E, --env                     Send environment variables.
@@ -169,6 +174,12 @@ class ClusterApp(Application):
 
     restart_mode: bool = False
     interface.add_argument('--restart', action='store_true', dest='restart_mode')
+
+    repeat_mode: bool = False
+    interface.add_argument('--repeat', action='store_true', dest='repeat_mode')
+
+    update_mode: bool = False
+    interface.add_argument('--update', action='store_true', dest='update_mode')
 
     ssh_mode: str = None
     mpi_mode: bool = False
@@ -359,6 +370,14 @@ class ClusterApp(Application):
             raise ArgumentError('Using --restart with --no-db is invalid')
         if self.forever_mode and self.restart_mode:
             raise ArgumentError('Using --forever with --restart is invalid')
+        if self.update_mode and self.repeat_mode:
+            raise ArgumentError('Cannot combine --update with --repeat')  # R16
+        if self.restart_mode and self.repeat_mode:
+            raise ArgumentError('Cannot combine --restart with --repeat')  # resume vs. fresh full run
+        if self.update_mode and self.in_memory:
+            raise ArgumentError('Using --update with --no-db is invalid')
+        if self.update_mode and not (self.restart_mode or self.repeat_mode):
+            raise ArgumentError('Using --update requires --restart')  # R13 (ambiguous on its own)
         if self.ssh_args and not self.ssh_mode:
             raise ArgumentError('Unexpected --ssh-args when not in --ssh mode')
         if self.ssh_group and self.ssh_mode != '<default>':
@@ -420,11 +439,16 @@ class ClusterApp(Application):
 
     @cached_property
     def input_stream(self: ClusterApp) -> Optional[IO]:
-        """IO stream to read task command-line args."""
-        if self.restart_mode or self.from_json:
+        """IO stream to read task command-line args.
+
+        ``None`` for ``--from-json`` (records are read separately) and for a bare
+        ``--restart`` with no file (a pure database resume). A named file is opened here
+        even under ``--restart``/``--repeat``/``--update`` — the file becomes the gated task
+        source (see :meth:`source`).
+        """
+        if self.from_json or self.filepath is None:
             return None
-        else:
-            return sys.stdin if self.filepath == '-' else open(self.filepath, mode='r')
+        return sys.stdin if self.filepath == '-' else open(self.filepath, mode='r')
 
     @cached_property
     def json_records(self: ClusterApp) -> list:
@@ -433,12 +457,57 @@ class ClusterApp(Application):
 
     @cached_property
     def source(self: ClusterApp) -> Iterable[str | dict]:
-        """Input source for task command-line args (or JSON records with --from-json)."""
-        if self.restart_mode:
-            return []
+        """Input source for task command-line args (or JSON records with --from-json).
+
+        A bare ``--restart`` (no file) yields an empty source — a pure database resume
+        driven by the server's revert-interrupted flow. A named file (with or without
+        ``--restart``/``--repeat``/``--update``) is run through the re-submission gate and
+        wrapped as a :class:`~hypershell.submit.GatedSource`; ``--from-json`` is ungated here.
+        """
         if self.from_json:
             return self.json_records
-        return self.input_stream
+        if self.filepath is None:
+            return []  # bare --restart: resume scheduling from the database
+        return self.prepare_source(self.input_stream)
+
+    def prepare_source(self: ClusterApp, stream: IO) -> Iterable[str | dict]:
+        """Resolve the task Source, apply the re-submission gate, and wrap the stream.
+
+        Mirrors :meth:`hypershell.submit.SubmitApp.prepare_source` for the cluster entry
+        point. A named file passes through :func:`~hypershell.submit.apply_source_gate`
+        (matrix R11-R15): a duplicate or changed-content re-submission is refused unless
+        ``--restart``/``--repeat``/``--update`` relaxes it, and the resolved :class:`Source`
+        records the upfront-counted expectation *before* any task is scheduled (R1/R7).
+        Explicit ``<stdin>`` and non-seekable inputs carry the reserved ``<stdin>`` source and
+        are exempt (R3); ``--no-db``/non-persistent runs gate nothing (invariant §4).
+
+        The upfront count uses ``DEFAULT_TEMPLATE`` (not ``--template``): the cluster expands
+        the user template client-side, so the server ingests raw lines verbatim and the
+        count must mirror that split (see :class:`~hypershell.server.ServerThread`). The
+        stable per-task fingerprint is template-independent by construction (R2), so the
+        de-dup set matches whether tasks were first ingested by ``hs submit`` or ``hsx``.
+        """
+        if self.in_memory or not DATABASE_ENABLED:
+            return stream  # no persistent database to gate against (invariant §4)
+        if stream is sys.stdin or not stream.seekable():
+            # Explicit <stdin> and non-seekable named inputs (process substitution, FIFOs,
+            # a piped /dev/stdin) cannot be re-read for an upfront count — stream them under
+            # the reserved <stdin> source, exempt from gating (R3). A re-read would drain them.
+            self.warn_gating_no_effect('<stdin>')
+            source_id = Source.reserved(STDIN_SOURCE_ID).id
+            name = '<stdin>' if stream is sys.stdin else os.path.abspath(self.filepath)
+            return GatedSource(stream, source_id, name=name)
+        path = os.path.abspath(self.filepath)
+        fingerprint, count = source_fingerprint_and_count(path)  # DEFAULT_TEMPLATE (raw-line split)
+        log.info(f'Found {count} tasks in {path} (md5={fingerprint})')
+        source_id, skip = apply_source_gate(path, fingerprint, count, repeat=self.repeat_mode,
+                                            update=self.update_mode, restart=self.restart_mode)
+        return GatedSource(stream, source_id, skip_fingerprints=skip, name=path)
+
+    def warn_gating_no_effect(self: ClusterApp, kind: str) -> None:
+        """Note that re-submission gating flags are inert for exempt sources (R3)."""
+        if self.repeat_mode or self.update_mode:
+            log.warning(f'--repeat/--update have no effect for {kind} submissions')
 
     def __enter__(self: ClusterApp) -> ClusterApp:
         """Set up resources and attributes."""

--- a/src/hypershell/cluster/__init__.py
+++ b/src/hypershell/cluster/__init__.py
@@ -6,7 +6,7 @@
 
 # Type annotations
 from __future__ import annotations
-from typing import Dict, IO, Optional, Iterable, Callable, Type
+from typing import Dict, IO, Optional, Iterable, Callable, Type, Tuple
 from types import TracebackType
 
 # Standard libs
@@ -30,7 +30,7 @@ from hypershell.data import initdb, checkdb, DATABASE_DIALECT, DATABASE_ENABLED
 from hypershell.data.model import Source, STDIN_SOURCE_ID
 from hypershell.client import DEFAULT_NUM_THREADS, DEFAULT_DELAY, DEFAULT_SIGNALWAIT
 from hypershell.server import DEFAULT_BUNDLESIZE, DEFAULT_ATTEMPTS, DEFAULT_SERVER_POLL, DEFAULT_PORT
-from hypershell.submit import (DEFAULT_BUNDLEWAIT, load_json_tasks, validate_json_expansion,
+from hypershell.submit import (DEFAULT_BUNDLEWAIT, load_json_source, json_source_key, validate_json_expansion,
                                GatedSource, source_fingerprint_and_count, apply_source_gate)
 from hypershell.cluster.ssh import run_ssh, SSHCluster, NodeList, DEFAULT_REMOTE_EXE
 from hypershell.cluster.local import run_local, LocalCluster
@@ -349,8 +349,6 @@ class ClusterApp(Application):
         if self.from_json:
             if given_filepath:
                 raise ArgumentError('Cannot combine --from-json with a positional task file')
-            if self.restart_mode:
-                raise ArgumentError('Cannot combine --from-json with --restart')
             validate_json_expansion(self.json_records, self.template)
         elif self.filepath is None and not self.restart_mode:
             self.filepath = '-'  # NOTE: assume STDIN
@@ -451,21 +449,26 @@ class ClusterApp(Application):
         return sys.stdin if self.filepath == '-' else open(self.filepath, mode='r')
 
     @cached_property
+    def json_source(self: ClusterApp) -> Tuple[list, Optional[str]]:
+        """Task records and content md5 from the --from-json spec (file read once)."""
+        return load_json_source(self.from_json)
+
+    @cached_property
     def json_records(self: ClusterApp) -> list:
         """Task records loaded from the --from-json spec (read once)."""
-        return load_json_tasks(self.from_json)
+        return self.json_source[0]
 
     @cached_property
     def source(self: ClusterApp) -> Iterable[str | dict]:
         """Input source for task command-line args (or JSON records with --from-json).
 
         A bare ``--restart`` (no file) yields an empty source — a pure database resume
-        driven by the server's revert-interrupted flow. A named file (with or without
-        ``--restart``/``--repeat``/``--update``) is run through the re-submission gate and
-        wrapped as a :class:`~hypershell.submit.GatedSource`; ``--from-json`` is ungated here.
+        driven by the server's revert-interrupted flow. A named file or ``--from-json``
+        source (with or without ``--restart``/``--repeat``/``--update``) is run through the
+        re-submission gate and wrapped as a :class:`~hypershell.submit.GatedSource`.
         """
         if self.from_json:
-            return self.json_records
+            return self.prepare_json_source()
         if self.filepath is None:
             return []  # bare --restart: resume scheduling from the database
         return self.prepare_source(self.input_stream)
@@ -503,6 +506,30 @@ class ClusterApp(Application):
         source_id, skip = apply_source_gate(path, fingerprint, count, repeat=self.repeat_mode,
                                             update=self.update_mode, restart=self.restart_mode)
         return GatedSource(stream, source_id, skip_fingerprints=skip, name=path)
+
+    def prepare_json_source(self: ClusterApp) -> Iterable[dict]:
+        """Resolve the Source and apply the re-submission gate to a ``--from-json`` source.
+
+        The JSON analogue of :meth:`prepare_source` (matrix R11-R15): the file's content md5
+        and record count feed :func:`~hypershell.submit.apply_source_gate`, keyed by
+        ``abspath(FILE)[@node]`` so distinct node selections are distinct sources. The
+        per-task fingerprint keys off the pre-template ``args``/tags (R2), so de-dup matches
+        whether the tasks were first ingested by ``hs submit`` or ``hsx``. ``--from-json -``
+        (stdin JSON) carries the reserved ``<stdin>`` source and is exempt (R3);
+        ``--no-db``/non-persistent runs gate nothing (invariant §4).
+        """
+        records, fingerprint = self.json_source
+        if self.in_memory or not DATABASE_ENABLED:
+            return records  # no persistent database to gate against (invariant §4)
+        key = json_source_key(self.from_json)
+        if key is None:
+            self.warn_gating_no_effect('<stdin>')
+            source_id = Source.reserved(STDIN_SOURCE_ID).id
+            return GatedSource(records, source_id, name='<stdin>')
+        log.info(f'Found {len(records)} tasks in {key} (md5={fingerprint})')
+        source_id, skip = apply_source_gate(key, fingerprint, len(records), repeat=self.repeat_mode,
+                                            update=self.update_mode, restart=self.restart_mode)
+        return GatedSource(records, source_id, skip_fingerprints=skip, name=key)
 
     def warn_gating_no_effect(self: ClusterApp, kind: str) -> None:
         """Note that re-submission gating flags are inert for exempt sources (R3)."""

--- a/src/hypershell/core/pretty_print.py
+++ b/src/hypershell/core/pretty_print.py
@@ -8,13 +8,15 @@
 from __future__ import annotations
 
 # Standard libs
+import os
+import re
 import json
 
 # Internal libs
 from hypershell.core.types import JSONData, to_json_type
 
 # Public interface
-__all__ = ['format_bytes', 'format_tag', 'format_json']
+__all__ = ['format_bytes', 'format_tag', 'format_json', 'format_source']
 
 
 def format_bytes(size: float) -> str:
@@ -45,3 +47,18 @@ def format_json(value: JSONData) -> str:
     if result.startswith('"') and result.endswith('"'):
         result = result[1:-1]
     return result.replace('\\"', '"')
+
+
+def format_source(path: str, *, relative: bool = False) -> str:
+    """Pretty-print a task source (resolved `Source.path`) for humans.
+
+    Reserved sentinels (``<direct>``/``<stdin>``, matching ``^<.*>$``) pass through
+    unchanged. Real filesystem paths are shown as stored (absolute) unless `relative`,
+    in which case they are made relative to the current directory. A ``--from-json``
+    spec carrying an ``@node`` suffix is opaque and is never relativized.
+    """
+    if re.match(r'^<.*>$', path):
+        return path
+    if relative and '@' not in path:
+        return os.path.relpath(path)
+    return path

--- a/src/hypershell/data/core.py
+++ b/src/hypershell/data/core.py
@@ -23,11 +23,14 @@ from sqlalchemy import event
 
 # Internal libs
 from hypershell.core.config import config, DEFAULT_DATABASE_FILE
-from hypershell.core.logging import stream_handler
+from hypershell.core.logging import Logger, stream_handler
 from hypershell.core.exceptions import display_critical, write_traceback
 
 # Public interface
 __all__ = ['DatabaseURL', 'engine', 'Session', 'config', 'in_memory', 'schema', 'providers']
+
+# Initialize logger
+log = Logger.with_name(__name__)
 
 
 class DatabaseURL(dict):
@@ -175,7 +178,14 @@ providers = {
     'sqlite': 'sqlite',
     'postgres': 'postgresql+psycopg',
     'postgresql': 'postgresql+psycopg',
+    'timescale': 'postgresql+psycopg',
+    'timescaledb': 'postgresql+psycopg',
 }
+
+# TimescaleDB is PostgreSQL under the hood; these aliases route to the postgres backend but
+# additionally gate the optional `uuid7` extra (below) so `uuid()` yields a time-ordered
+# UUIDv7 for Source.id — the lever TimescaleDB compression uses to prune chunks at scale.
+TIMESCALE_ALIASES = ('timescale', 'timescaledb')
 
 
 # Parse full configuration into local copy and allow for simple config
@@ -212,6 +222,17 @@ if config.provider == 'turso':
         sys.exit(exit_status.runtime_error)
 
 
+if config.provider in TIMESCALE_ALIASES:
+    try:
+        import uuid_utils  # noqa: F401 (guarantees uuid() -> UUIDv7 for a time-ordered Source.id)
+    except ImportError:
+        display_critical('Missing optional dependency "uuid-utils" (the "uuid7" extra) needed for TimescaleDB',
+                         module=__name__)
+        sys.exit(exit_status.runtime_error)
+    log.warning('TimescaleDB provider selected: automatic hypertable management (post-create_all hook) '
+                'is not yet implemented — the schema is created as plain PostgreSQL tables')
+
+
 def get_url() -> DatabaseURL | str:
     """Wraps parsing within function."""
     if 'url' in config:
@@ -224,7 +245,7 @@ def get_url() -> DatabaseURL | str:
         raise ConfigurationError(f'Unsupported database \'{config.provider}\'')
     try:
         params = Namespace({**config, 'provider': providers[config.provider]})
-        if config.provider == 'postgres' and config.file == DEFAULT_DATABASE_FILE:
+        if config.provider in ('postgres', *TIMESCALE_ALIASES) and config.file == DEFAULT_DATABASE_FILE:
             params.pop('file', None)  # Injected automatically from preload
         return DatabaseURL.from_namespace(params)
     except AttributeError as err:

--- a/src/hypershell/data/model.py
+++ b/src/hypershell/data/model.py
@@ -11,6 +11,7 @@ from typing import List, Dict, Tuple, Any, Type, Optional, Final
 # Standard libs
 import re
 import json
+import hashlib
 from datetime import datetime
 from dataclasses import dataclass
 
@@ -32,9 +33,9 @@ from hypershell.data.core import schema, Session
 
 # Public interface
 __all__ = [
-    'Task', 'Client', 'Entity', 'to_json_type', 'from_json_type', 'serialize_tasks', 'deserialize_tasks',
+    'Task', 'Client', 'Source', 'Entity', 'to_json_type', 'from_json_type', 'serialize_tasks', 'deserialize_tasks',
     'UUID', 'TEXT', 'INTEGER', 'SMALL_INTEGER', 'DATETIME', 'BOOLEAN', 'JSON',
-    'DEFAULT_TASK_GROUP', 'CANCEL_STATUS', 'TaskGroupInfo',
+    'DEFAULT_TASK_GROUP', 'CANCEL_STATUS', 'DIRECT_SOURCE_ID', 'STDIN_SOURCE_ID', 'TaskGroupInfo',
 ]
 
 # Initialize logger
@@ -52,6 +53,24 @@ A cancelled task is terminal: it must never be scheduled, retried, or counted as
 unrecoverable failure. It is distinguished from a genuine failure (positive exit codes,
 or the negative template/resource sentinels in `client.py`) solely by this value, so the
 scheduler's failure and retry queries filter it out explicitly.
+"""
+
+DIRECT_SOURCE_ID: Final[str] = '00000000-0000-7000-8000-000000000000'
+"""Reserved `Source` id for single command-line submissions (`hs submit '<cmd>'`)."""
+
+STDIN_SOURCE_ID: Final[str] = '00000000-0000-7000-8000-000000000001'
+"""Reserved `Source` id for streamed/stdin submissions."""
+
+RESERVED_SOURCE_PATHS: Final[Dict[str, str]] = {
+    DIRECT_SOURCE_ID: '<direct>',
+    STDIN_SOURCE_ID: '<stdin>',
+}
+"""Sentinel `path` values for the reserved source rows (see `Source.reserved`).
+
+The reserved sources are real rows with fixed, well-known UUIDv7 ids (zero timestamp,
+so they sort low and never raise a chunk's max) — this keeps `Task.source` a native UUID
+and lets them be statically excluded from the de-dup index. Both represent explicit user
+intent and are exempt from all re-submission gating.
 """
 
 
@@ -278,6 +297,9 @@ class Task(Entity):
 
     tag: Mapped[dict] = mapped_column(JSON, nullable=False, default={})
 
+    source: Mapped[Optional[str]] = mapped_column(UUID, nullable=True)  # Source.id or reserved-const id
+    fingerprint: Mapped[Optional[str]] = mapped_column(TEXT, nullable=True)  # stable identity (R2)
+
     columns = {
         'id': str,
         'group': int,
@@ -309,6 +331,8 @@ class Task(Entity):
         'previous_id': str,
         'next_id': str,
         'tag': dict,
+        'source': str,
+        'fingerprint': str,
     }
 
     class NotFound(NotFound):
@@ -339,12 +363,21 @@ class Task(Entity):
             group: int = DEFAULT_TASK_GROUP,
             strict_tag: bool = True,
             parse_inline: bool = True,
+            raw_args: str = None,
+            fingerprint: str = None,
+            source: str = None,
             **other: Any) -> Task:
         """Create a new Task.
 
         With ``strict_tag=False`` the tag character-set/length checks are relaxed
         (for JSON-sourced tags). With ``parse_inline=False`` the inline
         ``# HYPERSHELL:`` tag comment is not parsed and `args` is taken verbatim.
+
+        The stable identity ``fingerprint`` (R2) is computed from the pre-template
+        ``raw_args`` (falling back to the expanded ``args`` when not supplied) plus the
+        resolved group and tags, unless ``fingerprint`` is passed directly (retries copy
+        the parent's). ``source`` links the task to its ingested file's ``Source`` record
+        (R3); both columns are NULL only for historical/ungated rows.
         """
         cls.ensure_valid_tag(tag, strict=strict_tag)
         if parse_inline:
@@ -360,9 +393,37 @@ class Task(Entity):
         memory = tag.pop('memory', other.get('memory', None))
         other['memory'] = parse_bytes(memory) if isinstance(memory, str) else memory
         other['timeout'] = tag.pop('timeout', other.get('timeout', None))
-        return Task(id=uuid(), args=args,
+        if fingerprint is None:
+            if raw_args is None:
+                raw_command = args
+            elif parse_inline:
+                raw_command = cls.split_argline(raw_args)[0]
+            else:
+                raw_command = str(raw_args).strip()
+            fingerprint = cls.compute_fingerprint(raw_command, other['group'], tag)
+        return Task(id=uuid(), args=args, source=source, fingerprint=fingerprint,
                     submit_id=INSTANCE, submit_host=HOSTNAME, submit_time=datetime.now().astimezone(),
                     attempt=attempt, retried=retried, tag=tag, **other)
+
+    @classmethod
+    def compute_fingerprint(cls: Type[Task], raw_command: str, group: int,
+                            tags: Optional[Dict[str, JSONData]]) -> str:
+        """Stable, order-independent identity fingerprint (R2).
+
+        An md5 over canonical JSON of the pre-template ``raw_command``, the task
+        ``group``, and user ``tags`` (the bookkeeping ``part`` tag excluded; resource
+        knobs are already popped from the tag dict before this is called). The uuid,
+        attempt/retry counters, timing, exit status, and execution template deliberately
+        do not participate — re-running the same work under a different template yields
+        the same fingerprint. MD5 matches the SOURCE content fingerprint and is stdlib.
+        """
+        payload = json.dumps(
+            {'args': raw_command,
+             'group': group,
+             'tags': {key: value for key, value in (tags or {}).items() if key != 'part'}},
+            sort_keys=True, separators=(',', ':'), ensure_ascii=False,
+        )
+        return hashlib.md5(payload.encode()).hexdigest()
 
     @classmethod
     def split_argline(cls: Type[Task], args: str) -> Tuple[str, Dict[str, JSONData]]:
@@ -560,7 +621,9 @@ class Task(Entity):
                                  attempt=task.attempt + 1,
                                  previous_id=task.id,
                                  tag=task.tag,
-                                 group=task.group)
+                                 group=task.group,
+                                 fingerprint=task.fingerprint,  # a retry is the same logical task (R2)
+                                 source=task.source)            # keep the chain linked to its source (R3)
                          for task in failed_tasks]
             tasks.extend(new_tasks)
             cls.add_all(tasks)
@@ -758,10 +821,37 @@ class Task(Entity):
         else:
             return None
 
+    @classmethod
+    def count_for_source(cls: Type[Task], source_id: str) -> int:
+        """Count tasks stamped with the given `source_id` (R7 completeness check)."""
+        return cls.query().filter(cls.source == source_id).count()
+
+    @classmethod
+    def fingerprints_for_sources(cls: Type[Task], source_ids: List[str]) -> set[str]:
+        """Set of task identity fingerprints across the given `source_ids` (de-dup skip-set).
+
+        The de-dup scope is a same-path source lineage (R9/R12/R14) — a small set of
+        sources — so this is a bounded, index-backed scan (`index_tasks_source`), not a
+        walk of the whole task table.
+        """
+        if not source_ids:
+            return set()
+        rows = (cls.query(cls.fingerprint)
+                .filter(cls.source.in_(set(source_ids)))
+                .filter(cls.fingerprint.isnot(None))
+                .distinct()
+                .all())
+        return {row[0] for row in rows}
+
 
 # Indices for efficient queries
 index_tasks_unscheduled = Index('index_tasks_unscheduled', Task.group, Task.schedule_time)
 index_tasks_retries = Index('index_tasks_retries', Task.exit_status, Task.retried)
+index_tasks_source = Index(
+    'index_tasks_source', Task.source, Task.fingerprint,
+    postgresql_where=Task.source.not_in([DIRECT_SOURCE_ID, STDIN_SOURCE_ID]),
+    sqlite_where=Task.source.not_in([DIRECT_SOURCE_ID, STDIN_SOURCE_ID]),
+)
 
 
 class Client(Entity):
@@ -833,3 +923,98 @@ class Client(Entity):
 
 # Indices for efficient queries
 index_client_disconnect = Index('client_disconnected_at', Client.disconnected_at)
+
+
+class Source(Entity):
+    """Source entity: provenance record for a batch of ingested tasks.
+
+    One row per ingested named task file (R1), capturing the absolute path, a
+    file-content fingerprint (md5), the expected task count, and a creation time.
+    Re-submission consults these to detect a prior ingest, warn on an incomplete one
+    (R7), de-dup novel tasks, or refuse. The reserved ``<direct>`` and ``<stdin>``
+    submission modes are real rows with fixed ids (see `Source.reserved`,
+    `DIRECT_SOURCE_ID`, `STDIN_SOURCE_ID`) and are exempt from gating. Lineage is
+    *all sources sharing a `path`* — there is deliberately no lineage-pointer column.
+    """
+
+    id: Mapped[str] = mapped_column(UUID, primary_key=True, nullable=False)
+    path: Mapped[str] = mapped_column(TEXT, nullable=False)
+    fingerprint: Mapped[Optional[str]] = mapped_column(TEXT, nullable=True)
+    task_count: Mapped[Optional[int]] = mapped_column(INTEGER, nullable=True)
+    created: Mapped[datetime] = mapped_column(DATETIME, nullable=False)
+
+    columns = {
+        'id': str,
+        'path': str,
+        'fingerprint': str,
+        'task_count': int,
+        'created': datetime,
+    }
+
+    class NotFound(NotFound):
+        pass
+
+    class NotDistinct(NotDistinct):
+        pass
+
+    class AlreadyExists(AlreadyExists):
+        pass
+
+    @classmethod
+    def from_id(cls: Type[Source], id: str, caching: bool = True) -> Source:
+        """Look up source by unique `id`."""
+        try:
+            return cls.query(caching=caching).filter_by(id=id).one()
+        except NoResultFound as error:
+            raise cls.NotFound(f'No source with id={id}') from error
+        except MultipleResultsFound as error:
+            raise cls.NotDistinct(f'Multiple sources with id={id}') from error
+
+    @classmethod
+    def new(cls: Type[Source], path: str, fingerprint: str = None, task_count: int = None, **other) -> Source:
+        """Create a new source record (id minted via `uuid()`)."""
+        return cls(id=uuid(), path=path, fingerprint=fingerprint, task_count=task_count,
+                   created=datetime.now().astimezone(), **other)
+
+    @classmethod
+    def reserved(cls: Type[Source], const_id: str) -> Source:
+        """Lazily get-or-create the reserved source row identified by `const_id`.
+
+        Idempotent: the fixed-id row (`<direct>`/`<stdin>`) is created once on first use
+        and reused thereafter, so `Task.source` can point at a real native-UUID row.
+        """
+        try:
+            return cls.from_id(const_id, caching=False)
+        except cls.NotFound:
+            source = cls(id=const_id, path=RESERVED_SOURCE_PATHS[const_id],
+                         created=datetime.now().astimezone())
+            cls.add(source)
+            return source
+
+    @classmethod
+    def lookup(cls: Type[Source], path: str) -> List[Source]:
+        """All sources sharing `path` (the same-path lineage), newest first."""
+        return (cls.query()
+                .filter(cls.path == path)
+                .order_by(cls.created.desc())
+                .all())
+
+    @classmethod
+    def matching(cls: Type[Source], path: str, fingerprint: str) -> Optional[Source]:
+        """Most recent source with identical `path` and `fingerprint`, else None."""
+        return (cls.query()
+                .filter(cls.path == path)
+                .filter(cls.fingerprint == fingerprint)
+                .order_by(cls.created.desc())
+                .first())
+
+    @classmethod
+    def paths_for_ids(cls: Type[Source], ids: List[str]) -> Dict[str, str]:
+        """Map of source id -> path for the given `ids` (batched presentation lookup)."""
+        if not ids:
+            return {}
+        return dict(cls.query(cls.id, cls.path).filter(cls.id.in_(set(ids))).all())
+
+
+# Indices for efficient queries
+index_source_lookup = Index('index_source_lookup', Source.path, Source.fingerprint)

--- a/src/hypershell/data/model.py
+++ b/src/hypershell/data/model.py
@@ -296,7 +296,7 @@ class Task(Entity):
     next_id: Mapped[Optional[str]] = mapped_column(UUID, unique=True, nullable=True)
 
     source: Mapped[Optional[str]] = mapped_column(UUID, nullable=True)  # Source.id or reserved-const id
-    fingerprint: Mapped[Optional[str]] = mapped_column(TEXT, nullable=True)  # stable identity (R2)
+    fingerprint: Mapped[Optional[str]] = mapped_column(TEXT, nullable=True)  # Stable identity hash (args + group + tags).
 
     tag: Mapped[dict] = mapped_column(JSON, nullable=False, default={})  # kept last (export/print order)
 
@@ -373,11 +373,11 @@ class Task(Entity):
         (for JSON-sourced tags). With ``parse_inline=False`` the inline
         ``# HYPERSHELL:`` tag comment is not parsed and `args` is taken verbatim.
 
-        The stable identity ``fingerprint`` (R2) is computed from the pre-template
-        ``raw_args`` (falling back to the expanded ``args`` when not supplied) plus the
-        resolved group and tags, unless ``fingerprint`` is passed directly (retries copy
-        the parent's). ``source`` links the task to its ingested file's ``Source`` record
-        (R3); both columns are NULL only for historical/ungated rows.
+        The stable identity ``fingerprint`` is computed from the pre-template ``raw_args``
+        (falling back to the expanded ``args`` when not supplied) plus the resolved group and
+        tags, unless ``fingerprint`` is passed directly (retries copy the parent's). ``source``
+        links the task to its ingested file's ``Source`` record; both columns are NULL only for
+        historical/ungated rows.
         """
         cls.ensure_valid_tag(tag, strict=strict_tag)
         if parse_inline:
@@ -408,7 +408,7 @@ class Task(Entity):
     @classmethod
     def compute_fingerprint(cls: Type[Task], raw_command: str, group: int,
                             tags: Optional[Dict[str, JSONData]]) -> str:
-        """Stable, order-independent identity fingerprint (R2).
+        """Stable, order-independent identity fingerprint.
 
         An md5 over canonical JSON of the pre-template ``raw_command``, the task
         ``group``, and user ``tags`` (the bookkeeping ``part`` tag excluded; resource
@@ -622,8 +622,8 @@ class Task(Entity):
                                  previous_id=task.id,
                                  tag=task.tag,
                                  group=task.group,
-                                 fingerprint=task.fingerprint,  # a retry is the same logical task (R2)
-                                 source=task.source)            # keep the chain linked to its source (R3)
+                                 fingerprint=task.fingerprint,  # A retry is the same logical task.
+                                 source=task.source)            # Keep the retry chain linked to its source.
                          for task in failed_tasks]
             tasks.extend(new_tasks)
             cls.add_all(tasks)
@@ -823,10 +823,10 @@ class Task(Entity):
 
     @classmethod
     def count_for_source(cls: Type[Task], source_id: str) -> int:
-        """Count tasks stamped with the given `source_id` (R7 completeness check).
+        """Count tasks stamped with the given `source_id`, for the incomplete-prior-submission check.
 
         Served by the leading column of `index_tasks_source`; a bound `source_id` seeks the
-        B-tree (no full table `SCAN`), so the check stays sub-linear at scale (R17).
+        B-tree (no full table `SCAN`), so the check stays sub-linear even on a huge table.
         """
         return cls.query().filter(cls.source == source_id).count()
 
@@ -834,9 +834,9 @@ class Task(Entity):
     def fingerprints_for_sources(cls: Type[Task], source_ids: List[str]) -> set[str]:
         """Set of task identity fingerprints across the given `source_ids` (de-dup skip-set).
 
-        The de-dup scope is a same-path source lineage (R9/R12/R14) — a small set of
-        sources — so, backed by the covering `index_tasks_source` on `(source, fingerprint)`,
-        this is a bounded index-only scan, not a walk of the whole task table (R17).
+        The de-dup scope is a same-path source lineage — a small set of sources — so, backed by
+        the covering `index_tasks_source` on `(source, fingerprint)`, this is a bounded index-only
+        scan, not a walk of the whole task table.
         """
         if not source_ids:
             return set()
@@ -851,7 +851,7 @@ class Task(Entity):
 # Indices for efficient queries
 index_tasks_unscheduled = Index('index_tasks_unscheduled', Task.group, Task.schedule_time)
 index_tasks_retries = Index('index_tasks_retries', Task.exit_status, Task.retried)
-# Covering index for source detection / lineage de-dup (R17). Deliberately *not* partial:
+# Covering index for source detection / lineage de-dup. Deliberately *not* partial:
 # a partial `WHERE source NOT IN (<direct>, <stdin>)` predicate is only honored when the query
 # repeats it with matching literals, but `count_for_source`/`fingerprints_for_sources` bind the
 # source as a parameter — which neither SQLite nor PostgreSQL can prove satisfies a literal
@@ -935,10 +935,10 @@ index_client_disconnect = Index('client_disconnected_at', Client.disconnected_at
 class Source(Entity):
     """Source entity: provenance record for a batch of ingested tasks.
 
-    One row per ingested named task file (R1), capturing the absolute path, a
+    One row per ingested named task file, capturing the absolute path, a
     file-content fingerprint (md5), the expected task count, and a creation time.
-    Re-submission consults these to detect a prior ingest, warn on an incomplete one
-    (R7), de-dup novel tasks, or refuse. The reserved ``<direct>`` and ``<stdin>``
+    Re-submission consults these to detect a prior ingest, warn on an incomplete one,
+    de-dup novel tasks, or refuse. The reserved ``<direct>`` and ``<stdin>``
     submission modes are real rows with fixed ids (see `Source.reserved`,
     `DIRECT_SOURCE_ID`, `STDIN_SOURCE_ID`) and are exempt from gating. Lineage is
     *all sources sharing a `path`* — there is deliberately no lineage-pointer column.

--- a/src/hypershell/data/model.py
+++ b/src/hypershell/data/model.py
@@ -823,7 +823,11 @@ class Task(Entity):
 
     @classmethod
     def count_for_source(cls: Type[Task], source_id: str) -> int:
-        """Count tasks stamped with the given `source_id` (R7 completeness check)."""
+        """Count tasks stamped with the given `source_id` (R7 completeness check).
+
+        Served by the leading column of `index_tasks_source`; a bound `source_id` seeks the
+        B-tree (no full table `SCAN`), so the check stays sub-linear at scale (R17).
+        """
         return cls.query().filter(cls.source == source_id).count()
 
     @classmethod
@@ -831,8 +835,8 @@ class Task(Entity):
         """Set of task identity fingerprints across the given `source_ids` (de-dup skip-set).
 
         The de-dup scope is a same-path source lineage (R9/R12/R14) — a small set of
-        sources — so this is a bounded, index-backed scan (`index_tasks_source`), not a
-        walk of the whole task table.
+        sources — so, backed by the covering `index_tasks_source` on `(source, fingerprint)`,
+        this is a bounded index-only scan, not a walk of the whole task table (R17).
         """
         if not source_ids:
             return set()
@@ -847,11 +851,14 @@ class Task(Entity):
 # Indices for efficient queries
 index_tasks_unscheduled = Index('index_tasks_unscheduled', Task.group, Task.schedule_time)
 index_tasks_retries = Index('index_tasks_retries', Task.exit_status, Task.retried)
-index_tasks_source = Index(
-    'index_tasks_source', Task.source, Task.fingerprint,
-    postgresql_where=Task.source.not_in([DIRECT_SOURCE_ID, STDIN_SOURCE_ID]),
-    sqlite_where=Task.source.not_in([DIRECT_SOURCE_ID, STDIN_SOURCE_ID]),
-)
+# Covering index for source detection / lineage de-dup (R17). Deliberately *not* partial:
+# a partial `WHERE source NOT IN (<direct>, <stdin>)` predicate is only honored when the query
+# repeats it with matching literals, but `count_for_source`/`fingerprints_for_sources` bind the
+# source as a parameter — which neither SQLite nor PostgreSQL can prove satisfies a literal
+# partial predicate, so a partial index silently degrades those lookups to a full table SCAN.
+# A full index is used with plain bound parameters on every engine; the reserved-source rows it
+# also carries are a marginal cost (real named-file sources dominate the target workload).
+index_tasks_source = Index('index_tasks_source', Task.source, Task.fingerprint)
 
 
 class Client(Entity):

--- a/src/hypershell/data/model.py
+++ b/src/hypershell/data/model.py
@@ -295,10 +295,10 @@ class Task(Entity):
     previous_id: Mapped[Optional[str]] = mapped_column(UUID, unique=True, nullable=True)
     next_id: Mapped[Optional[str]] = mapped_column(UUID, unique=True, nullable=True)
 
-    tag: Mapped[dict] = mapped_column(JSON, nullable=False, default={})
-
     source: Mapped[Optional[str]] = mapped_column(UUID, nullable=True)  # Source.id or reserved-const id
     fingerprint: Mapped[Optional[str]] = mapped_column(TEXT, nullable=True)  # stable identity (R2)
+
+    tag: Mapped[dict] = mapped_column(JSON, nullable=False, default={})  # kept last (export/print order)
 
     columns = {
         'id': str,
@@ -330,9 +330,9 @@ class Task(Entity):
         'duration': int,
         'previous_id': str,
         'next_id': str,
-        'tag': dict,
         'source': str,
         'fingerprint': str,
+        'tag': dict,
     }
 
     class NotFound(NotFound):

--- a/src/hypershell/server.py
+++ b/src/hypershell/server.py
@@ -128,6 +128,7 @@ class Scheduler(StateMachine):
     poll_max: float
     startup_phase: bool
     current_group: Optional[int]
+    submitter: Optional[SubmitThread]
 
     state = SchedulerState.START
     states = SchedulerState
@@ -136,7 +137,7 @@ class Scheduler(StateMachine):
     def __init__(self: Scheduler, queue: QueueServer, bundlesize: int = DEFAULT_BUNDLESIZE,
                  attempts: int = DEFAULT_ATTEMPTS, eager: bool = DEFAULT_EAGER_MODE,
                  forever_mode: bool = False, restart_mode: bool = False,
-                 poll: int = DEFAULT_SERVER_POLL) -> None:
+                 poll: int = DEFAULT_SERVER_POLL, submitter: Optional[SubmitThread] = None) -> None:
         """Initialize queue and parameters."""
         self.queue = queue
         self.tasks = []
@@ -150,6 +151,19 @@ class Scheduler(StateMachine):
         self.poll_max = poll
         self.startup_phase = not self.restart_mode  # NOTE: Halt if everything in the database is already finished
         self.current_group = None
+        self.submitter = submitter
+
+    def submission_complete(self: Scheduler) -> bool:
+        """True once no more tasks can arrive from a co-running submitter.
+
+        The scheduler shares a process with an optional :class:`~hypershell.submit.SubmitThread`
+        (the cluster/server file-ingest path). It must not conclude "all tasks completed —
+        stop" while that submitter is still committing rows: a database holding only prior
+        *completed* tasks reads as ``remaining == 0`` right up until the first novel row lands,
+        so an unguarded early-exit would halt before the new work is ever scheduled. When there
+        is no submitter (bare ``--restart`` DB resume) submission is trivially complete.
+        """
+        return self.submitter is None or not self.submitter.is_alive()
 
     @cached_property
     def actions(self: Scheduler) -> Dict[SchedulerState, Callable[[], SchedulerState]]:
@@ -170,6 +184,10 @@ class Scheduler(StateMachine):
             if (tasks_remaining := Task.count_remaining()) == 0:
                 if self.forever_mode:
                     log.info(f'All previous tasks completed ({total_tasks:,}) - waiting for new tasks')
+                elif not self.submission_complete():
+                    # A submitter is still ingesting (e.g. `hsx FILE --restart`): the DB looks
+                    # done only because its novel rows have not landed yet. Wait in LOAD.
+                    log.info(f'All previous tasks completed ({total_tasks:,}) - waiting for incoming tasks')
                 else:
                     log.info(f'All previous tasks completed ({total_tasks:,}) - stopping')
                     return SchedulerState.FINAL
@@ -198,7 +216,10 @@ class Scheduler(StateMachine):
             self.startup_phase = False
             self.poll = SERVER_POLL_MIN
             return SchedulerState.PACK
-        elif not self.forever_mode and Task.count() > 0 and Task.count_remaining() == 0 and not self.startup_phase:
+        elif (not self.forever_mode and Task.count() > 0 and Task.count_remaining() == 0
+              and (not self.startup_phase or self.submission_complete())):
+            # Nothing left to schedule, and either real work has already been seen this run
+            # or the submitter has finished — safe to stop (won't fire mid-ingest).
             return SchedulerState.FINAL
         else:
             group_info = Task.increment_group(self.current_group, attempts=self.attempts)
@@ -252,11 +273,13 @@ class SchedulerThread(Thread):
                  eager: bool = DEFAULT_EAGER_MODE,
                  forever_mode: bool = False,
                  restart_mode: bool = False,
-                 poll: int = DEFAULT_SERVER_POLL) -> None:
+                 poll: int = DEFAULT_SERVER_POLL,
+                 submitter: Optional[SubmitThread] = None) -> None:
         """Initialize machine."""
         super().__init__(name='hypershell-scheduler')
         self.machine = Scheduler(queue=queue, bundlesize=bundlesize, attempts=attempts, eager=eager,
-                                 forever_mode=forever_mode, restart_mode=restart_mode, poll=poll)
+                                 forever_mode=forever_mode, restart_mode=restart_mode, poll=poll,
+                                 submitter=submitter)
 
     def run_with_exceptions(self: SchedulerThread) -> None:
         """Run machine."""
@@ -805,7 +828,7 @@ class ServerThread(Thread):
                 bundlesize=bundlesize, bundlewait=bundlewait, template=submit_template)
             self.scheduler = SchedulerThread(queue=self.queue, bundlesize=bundlesize, attempts=max_retries + 1,
                                              eager=eager, forever_mode=forever_mode, restart_mode=restart_mode,
-                                             poll=poll)
+                                             poll=poll, submitter=self.submitter)
         if self.no_confirm:
             self.confirm = None
         else:

--- a/src/hypershell/submit.py
+++ b/src/hypershell/submit.py
@@ -162,9 +162,10 @@ def source_fingerprint_and_count(path: str, template: str = DEFAULT_TEMPLATE) ->
 def _new_source_id(path: str, fingerprint: str, count: int) -> str:
     """Persist a fresh :class:`Source` row and return its id (R1).
 
-    The expected ``count`` is recorded *before* any task is committed, so an interrupted
-    ingest leaves a source whose recorded count exceeds the tasks that actually landed —
-    exactly the signal :func:`_warn_if_incomplete` reports on a later re-submission (R7).
+    The expected ``count`` (the file's full task count) is recorded *before* any task is
+    committed, so an interrupted ingest leaves the same-path lineage holding fewer tasks than
+    expected — the signal :func:`_warn_if_incomplete` reports on a later re-submission (R7),
+    measured across the lineage so a de-duplicated submission does not read as incomplete.
     """
     source = Source.new(path=path, fingerprint=fingerprint, task_count=count)
     Source.add(source)
@@ -172,11 +173,19 @@ def _new_source_id(path: str, fingerprint: str, count: int) -> str:
     return source.id
 
 
-def _warn_if_incomplete(source: Source) -> None:
-    """R7: warn when fewer tasks landed for `source` than its recorded count."""
+def _warn_if_incomplete(source: Source, lineage: List[Source]) -> None:
+    """R7: warn when fewer tasks landed across the same-path `lineage` than `source` expects.
+
+    Completeness is measured against the *whole* same-path lineage, not ``source`` alone.
+    De-dup (R9/R12/R14) deliberately distributes a file version's tasks across the lineage —
+    the novel ones onto the newest source, the rest already present under earlier same-path
+    sources — so a per-source count structurally under-counts a de-duplicated submission and
+    would cry wolf on a re-submission that is in fact complete. Each ``count_for_source`` is
+    index-backed, and a lineage is small (re-submissions of one path), so the sum stays cheap.
+    """
     if source.task_count is None:
         return
-    landed = Task.count_for_source(source.id)
+    landed = sum(Task.count_for_source(prior.id) for prior in lineage)
     if landed < source.task_count:
         log.warning(f'Prior submission of {source.path} appears incomplete: '
                     f'{landed} of {source.task_count} tasks present (source {source.id})')
@@ -213,7 +222,7 @@ def apply_source_gate(path: str, fingerprint: str, count: int, *,
     match = Source.matching(path, fingerprint)
     lineage = Source.lookup(path)
     if lineage:
-        _warn_if_incomplete(match or lineage[0])  # R7 — orthogonal to the submit/refuse decision
+        _warn_if_incomplete(match or lineage[0], lineage)  # R7 — orthogonal to the submit/refuse decision
     if repeat:
         # R8 / R15 — brand-new source, submit everything even on an identical match.
         log.info(f'Submitting all {count} tasks from {path} as a new source (--repeat)')

--- a/src/hypershell/submit.py
+++ b/src/hypershell/submit.py
@@ -135,7 +135,7 @@ def line_is_task(line: str, template: Template) -> bool:
 
 
 def source_fingerprint_and_count(path: str, template: str = DEFAULT_TEMPLATE) -> Tuple[str, int]:
-    """Read a named file upfront: content md5 (raw bytes) + task count (R4).
+    """Read a named file upfront: content md5 (raw bytes) + task count.
 
     The md5 is over the raw file bytes (parsing-independent). The count is taken over a
     *text-mode* read — the same universal-newline decoding the Loader uses — replaying the
@@ -160,11 +160,11 @@ def source_fingerprint_and_count(path: str, template: str = DEFAULT_TEMPLATE) ->
 
 
 def _new_source_id(path: str, fingerprint: str, count: int) -> str:
-    """Persist a fresh :class:`Source` row and return its id (R1).
+    """Persist a fresh :class:`Source` row and return its id.
 
     The expected ``count`` (the file's full task count) is recorded *before* any task is
     committed, so an interrupted ingest leaves the same-path lineage holding fewer tasks than
-    expected — the signal :func:`_warn_if_incomplete` reports on a later re-submission (R7),
+    expected — the signal :func:`_warn_if_incomplete` reports on a later re-submission,
     measured across the lineage so a de-duplicated submission does not read as incomplete.
     """
     source = Source.new(path=path, fingerprint=fingerprint, task_count=count)
@@ -174,10 +174,10 @@ def _new_source_id(path: str, fingerprint: str, count: int) -> str:
 
 
 def _warn_if_incomplete(source: Source, lineage: List[Source]) -> None:
-    """R7: warn when fewer tasks landed across the same-path `lineage` than `source` expects.
+    """Warn when fewer tasks landed across the same-path `lineage` than `source` expects.
 
     Completeness is measured against the *whole* same-path lineage, not ``source`` alone.
-    De-dup (R9/R12/R14) deliberately distributes a file version's tasks across the lineage —
+    De-dup deliberately distributes a file version's tasks across the lineage —
     the novel ones onto the newest source, the rest already present under earlier same-path
     sources — so a per-source count structurally under-counts a de-duplicated submission and
     would cry wolf on a re-submission that is in fact complete. Each ``count_for_source`` is
@@ -199,41 +199,41 @@ def apply_source_gate(path: str, fingerprint: str, count: int, *,
     the ``source_id`` to stamp onto tasks plus an optional ``skip_fingerprints`` set — task
     identities already present in the same-path lineage, which the :class:`Loader` drops for
     de-dup. Raises :class:`~cmdkit.cli.ArgumentError` (→ ``exit_status.bad_argument``) on a
-    refusal, with an actionable message. Emits the R18 detection logging (prior source,
+    refusal, with an actionable message. Emits detection logging (prior source,
     incomplete-prior warning, submit/de-dup intent, refusal reason).
 
     This is the shared gate for both entry points: ``hs submit`` calls it with
-    ``restart=False`` (matrix R5-R10); ``hsx``/``hs cluster`` also passes ``restart`` (matrix
-    R11-R16). Callers guarantee a *valid* flag combination — contradictory/ambiguous combos
-    are rejected upstream in each app's ``check_arguments`` (``--update``+``--repeat`` R10/R16;
-    ``hsx --update`` without ``--restart``/``--repeat`` R13; ``hsx --restart``+``--repeat``).
+    ``restart=False``; ``hsx``/``hs cluster`` also passes ``restart``. Callers guarantee a
+    *valid* flag combination — contradictory/ambiguous combos are rejected upstream in each
+    app's ``check_arguments`` (``--update``+``--repeat``; ``hsx --update`` without
+    ``--restart``/``--repeat``; ``hsx --restart``+``--repeat``).
 
     Decision table (prior state of `path` P with fingerprint F):
 
     ==============  ==================  ============================  ============================
     flags           none                match (P,F seen)              differs (P seen, F changed)
     ==============  ==================  ============================  ============================
-    (no flag)       new source, all     REFUSE, name prior (R5)       REFUSE, suggest --update (R6)
-    --repeat        new source, all     new source, all (R8/R15)      new source, all (R8/R15)
-    --update        new source, all     new source, novel-only (R9)   new source, novel-only (R9/R14)
-    --restart       new source, all     reuse source, novel-only(R12) REFUSE, suggest --update (R12)
+    (no flag)       new source, all     REFUSE, name prior            REFUSE, suggest --update
+    --repeat        new source, all     new source, all               new source, all
+    --update        new source, all     new source, novel-only        new source, novel-only
+    --restart       new source, all     reuse source, novel-only      REFUSE, suggest --update
     ==============  ==================  ============================  ============================
     """
     match = Source.matching(path, fingerprint)
     lineage = Source.lookup(path)
     if lineage:
-        _warn_if_incomplete(match or lineage[0], lineage)  # R7 — orthogonal to the submit/refuse decision
+        _warn_if_incomplete(match or lineage[0], lineage)  # Orthogonal to the submit/refuse decision.
     if repeat:
-        # R8 / R15 — brand-new source, submit everything even on an identical match.
+        # Brand-new source; submit everything even on an identical match.
         log.info(f'Submitting all {count} tasks from {path} as a new source (--repeat)')
         return _new_source_id(path, fingerprint, count), None
     if update:
-        # R9 / R14 — new source version; submit only identities absent from the same-path lineage.
+        # New source version; submit only identities absent from the same-path lineage.
         skip = Task.fingerprints_for_sources([source.id for source in lineage])
         log.info(f'Updating {path}: {len(skip)} task identity(ies) already present; submitting only new tasks')
         return _new_source_id(path, fingerprint, count), skip
     if restart:
-        # R12 — file-aware restart (cluster). Reusing the matched source keeps requeues
+        # File-aware restart (cluster). Reusing the matched source keeps requeues
         # idempotent (no row/count drift); the server's revert-interrupted flow re-runs any
         # mid-flight task, so novel-only here submits exactly what never landed.
         if match:
@@ -245,7 +245,7 @@ def apply_source_gate(path: str, fingerprint: str, count: int, *,
                                 f'pass --update --restart to submit only the new tasks')
         log.info(f'Submitting all {count} tasks from {path} as a new source (--restart)')
         return _new_source_id(path, fingerprint, count), None
-    # No gating flag — R5 / R6 / R11.
+    # No gating flag: refuse a known (path, fingerprint), else submit as a new source.
     if match:
         raise ArgumentError(f'File {path} was already submitted as source {match.id} '
                             f'({match.task_count} tasks, {match.created}); '
@@ -1316,7 +1316,7 @@ class SubmitApp(Application):
     }
 
     def check_arguments(self: SubmitApp) -> None:
-        """Reject contradictory re-submission flags before doing any work (R10)."""
+        """Reject contradictory re-submission flags before doing any work."""
         if self.update_mode and self.repeat_mode:
             raise ArgumentError('Cannot combine --update with --repeat')
 
@@ -1428,12 +1428,12 @@ class SubmitApp(Application):
     def prepare_source(self: SubmitApp) -> None:
         """Resolve the task Source, apply the re-submission gate, and wrap the stream (DB mode only).
 
-        A named file passes through :func:`apply_source_gate` (R5-R10): a duplicate or
+        A named file passes through :func:`apply_source_gate`: a duplicate or
         changed-content re-submission is refused unless ``--repeat``/``--update`` relaxes it,
         and the resolved :class:`Source` row's ``task_count`` is the upfront-counted
-        expectation, committed *before* any task so an incomplete prior stays detectable
-        (R1/R7). ``<stdin>`` and single-command ``<direct>`` submissions resolve their
-        reserved fixed-id rows and are exempt from gating (R3) — a gating flag there is a
+        expectation, committed *before* any task so an incomplete prior stays detectable.
+        ``<stdin>`` and single-command ``<direct>`` submissions resolve their
+        reserved fixed-id rows and are exempt from gating — a gating flag there is a
         no-op and says so. A ``--from-json`` source is gated too (see :meth:`prepare_json_source`).
         """
         if not DATABASE_ENABLED:
@@ -1462,14 +1462,14 @@ class SubmitApp(Application):
                                       name=self.source_path)
 
     def prepare_json_source(self: SubmitApp) -> None:
-        """Apply the re-submission gate to a ``--from-json`` source (R4/R5/R8/R9).
+        """Apply the re-submission gate to a ``--from-json`` source.
 
         The JSON file's content md5 (captured in :meth:`check_source`, no second read) and
         record count feed the same :func:`apply_source_gate` as a line file, keyed by
         ``abspath(FILE)[@node]``. The per-task fingerprint keys off the pre-template ``args``
-        and tags (R2), so ``--update`` de-dup matches whether the tasks were first ingested
+        and tags, so ``--update`` de-dup matches whether the tasks were first ingested
         here or from a line file. ``--from-json -`` (stdin JSON) has no stable path and is
-        exempt, carrying the reserved ``<stdin>`` source (R3). Called in DB mode only.
+        exempt, carrying the reserved ``<stdin>`` source. Called in DB mode only.
         """
         key = json_source_key(self.from_json)
         if key is None:
@@ -1484,7 +1484,7 @@ class SubmitApp(Application):
         self.source = GatedSource(self.source, self.source_id, skip_fingerprints=skip, name=key)
 
     def warn_gating_no_effect(self: SubmitApp, kind: str) -> None:
-        """Note that re-submission gating flags are inert for exempt sources (R3)."""
+        """Note that re-submission gating flags are inert for exempt sources."""
         if self.repeat_mode or self.update_mode:
             log.warning(f'--repeat/--update have no effect for {kind} submissions')
 

--- a/src/hypershell/submit.py
+++ b/src/hypershell/submit.py
@@ -78,7 +78,7 @@ from hypershell.data import initdb, checkdb, DATABASE_DIALECT, DATABASE_ENABLED
 
 # Public interface
 __all__ = ['submit_from', 'submit_file', 'load_json_tasks', 'validate_json_expansion',
-           'GatedSource', 'source_fingerprint_and_count',
+           'GatedSource', 'source_fingerprint_and_count', 'apply_source_gate',
            'SubmitThread', 'LiveSubmitThread', 'SubmitApp',
            'DEFAULT_TASK_GROUP', 'DEFAULT_BUNDLESIZE', 'DEFAULT_BUNDLEWAIT', 'DEFAULT_TEMPLATE']
 
@@ -156,6 +156,95 @@ def source_fingerprint_and_count(path: str, template: str = DEFAULT_TEMPLATE) ->
             if line_is_task(line, engine):
                 count += 1
     return digest.hexdigest(), count
+
+
+def _new_source_id(path: str, fingerprint: str, count: int) -> str:
+    """Persist a fresh :class:`Source` row and return its id (R1).
+
+    The expected ``count`` is recorded *before* any task is committed, so an interrupted
+    ingest leaves a source whose recorded count exceeds the tasks that actually landed —
+    exactly the signal :func:`_warn_if_incomplete` reports on a later re-submission (R7).
+    """
+    source = Source.new(path=path, fingerprint=fingerprint, task_count=count)
+    Source.add(source)
+    log.debug(f'Recorded source {source.id} for {path} ({count} tasks)')
+    return source.id
+
+
+def _warn_if_incomplete(source: Source) -> None:
+    """R7: warn when fewer tasks landed for `source` than its recorded count."""
+    if source.task_count is None:
+        return
+    landed = Task.count_for_source(source.id)
+    if landed < source.task_count:
+        log.warning(f'Prior submission of {source.path} appears incomplete: '
+                    f'{landed} of {source.task_count} tasks present (source {source.id})')
+
+
+def apply_source_gate(path: str, fingerprint: str, count: int, *,
+                      repeat: bool, update: bool, restart: bool = False) -> Tuple[str, Optional[set]]:
+    """Decide whether to submit, de-dup, or refuse a named-file submission.
+
+    Consults the :class:`Source` table for the file's ``(path, fingerprint)`` and returns
+    the ``source_id`` to stamp onto tasks plus an optional ``skip_fingerprints`` set — task
+    identities already present in the same-path lineage, which the :class:`Loader` drops for
+    de-dup. Raises :class:`~cmdkit.cli.ArgumentError` (→ ``exit_status.bad_argument``) on a
+    refusal, with an actionable message. Emits the R18 detection logging (prior source,
+    incomplete-prior warning, submit/de-dup intent, refusal reason).
+
+    This is the shared gate for both entry points: ``hs submit`` calls it with
+    ``restart=False`` (matrix R5-R10); ``hsx``/``hs cluster`` also passes ``restart`` (matrix
+    R11-R16). Callers guarantee a *valid* flag combination — contradictory/ambiguous combos
+    are rejected upstream in each app's ``check_arguments`` (``--update``+``--repeat`` R10/R16;
+    ``hsx --update`` without ``--restart``/``--repeat`` R13; ``hsx --restart``+``--repeat``).
+
+    Decision table (prior state of `path` P with fingerprint F):
+
+    ==============  ==================  ============================  ============================
+    flags           none                match (P,F seen)              differs (P seen, F changed)
+    ==============  ==================  ============================  ============================
+    (no flag)       new source, all     REFUSE, name prior (R5)       REFUSE, suggest --update (R6)
+    --repeat        new source, all     new source, all (R8/R15)      new source, all (R8/R15)
+    --update        new source, all     new source, novel-only (R9)   new source, novel-only (R9/R14)
+    --restart       new source, all     reuse source, novel-only(R12) REFUSE, suggest --update (R12)
+    ==============  ==================  ============================  ============================
+    """
+    match = Source.matching(path, fingerprint)
+    lineage = Source.lookup(path)
+    if lineage:
+        _warn_if_incomplete(match or lineage[0])  # R7 — orthogonal to the submit/refuse decision
+    if repeat:
+        # R8 / R15 — brand-new source, submit everything even on an identical match.
+        log.info(f'Submitting all {count} tasks from {path} as a new source (--repeat)')
+        return _new_source_id(path, fingerprint, count), None
+    if update:
+        # R9 / R14 — new source version; submit only identities absent from the same-path lineage.
+        skip = Task.fingerprints_for_sources([source.id for source in lineage])
+        log.info(f'Updating {path}: {len(skip)} task identity(ies) already present; submitting only new tasks')
+        return _new_source_id(path, fingerprint, count), skip
+    if restart:
+        # R12 — file-aware restart (cluster). Reusing the matched source keeps requeues
+        # idempotent (no row/count drift); the server's revert-interrupted flow re-runs any
+        # mid-flight task, so novel-only here submits exactly what never landed.
+        if match:
+            skip = Task.fingerprints_for_sources([source.id for source in lineage])
+            log.info(f'Restarting {path} (source {match.id}): {len(skip)} present; submitting only new tasks')
+            return match.id, skip
+        if lineage:
+            raise ArgumentError(f'File {path} differs from its prior submission (content changed); '
+                                f'pass --update --restart to submit only the new tasks')
+        log.info(f'Submitting all {count} tasks from {path} as a new source (--restart)')
+        return _new_source_id(path, fingerprint, count), None
+    # No gating flag — R5 / R6 / R11.
+    if match:
+        raise ArgumentError(f'File {path} was already submitted as source {match.id} '
+                            f'({match.task_count} tasks, {match.created}); '
+                            f'pass --repeat to submit it again, or --update to add only new tasks')
+    if lineage:
+        raise ArgumentError(f'A file at {path} was previously submitted with different content; '
+                            f'pass --update to submit only new tasks, or --repeat to submit all again')
+    log.info(f'Submitting all {count} tasks from {path} as a new source')
+    return _new_source_id(path, fingerprint, count), None
 
 
 class LoaderState(State, Enum):
@@ -1057,7 +1146,8 @@ PAD_NAME: Final[str] = ' ' * len(APP_NAME)
 APP_USAGE: Final[str] = f"""\
 Usage:
   {APP_NAME} [-h] [ARGS... | -f FILE | --from-json SPEC] [-q [-H ADDR] [-p NUM] [-k KEY] | --initdb]
-  {PAD_NAME} [-b NUM] [-w SEC] [-c NUM] [-m MEM] [-W SEC] [-g NUM] [--template CMD] [-t TAG...]
+  {PAD_NAME} [-b NUM] [-w SEC] [-c NUM] [-m MEM] [-W SEC] [-g NUM] [--repeat | --update]
+  {PAD_NAME} [--template CMD] [-t TAG...]
   {PAD_NAME} [--no-tls | [--tls-ca PATH] [--tls-cert PATH] [--tls-key PATH]]
 
   Submit one or more tasks.\
@@ -1078,6 +1168,8 @@ Arguments:
 Options:
   -f, --task-file    FILE    Path to task file ("-" for <stdin>).
       --from-json    SPEC    Read tasks from a JSON file ("FILE[@path]").
+      --repeat               Re-submit a known file's tasks again as a new source.
+      --update               Submit only tasks not already present from a known file.
   -q, --queue                Submit to live queue instead of database.
   -H, --host         ADDR    Hostname for server (default: {DEFAULT_HOST}). Used with --queue.
   -p, --port         NUM     Port number for server (default: {DEFAULT_PORT}). Used with --queue.
@@ -1135,6 +1227,12 @@ class SubmitApp(Application):
     group: Optional[int] = None
     interface.add_argument('-g', '--group', type=int, default=group)
 
+    repeat_mode: bool = False
+    interface.add_argument('--repeat', action='store_true', dest='repeat_mode')
+
+    update_mode: bool = False
+    interface.add_argument('--update', action='store_true', dest='update_mode')
+
     auto_initdb: bool = False
     interface.add_argument('--initdb', action='store_true', dest='auto_initdb')
 
@@ -1171,8 +1269,14 @@ class SubmitApp(Application):
         **get_shared_exception_mapping(__name__)
     }
 
+    def check_arguments(self: SubmitApp) -> None:
+        """Reject contradictory re-submission flags before doing any work (R10)."""
+        if self.update_mode and self.repeat_mode:
+            raise ArgumentError('Cannot combine --update with --repeat')
+
     def run(self: SubmitApp) -> None:
         """Run submit thread."""
+        self.check_arguments()
         self.check_source()
         self.queue = None
         if self.queue_mode:
@@ -1276,36 +1380,44 @@ class SubmitApp(Application):
             self.source = None
 
     def prepare_source(self: SubmitApp) -> None:
-        """Resolve the task Source and wrap the stream so tasks are stamped (DB mode only).
+        """Resolve the task Source, apply the re-submission gate, and wrap the stream (DB mode only).
 
-        A named file gets a fresh :class:`Source` row whose recorded ``task_count`` is the
-        upfront-counted expectation, committed *before* any task so an incomplete prior
-        submission stays detectable (R1/R7). ``<stdin>`` and single-command ``<direct>``
-        submissions resolve their reserved fixed-id rows and are exempt from gating (R3).
-        ``--from-json`` gating is deferred to a later phase. No refuse/repeat/update
-        decisions happen here — only stamping (that gate matrix lands in P3).
+        A named file passes through :func:`apply_source_gate` (R5-R10): a duplicate or
+        changed-content re-submission is refused unless ``--repeat``/``--update`` relaxes it,
+        and the resolved :class:`Source` row's ``task_count`` is the upfront-counted
+        expectation, committed *before* any task so an incomplete prior stays detectable
+        (R1/R7). ``<stdin>`` and single-command ``<direct>`` submissions resolve their
+        reserved fixed-id rows and are exempt from gating (R3) — a gating flag there is a
+        no-op and says so. ``--from-json`` gating is deferred to a later phase.
         """
         if not DATABASE_ENABLED:
             return  # non-persistent DB: nothing to record against (invariant §4)
         if self.from_json:
             return  # JSON source gating handled in a later phase
         if self.source is None:
+            self.warn_gating_no_effect('<direct>')
             self.source_id = Source.reserved(DIRECT_SOURCE_ID).id
         elif self.source is sys.stdin or not self.source.seekable():
             # Real <stdin> and non-seekable named inputs (process substitution, FIFOs, a
             # piped /dev/stdin) have no stable identity and cannot be re-read for an upfront
             # count — stream them under the reserved <stdin> source, exempt from gating. A
             # second read would drain the pipe and silently drop every task.
+            self.warn_gating_no_effect('<stdin>')
             self.source_id = Source.reserved(STDIN_SOURCE_ID).id
             name = '<stdin>' if self.source is sys.stdin else self.source_path
             self.source = GatedSource(self.source, self.source_id, name=name)
         else:
             fingerprint, count = source_fingerprint_and_count(self.source_path, self.template)
             log.info(f'Found {count} tasks in {self.source_path} (md5={fingerprint})')
-            source = Source.new(path=self.source_path, fingerprint=fingerprint, task_count=count)
-            Source.add(source)
-            self.source_id = source.id
-            self.source = GatedSource(self.source, self.source_id, name=self.source_path)
+            self.source_id, skip = apply_source_gate(self.source_path, fingerprint, count,
+                                                     repeat=self.repeat_mode, update=self.update_mode)
+            self.source = GatedSource(self.source, self.source_id, skip_fingerprints=skip,
+                                      name=self.source_path)
+
+    def warn_gating_no_effect(self: SubmitApp, kind: str) -> None:
+        """Note that re-submission gating flags are inert for exempt sources (R3)."""
+        if self.repeat_mode or self.update_mode:
+            log.warning(f'--repeat/--update have no effect for {kind} submissions')
 
     @staticmethod
     def quote_arg(arg: str) -> str:

--- a/src/hypershell/submit.py
+++ b/src/hypershell/submit.py
@@ -77,7 +77,8 @@ from hypershell.data.model import Task, Source, DIRECT_SOURCE_ID, STDIN_SOURCE_I
 from hypershell.data import initdb, checkdb, DATABASE_DIALECT, DATABASE_ENABLED
 
 # Public interface
-__all__ = ['submit_from', 'submit_file', 'load_json_tasks', 'validate_json_expansion',
+__all__ = ['submit_from', 'submit_file', 'load_json_tasks', 'load_json_source', 'json_source_key',
+           'validate_json_expansion',
            'GatedSource', 'source_fingerprint_and_count', 'apply_source_gate',
            'SubmitThread', 'LiveSubmitThread', 'SubmitApp',
            'DEFAULT_TASK_GROUP', 'DEFAULT_BUNDLESIZE', 'DEFAULT_BUNDLEWAIT', 'DEFAULT_TEMPLATE']
@@ -1065,30 +1066,32 @@ def submit_file(path: str,
                            template=template, cores=cores, memory=memory, timeout=timeout, group=group, tags=tags)
 
 
-def load_json_tasks(spec: str) -> List[dict]:
+def load_json_source(spec: str) -> Tuple[List[dict], Optional[str]]:
     """
-    Load a list of task records from a JSON file `spec`.
+    Load task records from a JSON `spec` together with its content fingerprint.
 
-    The `spec` is ``FILE[@dotted.path]``: split on the first ``@``, the remainder
-    is a dotted path of object keys locating the task list inside the document
-    (e.g. ``plan.json@results.tasks``). With no ``@`` the file's top level must
-    itself be the list. A `FILE` of ``-`` reads from ``<stdin>``.
-
-    The located node must be a non-empty list of objects; each object's key/values
-    become both a task's tags and its ``{key}`` template-expansion context.
+    Behaves exactly like :func:`load_json_tasks` (same ``FILE[@dotted.path]`` spec and
+    validation) but reads the file bytes once and also returns their md5 hex digest — the
+    content fingerprint the re-submission gate keys on, matching the md5 an ``hs submit``
+    line file records. A `FILE` of ``-`` reads from ``<stdin>`` and yields a ``None``
+    fingerprint (stdin JSON has no stable identity and stays gating-exempt).
 
     Returns:
         records (List[dict]): The list of task record objects.
+        fingerprint (Optional[str]): md5 hex of the file bytes, or None for ``<stdin>``.
     """
     filepath, _, path = spec.partition('@')
     if not filepath:
         raise ArgumentError(f'Missing filename in --from-json spec: "{spec}"')
+    fingerprint = None
     try:
         if filepath == '-':
             data = json.load(sys.stdin)
         else:
-            with open(filepath, mode='r') as stream:
-                data = json.load(stream)
+            with open(filepath, mode='rb') as stream:
+                content = stream.read()
+            fingerprint = hashlib.md5(content).hexdigest()
+            data = json.loads(content)
     except FileNotFoundError as error:
         raise ArgumentError(f'File not found: {filepath}') from error
     except json.JSONDecodeError as error:
@@ -1109,7 +1112,40 @@ def load_json_tasks(spec: str) -> List[dict]:
         if not isinstance(record, dict):
             raise ArgumentError(f'Task {index} at {location} in {filepath} is not an object '
                                 f'(found {type(record).__name__})')
-    return node
+    return node, fingerprint
+
+
+def load_json_tasks(spec: str) -> List[dict]:
+    """
+    Load a list of task records from a JSON file `spec`.
+
+    The `spec` is ``FILE[@dotted.path]``: split on the first ``@``, the remainder
+    is a dotted path of object keys locating the task list inside the document
+    (e.g. ``plan.json@results.tasks``). With no ``@`` the file's top level must
+    itself be the list. A `FILE` of ``-`` reads from ``<stdin>``.
+
+    The located node must be a non-empty list of objects; each object's key/values
+    become both a task's tags and its ``{key}`` template-expansion context.
+
+    Returns:
+        records (List[dict]): The list of task record objects.
+    """
+    return load_json_source(spec)[0]
+
+
+def json_source_key(spec: str) -> Optional[str]:
+    """
+    Absolute source key for a ``--from-json`` `spec`, or None for stdin (``-``).
+
+    The key is ``abspath(FILE)`` with any ``@dotted.path`` selector preserved, so distinct
+    node selections of one document are distinct sources (no false duplicate match) and it
+    lines up with the absolute path an ``hs submit`` line file records. A `FILE` of ``-``
+    (stdin JSON) has no stable path and returns None — gating-exempt, like ``<stdin>``.
+    """
+    filepath, _, _ = spec.partition('@')
+    if filepath == '-':
+        return None
+    return os.path.abspath(filepath) + spec[len(filepath):]
 
 
 def validate_json_expansion(records: List[dict], template: str = DEFAULT_TEMPLATE) -> None:
@@ -1200,6 +1236,7 @@ class SubmitApp(Application):
     source: IO | List[str] | None = None
     source_path: Optional[str] = None       # absolute path of a named task file (else None)
     source_id: Optional[str] = None         # resolved Source.id stamped onto submitted tasks
+    json_fingerprint: Optional[str] = None  # content md5 of a --from-json file (else None)
     task_args: List[str] = []
     task_file: str = None
     from_json: str = None
@@ -1342,7 +1379,7 @@ class SubmitApp(Application):
         if self.from_json:
             if self.task_args or self.task_file:
                 raise ArgumentError('Cannot combine --from-json with -f/--task-file or positional arguments')
-            records = load_json_tasks(self.from_json)
+            records, self.json_fingerprint = load_json_source(self.from_json)
             validate_json_expansion(records, self.template)
             log.debug(f'Loaded {len(records)} tasks from JSON ({self.from_json})')
             self.source = records
@@ -1388,12 +1425,13 @@ class SubmitApp(Application):
         expectation, committed *before* any task so an incomplete prior stays detectable
         (R1/R7). ``<stdin>`` and single-command ``<direct>`` submissions resolve their
         reserved fixed-id rows and are exempt from gating (R3) — a gating flag there is a
-        no-op and says so. ``--from-json`` gating is deferred to a later phase.
+        no-op and says so. A ``--from-json`` source is gated too (see :meth:`prepare_json_source`).
         """
         if not DATABASE_ENABLED:
             return  # non-persistent DB: nothing to record against (invariant §4)
         if self.from_json:
-            return  # JSON source gating handled in a later phase
+            self.prepare_json_source()
+            return
         if self.source is None:
             self.warn_gating_no_effect('<direct>')
             self.source_id = Source.reserved(DIRECT_SOURCE_ID).id
@@ -1413,6 +1451,28 @@ class SubmitApp(Application):
                                                      repeat=self.repeat_mode, update=self.update_mode)
             self.source = GatedSource(self.source, self.source_id, skip_fingerprints=skip,
                                       name=self.source_path)
+
+    def prepare_json_source(self: SubmitApp) -> None:
+        """Apply the re-submission gate to a ``--from-json`` source (R4/R5/R8/R9).
+
+        The JSON file's content md5 (captured in :meth:`check_source`, no second read) and
+        record count feed the same :func:`apply_source_gate` as a line file, keyed by
+        ``abspath(FILE)[@node]``. The per-task fingerprint keys off the pre-template ``args``
+        and tags (R2), so ``--update`` de-dup matches whether the tasks were first ingested
+        here or from a line file. ``--from-json -`` (stdin JSON) has no stable path and is
+        exempt, carrying the reserved ``<stdin>`` source (R3). Called in DB mode only.
+        """
+        key = json_source_key(self.from_json)
+        if key is None:
+            self.warn_gating_no_effect('<stdin>')
+            self.source_id = Source.reserved(STDIN_SOURCE_ID).id
+            self.source = GatedSource(self.source, self.source_id, name='<stdin>')
+            return
+        count = len(self.source)
+        log.info(f'Found {count} tasks in {key} (md5={self.json_fingerprint})')
+        self.source_id, skip = apply_source_gate(key, self.json_fingerprint, count,
+                                                 repeat=self.repeat_mode, update=self.update_mode)
+        self.source = GatedSource(self.source, self.source_id, skip_fingerprints=skip, name=key)
 
     def warn_gating_no_effect(self: SubmitApp, kind: str) -> None:
         """Note that re-submission gating flags are inert for exempt sources (R3)."""

--- a/src/hypershell/submit.py
+++ b/src/hypershell/submit.py
@@ -39,7 +39,7 @@ Warning:
 
 # Type annotations
 from __future__ import annotations
-from typing import List, Iterable, Iterator, IO, Optional, Dict, Callable, Type, Optional, Final
+from typing import List, Iterable, Iterator, IO, Optional, Dict, Tuple, Callable, Type, Final
 from types import TracebackType
 
 # Standard libs
@@ -48,6 +48,7 @@ import re
 import io
 import sys
 import json
+import hashlib
 import functools
 from enum import Enum
 from datetime import datetime
@@ -72,11 +73,12 @@ from hypershell.core.pretty_print import format_tag
 from hypershell.core.tag import Tag
 from hypershell.core.exceptions import (handle_exception, handle_disconnect,
                                         handle_address_unknown, HostAddressInfo, get_shared_exception_mapping)
-from hypershell.data.model import Task, DEFAULT_TASK_GROUP, serialize_tasks
-from hypershell.data import initdb, checkdb, DATABASE_DIALECT
+from hypershell.data.model import Task, Source, DIRECT_SOURCE_ID, STDIN_SOURCE_ID, DEFAULT_TASK_GROUP, serialize_tasks
+from hypershell.data import initdb, checkdb, DATABASE_DIALECT, DATABASE_ENABLED
 
 # Public interface
 __all__ = ['submit_from', 'submit_file', 'load_json_tasks', 'validate_json_expansion',
+           'GatedSource', 'source_fingerprint_and_count',
            'SubmitThread', 'LiveSubmitThread', 'SubmitApp',
            'DEFAULT_TASK_GROUP', 'DEFAULT_BUNDLESIZE', 'DEFAULT_BUNDLEWAIT', 'DEFAULT_TEMPLATE']
 
@@ -87,6 +89,73 @@ log = Logger.with_name(__name__)
 # Redefined for docs
 DEFAULT_TASK_GROUP: Final[int] = DEFAULT_TASK_GROUP
 """Default task group for backwards compatibility."""
+
+
+class GatedSource:
+    """Wrap a task source with gate context that rides *inside* the source iterable.
+
+    Carries the resolved ``source_id`` (stamped onto every task by the :class:`Loader`)
+    and an optional ``skip_fingerprints`` set — task identities already present in a prior
+    same-path source lineage, which the Loader drops for ``--update``/``--restart`` de-dup.
+    Threading this inside ``source`` (rather than as kwargs) confines the gate plumbing to
+    the single ``Loader``/``Task.new`` stamping chokepoint instead of the ~10 coupled-core
+    constructors (submit_from / SubmitThread / ServerThread / cluster launchers).
+
+    ``__iter__`` delegates to the wrapped iterable, so every existing consumer that only
+    iterates ``source`` keeps working unchanged.
+    """
+
+    def __init__(self: GatedSource,
+                 iterable: Iterable[str | dict],
+                 source_id: str,
+                 skip_fingerprints: Optional[set] = None,
+                 name: Optional[str] = None) -> None:
+        """Initialize wrapper around `iterable` with gate context."""
+        self.iterable = iterable
+        self.source_id = source_id
+        self.skip_fingerprints = skip_fingerprints
+        self.name = name
+
+    def __iter__(self: GatedSource) -> Iterator[str | dict]:
+        """Delegate iteration to the wrapped source."""
+        return iter(self.iterable)
+
+
+def line_is_task(line: str, template: Template) -> bool:
+    """True if `line` yields a task under `template`.
+
+    A raw text line becomes a task iff, after template expansion and inline-comment
+    stripping, the command is non-empty. This mirrors the :class:`Loader`'s own
+    task/non-task split (blank, comment-only, and inline-tag-only lines are *not* tasks),
+    so an upfront count matches exactly what the Loader will submit.
+    """
+    args, _ = Task.split_argline(template.expand(str(line).strip()))
+    return bool(args)
+
+
+def source_fingerprint_and_count(path: str, template: str = DEFAULT_TEMPLATE) -> Tuple[str, int]:
+    """Read a named file upfront: content md5 (raw bytes) + task count (R4).
+
+    The md5 is over the raw file bytes (parsing-independent). The count is taken over a
+    *text-mode* read — the same universal-newline decoding the Loader uses — replaying the
+    shared :func:`line_is_task` predicate, so blank/comment/inline-tag-only lines are
+    excluded and the recorded count matches exactly what the Loader will submit, for any
+    newline convention (LF, CRLF, or bare CR). Both reads stream (no whole-file buffering).
+    Callers must route only seekable, re-readable files here; non-seekable inputs (pipes,
+    FIFOs, piped ``/dev/stdin``) are handled upstream (streamed like ``<stdin>``), because a
+    second independent read would drain them.
+    """
+    engine = Template(template)
+    digest = hashlib.md5()
+    with open(path, mode='rb') as raw_stream:
+        for chunk in iter(lambda: raw_stream.read(1 << 20), b''):
+            digest.update(chunk)
+    count = 0
+    with open(path, mode='r') as text_stream:  # text mode == the Loader's universal-newline split
+        for line in text_stream:
+            if line_is_task(line, engine):
+                count += 1
+    return digest.hexdigest(), count
 
 
 class LoaderState(State, Enum):
@@ -103,6 +172,8 @@ class Loader(StateMachine):
 
     task: Task
     source: Iterator[str | dict]
+    source_id: Optional[str]
+    skip_fingerprints: Optional[set]
     queue: Queue[Optional[Task]]
     cores: Optional[int]
     memory: Optional[int]
@@ -110,6 +181,7 @@ class Loader(StateMachine):
     template: Template
     group: int
     count: int
+    present: int
     tags: Dict[str, str]
 
     state = LoaderState.START
@@ -124,7 +196,18 @@ class Loader(StateMachine):
                  template: str = DEFAULT_TEMPLATE,
                  group: int = DEFAULT_TASK_GROUP,
                  tags: Dict[str, str] = None) -> None:
-        """Initialize source to read tasks and submit to database."""
+        """Initialize source to read tasks and submit to database.
+
+        A :class:`GatedSource` is unwrapped here: its ``source_id`` is stamped onto every
+        task and its ``skip_fingerprints`` (if any) drive de-dup. A plain iterable leaves
+        both unset (no stamping, no de-dup) — unchanged behavior for every legacy caller.
+        """
+        if isinstance(source, GatedSource):
+            self.source_id = source.source_id
+            self.skip_fingerprints = source.skip_fingerprints
+        else:
+            self.source_id = None
+            self.skip_fingerprints = None
         self.template = Template(template)
         self.source = iter(source)
         self.queue = queue
@@ -134,6 +217,7 @@ class Loader(StateMachine):
         self.group = group
         self.tags = tags
         self.count = 0
+        self.present = 0
 
     @functools.cached_property
     def actions(self: Loader) -> Dict[LoaderState, Callable[[], LoaderState]]:
@@ -163,10 +247,14 @@ class Loader(StateMachine):
 
     def load_line_task(self: Loader, line: str) -> LoaderState:
         """Build the next task from a command-line string in the text source."""
-        args = self.template.expand(str(line).strip())
-        self.task = Task.new(args=args, cores=self.cores, memory=self.memory, timeout=self.timeout,
+        raw = str(line).strip()
+        args = self.template.expand(raw)
+        self.task = Task.new(args=args, raw_args=raw, source=self.source_id,
+                             cores=self.cores, memory=self.memory, timeout=self.timeout,
                              group=self.group, tag=self.tags)
         if self.task.args:
+            if self.skip_task():
+                return LoaderState.GET
             log.trace(f'Loaded task ({self.task.args})')
             return LoaderState.PUT
         else:
@@ -192,10 +280,26 @@ class Loader(StateMachine):
         record_tags = {key: (json.dumps(value, separators=(',', ':')) if isinstance(value, (dict, list)) else value)
                        for key, value in record.items() if key != 'args'}
         tags = {**(self.tags or {}), **record_tags}
-        self.task = Task.new(args=args, cores=self.cores, memory=self.memory, timeout=self.timeout,
+        self.task = Task.new(args=args, raw_args=base, source=self.source_id,
+                             cores=self.cores, memory=self.memory, timeout=self.timeout,
                              group=self.group, tag=tags, strict_tag=False, parse_inline=False)
+        if self.skip_task():
+            return LoaderState.GET
         log.trace(f'Loaded task ({self.task.args})')
         return LoaderState.PUT
+
+    def skip_task(self: Loader) -> bool:
+        """True if the loaded task's identity is already present in the prior lineage (de-dup).
+
+        Used by ``--update``/``--restart``: a task whose fingerprint is in the skip-set is
+        counted as *present* and not enqueued (no ``count`` increment). Without a skip-set
+        (the common case) this is always False.
+        """
+        if self.skip_fingerprints and self.task.fingerprint in self.skip_fingerprints:
+            self.present += 1
+            log.trace(f'Skipping already-present task ({self.task.args})')
+            return True
+        return False
 
     def put_task(self: Loader) -> LoaderState:
         """Enqueue loaded task."""
@@ -206,9 +310,10 @@ class Loader(StateMachine):
         except QueueFull:
             return LoaderState.PUT
 
-    @staticmethod
-    def finalize() -> LoaderState:
-        """Return HALT."""
+    def finalize(self: Loader) -> LoaderState:
+        """Log the de-dup tally (when active) and return HALT."""
+        if self.skip_fingerprints is not None:
+            log.info(f'{self.present} tasks already present; submitting {self.count} new tasks')
         log.debug('Done (loader)')
         return LoaderState.HALT
 
@@ -434,7 +539,9 @@ class SubmitThread(Thread):
     @functools.cached_property
     def source_name(self: SubmitThread) -> str:
         """Log details of source."""
-        if self.source is sys.stdin:
+        if isinstance(self.source, GatedSource):
+            return self.source.name or '<iterable>'
+        elif self.source is sys.stdin:
             return '<stdin>'
         elif isinstance(self.source, io.TextIOWrapper):
             return self.source.name
@@ -673,7 +780,9 @@ class LiveSubmitThread(Thread):
     @functools.cached_property
     def source_name(self: LiveSubmitThread) -> str:
         """Log details of source."""
-        if self.source is sys.stdin:
+        if isinstance(self.source, GatedSource):
+            return self.source.name or '<iterable>'
+        elif self.source is sys.stdin:
             return '<stdin>'
         elif isinstance(self.source, io.TextIOWrapper):
             return self.source.name
@@ -997,6 +1106,8 @@ class SubmitApp(Application):
     interface = Interface(APP_NAME, APP_USAGE, APP_HELP)
 
     source: IO | List[str] | None = None
+    source_path: Optional[str] = None       # absolute path of a named task file (else None)
+    source_id: Optional[str] = None         # resolved Source.id stamped onto submitted tasks
     task_args: List[str] = []
     task_file: str = None
     from_json: str = None
@@ -1078,6 +1189,7 @@ class SubmitApp(Application):
                 group = Task.current_group()
                 self.group = group.value
                 log.info(f'Auto-selected task group {group.value} ({group.reason})')
+            self.prepare_source()
         if self.source is not None:
             self.submit_all()
         else:
@@ -1098,8 +1210,8 @@ class SubmitApp(Application):
                         cores=self.cores, memory=self.memory, timeout=self.timeout, group=self.group,
                         tags=self.tags)
         else:
-            task = Task.new(args=args, cores=self.cores, memory=self.memory, timeout=self.timeout, 
-                            group=self.group, tag=self.tags)
+            task = Task.new(args=args, cores=self.cores, memory=self.memory, timeout=self.timeout,
+                            group=self.group, tag=self.tags, source=self.source_id)
             Task.add(task)
             log.info(f'Submitted task ({task.id})')
 
@@ -1139,6 +1251,7 @@ class SubmitApp(Application):
         elif self.task_file is not None:
             log.debug(f'Submitted from {self.task_file} (explicit)')
             self.source = open(self.task_file, mode='r')
+            self.source_path = os.path.abspath(self.task_file)
         elif len(self.task_args) == 0:
             log.debug(f'Submitted from <stdin> (implicit)')
             self.source = sys.stdin
@@ -1151,6 +1264,7 @@ class SubmitApp(Application):
                 if not os.access(filepath, os.X_OK):
                     log.debug(f'Submitted from {filepath} (implicit - not executable)')
                     self.source = open(filepath, mode='r')
+                    self.source_path = os.path.abspath(filepath)
                 else:
                     log.debug(f'Submitted single task (implicit - executable)')
                     self.source = None
@@ -1160,6 +1274,38 @@ class SubmitApp(Application):
         else:
             log.debug(f'Submitted single task (explicit)')
             self.source = None
+
+    def prepare_source(self: SubmitApp) -> None:
+        """Resolve the task Source and wrap the stream so tasks are stamped (DB mode only).
+
+        A named file gets a fresh :class:`Source` row whose recorded ``task_count`` is the
+        upfront-counted expectation, committed *before* any task so an incomplete prior
+        submission stays detectable (R1/R7). ``<stdin>`` and single-command ``<direct>``
+        submissions resolve their reserved fixed-id rows and are exempt from gating (R3).
+        ``--from-json`` gating is deferred to a later phase. No refuse/repeat/update
+        decisions happen here — only stamping (that gate matrix lands in P3).
+        """
+        if not DATABASE_ENABLED:
+            return  # non-persistent DB: nothing to record against (invariant §4)
+        if self.from_json:
+            return  # JSON source gating handled in a later phase
+        if self.source is None:
+            self.source_id = Source.reserved(DIRECT_SOURCE_ID).id
+        elif self.source is sys.stdin or not self.source.seekable():
+            # Real <stdin> and non-seekable named inputs (process substitution, FIFOs, a
+            # piped /dev/stdin) have no stable identity and cannot be re-read for an upfront
+            # count — stream them under the reserved <stdin> source, exempt from gating. A
+            # second read would drain the pipe and silently drop every task.
+            self.source_id = Source.reserved(STDIN_SOURCE_ID).id
+            name = '<stdin>' if self.source is sys.stdin else self.source_path
+            self.source = GatedSource(self.source, self.source_id, name=name)
+        else:
+            fingerprint, count = source_fingerprint_and_count(self.source_path, self.template)
+            log.info(f'Found {count} tasks in {self.source_path} (md5={fingerprint})')
+            source = Source.new(path=self.source_path, fingerprint=fingerprint, task_count=count)
+            Source.add(source)
+            self.source_id = source.id
+            self.source = GatedSource(self.source, self.source_id, name=self.source_path)
 
     @staticmethod
     def quote_arg(arg: str) -> str:
@@ -1188,5 +1334,6 @@ class SubmitApp(Application):
                  exc_val: Optional[Exception],
                  exc_tb: Optional[TracebackType]) -> None:
         """Close file if not stdin."""
-        if self.source is not None and self.source is not sys.stdin and hasattr(self.source, 'close'):
-            self.source.close()
+        source = self.source.iterable if isinstance(self.source, GatedSource) else self.source
+        if source is not None and source is not sys.stdin and hasattr(source, 'close'):
+            source.close()

--- a/src/hypershell/task.py
+++ b/src/hypershell/task.py
@@ -44,10 +44,10 @@ from hypershell.core.logging import Logger, HOSTNAME
 from hypershell.core.remote import SSHConnection
 from hypershell.core.signal import exit_status_for_signal
 from hypershell.core.types import smart_coerce, JSONData, to_json_type
-from hypershell.core.pretty_print import format_tag, format_json, format_bytes
+from hypershell.core.pretty_print import format_tag, format_json, format_bytes, format_source
 from hypershell.core.tag import Tag
 from hypershell.data.core import Session
-from hypershell.data.model import Task, JSON, CANCEL_STATUS
+from hypershell.data.model import Task, Source, JSON, CANCEL_STATUS
 from hypershell.data import ensuredb, DATABASE_DIALECT
 
 # Public interface
@@ -776,9 +776,11 @@ class TaskSearchApp(Application, SearchableMixin):
     @staticmethod
     def print_normal(results: List[Tuple]) -> None:
         """Print semi-structured output with all field names."""
-        for record in results:
+        tasks = [Task.from_dict(dict(zip(Task.columns, record))) for record in results]
+        source_map = Source.paths_for_ids([task.source for task in tasks if task.source])
+        for task in tasks:
             print('---')
-            print_normal(Task.from_dict(dict(zip(Task.columns, record))))
+            print_normal(task, source_map=source_map)
 
     def print_plain(self: TaskSearchApp, results: List[Tuple]) -> None:
         """Print plain text output with given field names, one task per line."""
@@ -1285,6 +1287,7 @@ class WhereClause:
 NORMAL_MODE_TEMPLATE: Final[str] = """\
           id: {id}
        group: {group}
+      source: {source}
         args: {args}
      command: {command}
        cores: {cores} (used: {cores_max})
@@ -1349,8 +1352,31 @@ def select_style(status: Optional[int]) -> Optional[str]:
     return SPECIAL_TASK_STYLES.get(status, 'yellow' if status is not None and status < 0 else 'red')
 
 
-def print_normal(task: Task) -> None:
-    """Print semi-structured task metadata with all field names."""
+def resolve_source(source: Optional[str], source_map: Optional[Dict[str, str]] = None) -> str:
+    """Resolve a task's `source` UUID to a display path/sentinel for the normal view.
+
+    NULL (historical rows) renders as ``null``. A batched `source_map` (id -> path) is
+    consulted first to avoid an N+1 lookup; otherwise a single `Source.from_id` resolves
+    it. An id with no matching source row degrades to the raw id rather than raising.
+    """
+    if not source:
+        return 'null'
+    if source_map is not None:
+        path = source_map.get(source)
+    else:
+        try:
+            path = Source.from_id(source).path
+        except Source.NotFound:
+            path = None
+    return format_source(path) if path else source
+
+
+def print_normal(task: Task, source_map: Optional[Dict[str, str]] = None) -> None:
+    """Print semi-structured task metadata with all field names.
+
+    `source_map` (id -> path) lets a multi-task caller batch-resolve sources up front and
+    avoid an N+1 lookup; when omitted (e.g. `hs info`), the single source is resolved directly.
+    """
     task_data = {k: format_json(v) for k, v in task.to_dict().items()}
     task_data['waited'] = 'null' if task.waited is None else timedelta(seconds=int(task_data['waited']))
     task_data['duration'] = 'null' if task.duration is None else timedelta(seconds=int(task_data['duration']))
@@ -1360,5 +1386,6 @@ def print_normal(task: Task) -> None:
     task_data['memory'] = format_bytes(int(task.memory or 0))
     task_data['memory_max'] = 'null' if not task.memory_max else format_bytes(int(task.memory_max))
     task_data['timeout'] = 'null' if not task.timeout else timedelta(seconds=int(task.timeout))
+    task_data['source'] = resolve_source(task.source, source_map)
     color = select_color(task.exit_status)
     print(color(NORMAL_MODE_TEMPLATE.format(**task_data)))

--- a/src/hypershell/task.py
+++ b/src/hypershell/task.py
@@ -1285,9 +1285,9 @@ class WhereClause:
 
 
 NORMAL_MODE_TEMPLATE: Final[str] = """\
-          id: {id}
+          id: {id} ({fingerprint})
        group: {group}
-      source: {source}
+      source: {source} ({source_id})
         args: {args}
      command: {command}
        cores: {cores} (used: {cores_max})
@@ -1386,6 +1386,7 @@ def print_normal(task: Task, source_map: Optional[Dict[str, str]] = None) -> Non
     task_data['memory'] = format_bytes(int(task.memory or 0))
     task_data['memory_max'] = 'null' if not task.memory_max else format_bytes(int(task.memory_max))
     task_data['timeout'] = 'null' if not task.timeout else timedelta(seconds=int(task.timeout))
+    task_data['source_id'] = format_json(task.source)          # raw Source.id, shown in parens on `source`
     task_data['source'] = resolve_source(task.source, source_map)
     color = select_color(task.exit_status)
     print(color(NORMAL_MODE_TEMPLATE.format(**task_data)))

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -215,7 +215,9 @@ def test_group_starts_based_on_previous_scheduled_tasks(temp_site: Path) -> None
         'echo 3  #HYPERSHELL: n:3 group:5',
     ]
 
-    taskfile = create_taskfile(temp_site, tasks)
+    # Distinct source paths: the two batches are genuinely different files, so re-submission
+    # gating (R6 refuses changed content at a seen path with no flag) does not apply between them.
+    taskfile = create_taskfile(temp_site, tasks, filename='batch1.in')
     main(['hs', 'submit', '-f', str(taskfile)])
     rc, stdout, stderr = main(['hs', 'cluster', '--restart'])
     assert rc == exit_status.success
@@ -231,7 +233,7 @@ def test_group_starts_based_on_previous_scheduled_tasks(temp_site: Path) -> None
         'echo 13  #HYPERSHELL: n:13 group:50',
     ]
 
-    taskfile = create_taskfile(temp_site, tasks)
+    taskfile = create_taskfile(temp_site, tasks, filename='batch2.in')
     main(['hs', 'submit', '-f', str(taskfile)])
     rc, stdout, stderr = main(['hs', 'cluster', '--restart'])
     assert rc == exit_status.success

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -216,7 +216,7 @@ def test_group_starts_based_on_previous_scheduled_tasks(temp_site: Path) -> None
     ]
 
     # Distinct source paths: the two batches are genuinely different files, so re-submission
-    # gating (R6 refuses changed content at a seen path with no flag) does not apply between them.
+    # gating (which refuses changed content at a seen path with no flag) does not apply between them.
     taskfile = create_taskfile(temp_site, tasks, filename='batch1.in')
     main(['hs', 'submit', '-f', str(taskfile)])
     rc, stdout, stderr = main(['hs', 'cluster', '--restart'])

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Geoffrey Lentner
 # SPDX-License-Identifier: Apache-2.0
 
-"""Integration tests for the ``hsx`` / ``hs cluster`` re-submission gate (R11-R16).
+"""Integration tests for the ``hsx`` / ``hs cluster`` re-submission gate.
 
 These drive the real cluster (embedded server + local client) so that de-duplicated and
 novel tasks are not merely *submitted* but actually *run* — the scheduler must not stop a
@@ -26,7 +26,7 @@ from tests import main, main_lines, NO_OUTPUT, create_taskfile, create_taskfile_
 
 @mark.integration
 def test_restart_no_flag_refuses_seen_file(temp_site: Path) -> None:
-    """hsx with no gating flag detects and refuses a file already submitted (R11 == R5)."""
+    """hsx with no gating flag detects and refuses a file already submitted."""
     taskfile = create_taskfile_echo(temp_site, count=4)
 
     # First run: a new file — submit all and run to completion.
@@ -46,7 +46,7 @@ def test_restart_no_flag_refuses_seen_file(temp_site: Path) -> None:
 
 @mark.integration
 def test_restart_idempotent_across_requeues(temp_site: Path) -> None:
-    """hsx FILE --restart is idempotent — requeuing the same job submits nothing new (R12)."""
+    """hsx FILE --restart is idempotent — requeuing the same job submits nothing new."""
     taskfile = create_taskfile_echo(temp_site, count=4)
 
     rc, stdout, stderr = main(['hsx', str(taskfile), '--restart'])
@@ -63,7 +63,7 @@ def test_restart_idempotent_across_requeues(temp_site: Path) -> None:
 
 @mark.integration
 def test_restart_refuses_changed_file(temp_site: Path) -> None:
-    """hsx FILE --restart refuses a changed file at a seen path, suggesting --update (R12)."""
+    """hsx FILE --restart refuses a changed file at a seen path, suggesting --update."""
     taskfile = create_taskfile_echo(temp_site, count=4)
     rc, _, stderr = main(['hsx', str(taskfile), '--restart'])
     assert rc == exit_status.success, stderr
@@ -79,7 +79,7 @@ def test_restart_refuses_changed_file(temp_site: Path) -> None:
 
 @mark.integration
 def test_restart_update_alone_is_ambiguous(temp_site: Path) -> None:
-    """hsx --update without --restart (or --repeat) is ambiguous and rejected (R13)."""
+    """hsx --update without --restart (or --repeat) is ambiguous and rejected."""
     taskfile = create_taskfile_echo(temp_site, count=2)
     assert main_lines(['hsx', str(taskfile), '--update']) == (
         exit_status.bad_argument, NO_OUTPUT, ['CRITICAL [hypershell] Using --update requires --restart']
@@ -88,7 +88,7 @@ def test_restart_update_alone_is_ambiguous(temp_site: Path) -> None:
 
 @mark.integration
 def test_restart_update_adds_novel_and_runs(temp_site: Path) -> None:
-    """hsx --update --restart records a new source and runs only the novel tasks (R14)."""
+    """hsx --update --restart records a new source and runs only the novel tasks."""
     taskfile = create_taskfile_echo(temp_site, count=4)
     rc, _, stderr = main(['hsx', str(taskfile), '--restart'])
     assert rc == exit_status.success, stderr
@@ -98,7 +98,7 @@ def test_restart_update_adds_novel_and_runs(temp_site: Path) -> None:
     create_taskfile_echo(temp_site, count=6)  # overwrites task.in at the same path
     rc, stdout, stderr = main(['hsx', str(taskfile), '--update', '--restart'])
     assert rc == exit_status.success, stderr
-    # Only the two novel tasks run; the four already-present tasks are skipped (R18 tally).
+    # Only the two novel tasks run; the four already-present tasks are skipped (de-dup tally).
     assert sorted(stdout.split('\n')) == ['4', '5']
     assert_output(r'INFO .* 4 tasks already present; submitting 2 new tasks$', stderr, 1)
     assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['6'], NO_OUTPUT)
@@ -106,7 +106,7 @@ def test_restart_update_adds_novel_and_runs(temp_site: Path) -> None:
 
 @mark.integration
 def test_restart_repeat_resubmits_all(temp_site: Path) -> None:
-    """hsx --repeat records a new source and resubmits all tasks even on a match (R15)."""
+    """hsx --repeat records a new source and resubmits all tasks even on a match."""
     taskfile = create_taskfile_echo(temp_site, count=4)
     rc, _, stderr = main(['hsx', str(taskfile), '--restart'])
     assert rc == exit_status.success, stderr
@@ -121,7 +121,7 @@ def test_restart_repeat_resubmits_all(temp_site: Path) -> None:
 
 @mark.integration
 def test_restart_update_repeat_contradictory(temp_site: Path) -> None:
-    """hsx --update --repeat is contradictory and rejected before any work (R16)."""
+    """hsx --update --repeat is contradictory and rejected before any work."""
     taskfile = create_taskfile_echo(temp_site, count=2)
     assert main_lines(['hsx', str(taskfile), '--update', '--repeat']) == (
         exit_status.bad_argument, NO_OUTPUT, ['CRITICAL [hypershell] Cannot combine --update with --repeat']

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: 2026 Geoffrey Lentner
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for the ``hsx`` / ``hs cluster`` re-submission gate (R11-R16).
+
+These drive the real cluster (embedded server + local client) so that de-duplicated and
+novel tasks are not merely *submitted* but actually *run* — the scheduler must not stop a
+run before a co-running submitter has committed its novel rows into a database that already
+holds only completed tasks (see ``hypershell.server.Scheduler.submission_complete``).
+"""
+
+
+# Type annotations
+from __future__ import annotations
+
+# Standard libs
+from pathlib import Path
+
+# External libs
+from pytest import mark
+from cmdkit.app import exit_status
+
+# Internal libs
+from tests import main, main_lines, NO_OUTPUT, create_taskfile, create_taskfile_echo, assert_output
+
+
+@mark.integration
+def test_restart_no_flag_refuses_seen_file(temp_site: Path) -> None:
+    """hsx with no gating flag detects and refuses a file already submitted (R11 == R5)."""
+    taskfile = create_taskfile_echo(temp_site, count=4)
+
+    # First run: a new file — submit all and run to completion.
+    rc, stdout, stderr = main(['hsx', str(taskfile)])
+    assert rc == exit_status.success, stderr
+    assert sorted(stdout.split('\n')) == ['0', '1', '2', '3']
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['4'], NO_OUTPUT)
+
+    # Second run, no flag: the (path, fingerprint) match is refused, naming the prior source.
+    rc, stdout, stderr = main(['hsx', str(taskfile)])
+    assert rc == exit_status.bad_argument
+    assert stdout == ''
+    assert_output(r'CRITICAL .* was already submitted as source .*', stderr, 1)
+    # Refused before anything new is written — the count is unchanged.
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['4'], NO_OUTPUT)
+
+
+@mark.integration
+def test_restart_idempotent_across_requeues(temp_site: Path) -> None:
+    """hsx FILE --restart is idempotent — requeuing the same job submits nothing new (R12)."""
+    taskfile = create_taskfile_echo(temp_site, count=4)
+
+    rc, stdout, stderr = main(['hsx', str(taskfile), '--restart'])
+    assert rc == exit_status.success, stderr
+    assert sorted(stdout.split('\n')) == ['0', '1', '2', '3']
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['4'], NO_OUTPUT)
+
+    # Requeue: the fingerprint matches, every task is already present -> zero new tasks.
+    rc, stdout, stderr = main(['hsx', str(taskfile), '--restart'])
+    assert rc == exit_status.success, stderr
+    assert stdout == ''
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['4'], NO_OUTPUT)
+
+
+@mark.integration
+def test_restart_refuses_changed_file(temp_site: Path) -> None:
+    """hsx FILE --restart refuses a changed file at a seen path, suggesting --update (R12)."""
+    taskfile = create_taskfile_echo(temp_site, count=4)
+    rc, _, stderr = main(['hsx', str(taskfile), '--restart'])
+    assert rc == exit_status.success, stderr
+
+    # Same path, different content -> different source fingerprint -> refuse (alert + suggest).
+    create_taskfile_echo(temp_site, count=6)  # overwrites task.in at the same path
+    rc, stdout, stderr = main(['hsx', str(taskfile), '--restart'])
+    assert rc == exit_status.bad_argument
+    assert_output(r'CRITICAL .* differs from its prior submission.*--update', stderr, 1)
+    # Nothing new landed on the refusal.
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['4'], NO_OUTPUT)
+
+
+@mark.integration
+def test_restart_update_alone_is_ambiguous(temp_site: Path) -> None:
+    """hsx --update without --restart (or --repeat) is ambiguous and rejected (R13)."""
+    taskfile = create_taskfile_echo(temp_site, count=2)
+    assert main_lines(['hsx', str(taskfile), '--update']) == (
+        exit_status.bad_argument, NO_OUTPUT, ['CRITICAL [hypershell] Using --update requires --restart']
+    )
+
+
+@mark.integration
+def test_restart_update_adds_novel_and_runs(temp_site: Path) -> None:
+    """hsx --update --restart records a new source and runs only the novel tasks (R14)."""
+    taskfile = create_taskfile_echo(temp_site, count=4)
+    rc, _, stderr = main(['hsx', str(taskfile), '--restart'])
+    assert rc == exit_status.success, stderr
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['4'], NO_OUTPUT)
+
+    # Extend the same file: the first four lines are byte-identical, two are new.
+    create_taskfile_echo(temp_site, count=6)  # overwrites task.in at the same path
+    rc, stdout, stderr = main(['hsx', str(taskfile), '--update', '--restart'])
+    assert rc == exit_status.success, stderr
+    # Only the two novel tasks run; the four already-present tasks are skipped (R18 tally).
+    assert sorted(stdout.split('\n')) == ['4', '5']
+    assert_output(r'INFO .* 4 tasks already present; submitting 2 new tasks$', stderr, 1)
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['6'], NO_OUTPUT)
+
+
+@mark.integration
+def test_restart_repeat_resubmits_all(temp_site: Path) -> None:
+    """hsx --repeat records a new source and resubmits all tasks even on a match (R15)."""
+    taskfile = create_taskfile_echo(temp_site, count=4)
+    rc, _, stderr = main(['hsx', str(taskfile), '--restart'])
+    assert rc == exit_status.success, stderr
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['4'], NO_OUTPUT)
+
+    rc, stdout, stderr = main(['hsx', str(taskfile), '--repeat'])
+    assert rc == exit_status.success, stderr
+    # All four tasks run again; the database now holds two copies (two sources).
+    assert sorted(stdout.split('\n')) == ['0', '1', '2', '3']
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['8'], NO_OUTPUT)
+
+
+@mark.integration
+def test_restart_update_repeat_contradictory(temp_site: Path) -> None:
+    """hsx --update --repeat is contradictory and rejected before any work (R16)."""
+    taskfile = create_taskfile_echo(temp_site, count=2)
+    assert main_lines(['hsx', str(taskfile), '--update', '--repeat']) == (
+        exit_status.bad_argument, NO_OUTPUT, ['CRITICAL [hypershell] Cannot combine --update with --repeat']
+    )
+
+
+@mark.integration
+def test_restart_repeat_contradictory(temp_site: Path) -> None:
+    """hsx --restart --repeat is contradictory (resume vs. fresh full run) and rejected."""
+    taskfile = create_taskfile_echo(temp_site, count=2)
+    assert main_lines(['hsx', str(taskfile), '--restart', '--repeat']) == (
+        exit_status.bad_argument, NO_OUTPUT, ['CRITICAL [hypershell] Cannot combine --restart with --repeat']
+    )
+
+
+@mark.integration
+def test_cluster_new_file_runs_against_completed_db(temp_site: Path) -> None:
+    """A brand-new file runs even when the database already holds only completed tasks.
+
+    Guards the scheduler start-race: with prior work all completed the database reads as
+    ``remaining == 0``, so the scheduler must wait for the co-running submitter to commit the
+    novel rows instead of stopping immediately.
+    """
+    first = create_taskfile_echo(temp_site, count=4)  # task.in -> run to completion
+    rc, _, stderr = main(['hsx', str(first), '--restart'])
+    assert rc == exit_status.success, stderr
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['4'], NO_OUTPUT)
+
+    # Different path, new content: all tasks must actually run, not just get submitted.
+    second = create_taskfile(temp_site, ['echo x', 'echo y'], filename='second.in')
+    rc, stdout, stderr = main(['hsx', str(second)])
+    assert rc == exit_status.success, stderr
+    assert sorted(stdout.split('\n')) == ['x', 'y']
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['6'], NO_OUTPUT)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -117,15 +117,52 @@ def test_fresh_schema_creates_source_table_columns_and_indices() -> None:
 
 
 @mark.unit
-def test_tasks_source_index_is_partial_excluding_reserved() -> None:
-    """The de-dup index excludes the reserved <direct>/<stdin> source ids (partial predicate)."""
+def test_tasks_source_index_is_full_covering_not_partial() -> None:
+    """The de-dup/detection index covers (source, fingerprint) and is NOT partial (R17).
+
+    A partial ``WHERE source NOT IN (reserved)`` predicate is only honored when the query
+    repeats it with matching literals; the parameterized ``count_for_source`` /
+    ``fingerprints_for_sources`` lookups bind ``source`` instead, which no engine can prove
+    satisfies a literal partial predicate — so a partial index silently degrades them to a
+    full table scan. A full index is used with plain bound parameters everywhere.
+    """
     engine = create_engine('sqlite://')
     Entity.metadata.create_all(engine)
     insp = inspect(engine)
     (entry,) = [ix for ix in insp.get_indexes('task') if ix['name'] == 'index_tasks_source']
-    predicate = str(entry.get('dialect_options', {}).get('sqlite_where'))
-    assert DIRECT_SOURCE_ID in predicate
-    assert STDIN_SOURCE_ID in predicate
+    assert entry['column_names'] == ['source', 'fingerprint']         # covering (source, fingerprint)
+    assert not entry.get('dialect_options', {}).get('sqlite_where')   # no partial predicate
+
+
+@mark.unit
+def test_source_lookups_use_the_index_not_a_full_scan() -> None:
+    """R17: the count + lineage de-dup lookups are index-backed, not full table scans.
+
+    Mirrors the ``WHERE`` clauses of :meth:`Task.count_for_source` and
+    :meth:`Task.fingerprints_for_sources` on a populated throwaway table and asserts the
+    planner reaches for ``index_tasks_source`` instead of scanning ``task`` (the linear cost
+    R17 forbids at billions–trillions of rows). A partial index would ``SCAN`` here.
+    """
+    engine = create_engine('sqlite://')
+    Entity.metadata.create_all(engine)
+    real = 'aaaaaaaa-0000-7000-8000-000000000000'
+    columns = ('id', '"group"', 'args', 'submit_id', 'submit_time', 'attempt', 'retried', 'tag',
+               'source', 'fingerprint')
+    rows = ([(f'{i:036d}', 1, 'echo', 'sub', '2026-01-01', 1, 0, '{}', real, f'fp{i % 5}')
+             for i in range(30)] +
+            [(f'r{i:035d}', 1, 'echo', 'sub', '2026-01-01', 1, 0, '{}', DIRECT_SOURCE_ID, None)
+             for i in range(2000)])   # bulk reserved rows -> a scan would be far costlier than the index
+    with engine.begin() as conn:
+        conn.exec_driver_sql(f'INSERT INTO task ({", ".join(columns)}) VALUES ({", ".join(["?"] * len(columns))})', rows)
+        conn.exec_driver_sql('ANALYZE')
+    with engine.connect() as conn:
+        count_plan = ' | '.join(r[-1] for r in conn.exec_driver_sql(
+            'EXPLAIN QUERY PLAN SELECT count(*) FROM task WHERE source = ?', (real,)))
+        fp_plan = ' | '.join(r[-1] for r in conn.exec_driver_sql(
+            'EXPLAIN QUERY PLAN SELECT DISTINCT fingerprint FROM task WHERE source IN (?) '
+            'AND fingerprint IS NOT NULL', (real,)))
+    assert 'index_tasks_source' in count_plan and 'SCAN task' not in count_plan, count_plan
+    assert 'index_tasks_source' in fp_plan and 'SCAN task' not in fp_plan, fp_plan
 
 
 # --- Presentation: source resolution for humans (R18-adjacent) -------------------------------------

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: 2026 Geoffrey Lentner
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the source/fingerprint core (Task.compute_fingerprint, Source schema)."""
+
+
+# Type annotations
+from __future__ import annotations
+
+# External libs
+from pytest import mark
+from sqlalchemy import create_engine, inspect
+
+# Internal libs
+from hypershell.data.model import (
+    Task, Source, Entity, DIRECT_SOURCE_ID, STDIN_SOURCE_ID,
+)
+
+
+# --- Identity fingerprint semantics (R2) -----------------------------------------------------------
+
+@mark.unit
+def test_fingerprint_is_order_independent_over_tags() -> None:
+    """Tag insertion order must not change the fingerprint (canonical, sorted keys)."""
+    a = Task.compute_fingerprint('echo 1', 0, {'alpha': '1', 'beta': '2', 'gamma': '3'})
+    b = Task.compute_fingerprint('echo 1', 0, {'gamma': '3', 'alpha': '1', 'beta': '2'})
+    assert a == b
+
+
+@mark.unit
+def test_fingerprint_stable_across_template_uuid_and_attempt() -> None:
+    """Identity keys off the pre-template raw command, not the expanded args/uuid/attempt.
+
+    Two tasks built from the same raw line but different templates (different expanded
+    ``args``), different uuids, and different attempt counters share one fingerprint.
+    """
+    t1 = Task.new(args='echo hello', raw_args='hello', attempt=1)
+    t2 = Task.new(args='printf hello', raw_args='hello', attempt=4)
+    assert t1.args != t2.args           # different template expansions
+    assert t1.id != t2.id               # freshly minted uuids
+    assert t1.attempt != t2.attempt
+    assert t1.fingerprint == t2.fingerprint
+
+
+@mark.unit
+def test_fingerprint_differs_on_args_group_or_tag_change() -> None:
+    """Any change to args, group, or a user tag yields a different fingerprint."""
+    base = Task.compute_fingerprint('echo a', 0, {'x': '1'})
+    assert base != Task.compute_fingerprint('echo b', 0, {'x': '1'})   # args
+    assert base != Task.compute_fingerprint('echo a', 1, {'x': '1'})   # group
+    assert base != Task.compute_fingerprint('echo a', 0, {'x': '2'})   # tag value
+    assert base != Task.compute_fingerprint('echo a', 0, {'y': '1'})   # tag key
+
+
+@mark.unit
+def test_fingerprint_excludes_part_tag() -> None:
+    """The bookkeeping ``part`` tag (rewritten on rotation) must not affect identity."""
+    a = Task.compute_fingerprint('echo a', 0, {'k': '1', 'part': 0})
+    b = Task.compute_fingerprint('echo a', 0, {'k': '1', 'part': 7})
+    c = Task.compute_fingerprint('echo a', 0, {'k': '1'})
+    assert a == b == c
+
+
+@mark.unit
+def test_fingerprint_excludes_resource_knobs() -> None:
+    """cores/memory/timeout are popped into columns before identity, so they don't count."""
+    t1 = Task.new(args='echo', raw_args='echo', tag={'cores': 2, 'memory': 100, 'timeout': 30})
+    t2 = Task.new(args='echo', raw_args='echo', tag={'cores': 8, 'memory': 999, 'timeout': 90})
+    plain = Task.new(args='echo', raw_args='echo')
+    assert t1.fingerprint == t2.fingerprint == plain.fingerprint
+
+
+@mark.unit
+def test_new_stamps_source_and_falls_back_to_args_without_raw() -> None:
+    """``source`` is stamped verbatim; without ``raw_args`` the fingerprint falls back to args."""
+    stamped = Task.new(args='echo x', raw_args='x', source=DIRECT_SOURCE_ID)
+    assert stamped.source == DIRECT_SOURCE_ID
+    fallback = Task.new(args='echo x')            # no raw_args -> uses expanded args
+    assert fallback.fingerprint == Task.compute_fingerprint('echo x', 0, {'part': 0})
+
+
+@mark.unit
+def test_supplied_fingerprint_is_not_recomputed() -> None:
+    """A retry copies its parent's fingerprint verbatim rather than recomputing it."""
+    parent_fp = 'deadbeef' * 4
+    child = Task.new(args='echo different', raw_args='different', fingerprint=parent_fp)
+    assert child.fingerprint == parent_fp
+
+
+# --- Schema groundwork (R1, R17) -------------------------------------------------------------------
+
+@mark.unit
+def test_fresh_schema_creates_source_table_columns_and_indices() -> None:
+    """A fresh ``create_all`` yields the source table, the new task columns, and both indices."""
+    engine = create_engine('sqlite://')  # throwaway in-memory db, independent of the global engine
+    Entity.metadata.create_all(engine)
+    insp = inspect(engine)
+
+    assert insp.has_table('source')
+    source_columns = {col['name'] for col in insp.get_columns('source')}
+    assert source_columns == {'id', 'path', 'fingerprint', 'task_count', 'created'}
+
+    task_columns = {col['name'] for col in insp.get_columns('task')}
+    assert {'source', 'fingerprint'} <= task_columns
+
+    source_indices = {ix['name'] for ix in insp.get_indexes('source')}
+    task_indices = {ix['name'] for ix in insp.get_indexes('task')}
+    assert 'index_source_lookup' in source_indices
+    assert 'index_tasks_source' in task_indices
+
+
+@mark.unit
+def test_tasks_source_index_is_partial_excluding_reserved() -> None:
+    """The de-dup index excludes the reserved <direct>/<stdin> source ids (partial predicate)."""
+    engine = create_engine('sqlite://')
+    Entity.metadata.create_all(engine)
+    insp = inspect(engine)
+    (entry,) = [ix for ix in insp.get_indexes('task') if ix['name'] == 'index_tasks_source']
+    predicate = str(entry.get('dialect_options', {}).get('sqlite_where'))
+    assert DIRECT_SOURCE_ID in predicate
+    assert STDIN_SOURCE_ID in predicate

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -185,8 +185,8 @@ def test_format_source_passes_sentinels_shows_paths_and_keeps_specs_opaque() -> 
 
 @mark.integration
 def test_normal_view_resolves_source_while_machine_formats_stay_raw(temp_site: Path) -> None:
-    """The human `normal` view resolves `source` UUID -> path (single + batched); machine surfaces keep
-    the raw UUID and `fingerprint` never leaks into the normal template."""
+    """The human `normal` view resolves `source` UUID -> path (single + batched) with the raw Source.id
+    in parens, and shows the identity fingerprint in parens on the id; machine surfaces keep raw values."""
     taskfile = create_taskfile_echo(temp_site, count=3)
     assert main(['hs', 'submit', str(taskfile)])[0] == 0
 
@@ -194,16 +194,18 @@ def test_normal_view_resolves_source_while_machine_formats_stay_raw(temp_site: P
     assert rc == 0
     task_id = ids[0]
 
-    # `hs info` (single-task normal view) resolves source to the absolute file path...
+    # `hs info` (single-task normal view) resolves source -> abspath with the Source.id in parens, and
+    # shows the identity fingerprint (md5) in parens on the id line.
     rc, stdout, _ = main(['hs', 'info', task_id])
     assert rc == 0
-    assert_output(rf'source: {re.escape(str(taskfile))}$', stdout, 1)
-    assert 'fingerprint:' not in stdout            # fingerprint stays out of the normal template
+    assert_output(rf'source: {re.escape(str(taskfile))} \([0-9a-f-]+\)$', stdout, 1)
+    assert_output(r'id: [0-9a-f-]+ \([0-9a-f]{32}\)$', stdout, 1)   # fingerprint (md5) in parens on the id
+    assert 'fingerprint:' not in stdout            # shown inline on `id`, not as a separate labeled field
 
     # ...and the many-task normal view resolves every row via the batched source_map (no N+1)
     rc, listing, _ = main(['hs', 'list', '--all'])
     assert rc == 0
-    assert_output(rf'source: {re.escape(str(taskfile))}$', listing, 3)
+    assert_output(rf'source: {re.escape(str(taskfile))} \([0-9a-f-]+\)$', listing, 3)
 
     # machine surfaces keep the raw source UUID (stable, scriptable)
     rc, raw, _ = main(['hs', 'info', task_id, '-x', 'source'])
@@ -219,4 +221,4 @@ def test_normal_view_resolves_reserved_sentinels(temp_site: Path) -> None:
     assert rc == 0
     rc, stdout, _ = main(['hs', 'info', ids[0]])
     assert rc == 0
-    assert_output(r'source: <direct>$', stdout, 1)
+    assert_output(rf'source: <direct> \({re.escape(DIRECT_SOURCE_ID)}\)$', stdout, 1)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -6,15 +6,22 @@
 
 # Type annotations
 from __future__ import annotations
+from pathlib import Path
+
+# Standard libs
+import os
+import re
 
 # External libs
 from pytest import mark
 from sqlalchemy import create_engine, inspect
 
 # Internal libs
+from hypershell.core.pretty_print import format_source
 from hypershell.data.model import (
     Task, Source, Entity, DIRECT_SOURCE_ID, STDIN_SOURCE_ID,
 )
+from tests import main, main_lines, assert_output, create_taskfile_echo, UUID_PATTERN
 
 
 # --- Identity fingerprint semantics (R2) -----------------------------------------------------------
@@ -119,3 +126,60 @@ def test_tasks_source_index_is_partial_excluding_reserved() -> None:
     predicate = str(entry.get('dialect_options', {}).get('sqlite_where'))
     assert DIRECT_SOURCE_ID in predicate
     assert STDIN_SOURCE_ID in predicate
+
+
+# --- Presentation: source resolution for humans (R18-adjacent) -------------------------------------
+
+@mark.unit
+def test_format_source_passes_sentinels_shows_paths_and_keeps_specs_opaque() -> None:
+    """Sentinels pass through; real paths are absolute by default / relative on request; @node opaque."""
+    # reserved sentinels pass through unchanged in both modes
+    assert format_source('<direct>') == '<direct>'
+    assert format_source('<stdin>') == '<stdin>'
+    assert format_source('<stdin>', relative=True) == '<stdin>'
+    # a real path shows as-stored (absolute) by default, relativized only on request
+    assert format_source('/data/tasks/run.in') == '/data/tasks/run.in'
+    assert format_source(os.path.abspath('run.in'), relative=True) == 'run.in'
+    # a --from-json spec carrying an @node suffix is opaque and never relativized
+    spec = '/data/plan.json@chunks'
+    assert format_source(spec) == spec
+    assert format_source(spec, relative=True) == spec
+
+
+@mark.integration
+def test_normal_view_resolves_source_while_machine_formats_stay_raw(temp_site: Path) -> None:
+    """The human `normal` view resolves `source` UUID -> path (single + batched); machine surfaces keep
+    the raw UUID and `fingerprint` never leaks into the normal template."""
+    taskfile = create_taskfile_echo(temp_site, count=3)
+    assert main(['hs', 'submit', str(taskfile)])[0] == 0
+
+    rc, ids, _ = main_lines(['hs', 'list', 'id', '-f', 'plain'])
+    assert rc == 0
+    task_id = ids[0]
+
+    # `hs info` (single-task normal view) resolves source to the absolute file path...
+    rc, stdout, _ = main(['hs', 'info', task_id])
+    assert rc == 0
+    assert_output(rf'source: {re.escape(str(taskfile))}$', stdout, 1)
+    assert 'fingerprint:' not in stdout            # fingerprint stays out of the normal template
+
+    # ...and the many-task normal view resolves every row via the batched source_map (no N+1)
+    rc, listing, _ = main(['hs', 'list', '--all'])
+    assert rc == 0
+    assert_output(rf'source: {re.escape(str(taskfile))}$', listing, 3)
+
+    # machine surfaces keep the raw source UUID (stable, scriptable)
+    rc, raw, _ = main(['hs', 'info', task_id, '-x', 'source'])
+    assert rc == 0
+    assert UUID_PATTERN.match(raw.strip('"'))
+
+
+@mark.integration
+def test_normal_view_resolves_reserved_sentinels(temp_site: Path) -> None:
+    """Single-command (`<direct>`) submissions resolve to the reserved sentinel in the normal view."""
+    assert main(['hs', 'submit', 'echo direct-presentation'])[0] == 0
+    rc, ids, _ = main_lines(['hs', 'list', 'id', '-f', 'plain'])
+    assert rc == 0
+    rc, stdout, _ = main(['hs', 'info', ids[0]])
+    assert rc == 0
+    assert_output(r'source: <direct>$', stdout, 1)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -24,7 +24,7 @@ from hypershell.data.model import (
 from tests import main, main_lines, assert_output, create_taskfile_echo, UUID_PATTERN
 
 
-# --- Identity fingerprint semantics (R2) -----------------------------------------------------------
+# --- Identity fingerprint semantics ----------------------------------------------------------------
 
 @mark.unit
 def test_fingerprint_is_order_independent_over_tags() -> None:
@@ -94,7 +94,7 @@ def test_supplied_fingerprint_is_not_recomputed() -> None:
     assert child.fingerprint == parent_fp
 
 
-# --- Schema groundwork (R1, R17) -------------------------------------------------------------------
+# --- Schema groundwork -----------------------------------------------------------------------------
 
 @mark.unit
 def test_fresh_schema_creates_source_table_columns_and_indices() -> None:
@@ -118,7 +118,7 @@ def test_fresh_schema_creates_source_table_columns_and_indices() -> None:
 
 @mark.unit
 def test_tasks_source_index_is_full_covering_not_partial() -> None:
-    """The de-dup/detection index covers (source, fingerprint) and is NOT partial (R17).
+    """The de-dup/detection index covers (source, fingerprint) and is NOT partial.
 
     A partial ``WHERE source NOT IN (reserved)`` predicate is only honored when the query
     repeats it with matching literals; the parameterized ``count_for_source`` /
@@ -136,12 +136,12 @@ def test_tasks_source_index_is_full_covering_not_partial() -> None:
 
 @mark.unit
 def test_source_lookups_use_the_index_not_a_full_scan() -> None:
-    """R17: the count + lineage de-dup lookups are index-backed, not full table scans.
+    """The count + lineage de-dup lookups are index-backed, not full table scans.
 
     Mirrors the ``WHERE`` clauses of :meth:`Task.count_for_source` and
     :meth:`Task.fingerprints_for_sources` on a populated throwaway table and asserts the
     planner reaches for ``index_tasks_source`` instead of scanning ``task`` (the linear cost
-    R17 forbids at billions–trillions of rows). A partial index would ``SCAN`` here.
+    forbidden at billions–trillions of rows). A partial index would ``SCAN`` here.
     """
     engine = create_engine('sqlite://')
     Entity.metadata.create_all(engine)
@@ -165,7 +165,7 @@ def test_source_lookups_use_the_index_not_a_full_scan() -> None:
     assert 'index_tasks_source' in fp_plan and 'SCAN task' not in fp_plan, fp_plan
 
 
-# --- Presentation: source resolution for humans (R18-adjacent) -------------------------------------
+# --- Presentation: source resolution for humans ---------------------------------------------------
 
 @mark.unit
 def test_format_source_passes_sentinels_shows_paths_and_keeps_specs_opaque() -> None:

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -451,6 +451,17 @@ def test_gate_update_submits_only_novel(temp_site: Path) -> None:
 
 
 @mark.integration
+def test_gate_update_on_unseen_path_submits_all(temp_site: Path) -> None:
+    """--update on a never-before-seen path has an empty lineage, so nothing is skipped and all
+    tasks are submitted — `--update` degrades to a plain submit when there is no prior source (R9 edge)."""
+    taskfile = create_taskfile_echo(temp_site, count=4)
+    rc, stdout, stderr = main(['hs', 'submit', '-f', str(taskfile), '-g0', '--update'])
+    assert rc == exit_status.success, stderr
+    assert_output(r'INFO .* 0 tasks already present; submitting 4 new tasks$', stderr, 1)
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['4'], NO_OUTPUT)
+
+
+@mark.integration
 def test_gate_update_repeat_contradictory() -> None:
     """--update and --repeat together are contradictory and rejected before any work (R10)."""
     assert main_lines(['hs', 'submit', '-f', 'x.in', '-g0', '--update', '--repeat']) == (

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -366,3 +366,109 @@ print('OK')
     rc, stdout, stderr = main([sys.executable, '-c', query])
     assert rc == 0, stderr
     assert stdout == 'OK'
+
+
+# --- Re-submission source gate: hs submit matrix (R3 exempt, R5-R10) --------------------------------
+
+@mark.integration
+def test_gate_refuse_resubmit_identical(temp_site: Path) -> None:
+    """Re-submitting an identical named file with no flag is refused, naming the prior (R5)."""
+    taskfile = create_taskfile_echo(temp_site, count=4)
+    rc, _, stderr = main(['hs', 'submit', '-f', str(taskfile), '-g0'])
+    assert rc == exit_status.success, stderr
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['4'], NO_OUTPUT)
+
+    rc, stdout, stderr = main(['hs', 'submit', '-f', str(taskfile), '-g0'])
+    assert rc == exit_status.bad_argument
+    assert stdout == ''
+    assert_output(r'CRITICAL .* was already submitted as source .*', stderr, 1)
+    # Refused before any new task is written — the count is unchanged.
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['4'], NO_OUTPUT)
+
+
+@mark.integration
+def test_gate_refuse_changed_suggests_update(temp_site: Path) -> None:
+    """A changed file at a seen path with no flag is refused, suggesting --update (R6)."""
+    taskfile = create_taskfile_echo(temp_site, count=2)
+    rc, _, stderr = main(['hs', 'submit', '-f', str(taskfile), '-g0'])
+    assert rc == exit_status.success, stderr
+
+    # Same path, different content -> different source fingerprint.
+    create_taskfile_echo(temp_site, count=3)  # overwrites task.in at the same path
+    rc, stdout, stderr = main(['hs', 'submit', '-f', str(taskfile), '-g0'])
+    assert rc == exit_status.bad_argument
+    assert_output(r'CRITICAL .* previously submitted with different content.*--update', stderr, 1)
+
+
+@mark.integration
+def test_gate_warns_incomplete_prior(temp_site: Path) -> None:
+    """When fewer tasks landed than recorded, detection warns of an incomplete prior (R7)."""
+    taskfile = create_taskfile_echo(temp_site, count=4)
+    rc, _, stderr = main(['hs', 'submit', '-f', str(taskfile), '-g0'])
+    assert rc == exit_status.success, stderr
+
+    # Delete two task rows so the DB count for the source drops below its recorded count.
+    prune = """
+from hypershell.data.model import Task
+Task.delete_all(Task.query().limit(2).all())
+print('OK')
+"""
+    rc, stdout, stderr = main([sys.executable, '-c', prune])
+    assert rc == 0, stderr
+    assert stdout == 'OK'
+
+    # Re-detect: no flag still refuses (R5), and now also warns about the incomplete prior (R7).
+    rc, stdout, stderr = main(['hs', 'submit', '-f', str(taskfile), '-g0'])
+    assert rc == exit_status.bad_argument
+    assert_output(r'WARNING .* appears incomplete: 2 of 4 tasks present.*', stderr, 1)
+
+
+@mark.integration
+def test_gate_repeat_submits_all_again(temp_site: Path) -> None:
+    """--repeat ingests a new source and submits all tasks again, even on an identical match (R8)."""
+    taskfile = create_taskfile_echo(temp_site, count=4)
+    assert main(['hs', 'submit', '-f', str(taskfile), '-g0'])[0] == exit_status.success
+
+    rc, stdout, stderr = main(['hs', 'submit', '-f', str(taskfile), '-g0', '--repeat'])
+    assert rc == exit_status.success, stderr
+    assert_output(r'INFO .* Submitted 4 tasks$', stderr, 1)
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['8'], NO_OUTPUT)
+
+
+@mark.integration
+def test_gate_update_submits_only_novel(temp_site: Path) -> None:
+    """--update creates a new source but submits only task identities not already present (R9)."""
+    taskfile = create_taskfile_echo(temp_site, count=4)
+    assert main(['hs', 'submit', '-f', str(taskfile), '-g0'])[0] == exit_status.success
+
+    # Extend the same file: the first four lines are byte-identical, two are new.
+    create_taskfile_echo(temp_site, count=6)  # overwrites task.in at the same path
+    rc, stdout, stderr = main(['hs', 'submit', '-f', str(taskfile), '-g0', '--update'])
+    assert rc == exit_status.success, stderr
+    # Loader de-dup tally (R18): four already present, two submitted.
+    assert_output(r'INFO .* 4 tasks already present; submitting 2 new tasks$', stderr, 1)
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['6'], NO_OUTPUT)
+
+
+@mark.integration
+def test_gate_update_repeat_contradictory() -> None:
+    """--update and --repeat together are contradictory and rejected before any work (R10)."""
+    assert main_lines(['hs', 'submit', '-f', 'x.in', '-g0', '--update', '--repeat']) == (
+        exit_status.bad_argument, NO_OUTPUT, ['CRITICAL [hypershell] Cannot combine --update with --repeat']
+    )
+
+
+@mark.integration
+def test_gate_direct_and_stdin_exempt(temp_site: Path) -> None:
+    """Single-command <direct> and streamed <stdin> submissions are exempt from gating (R3)."""
+    import os
+    from subprocess import run, PIPE
+    # <direct>: an identical single command submitted twice — both succeed, no refusal.
+    for _ in range(2):
+        rc, _, stderr = main(['hs', 'submit', 'echo', 'solo', '-g0'])
+        assert rc == exit_status.success, stderr
+    # <stdin>: identical piped input submitted twice — both succeed (main() does not feed stdin).
+    for _ in range(2):
+        proc = run(['hs', 'submit', '-f', '-', '-g0'], input=b'echo a\necho b\n',
+                   stdout=PIPE, stderr=PIPE, env=os.environ)
+        assert proc.returncode == exit_status.success, proc.stderr.decode()

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -258,7 +258,7 @@ print('OK', src.task_count)
 
 @mark.integration
 def test_source_stamp_named_file(temp_site: Path) -> None:
-    """A named-file submit records one Source row and stamps every task (R1, R3, R4)."""
+    """A named-file submit records one Source row and stamps every task."""
 
     # Real tasks: echo a/b/c. Non-tasks (excluded from the count): blank, comment-only,
     # and an inline-tag-only line (sets a global tag, produces no task).
@@ -273,7 +273,7 @@ def test_source_stamp_named_file(temp_site: Path) -> None:
 
     rc, stdout, stderr = main(['hs', 'submit', '-f', str(taskfile)])
     assert rc == exit_status.success, stderr
-    # R18 upfront-ingest log: found N + md5, and the excluded lines are not counted.
+    # Upfront-ingest log: found N + md5, and the excluded lines are not counted.
     assert_output(r'INFO .* Found 3 tasks in .* \(md5=[0-9a-f]{32}\)$', stderr, 1)
     assert_output(r'INFO .* Submitted 3 tasks$', stderr, 1)
 
@@ -284,7 +284,7 @@ def test_source_stamp_named_file(temp_site: Path) -> None:
 
 @mark.integration
 def test_source_stamp_reserved_direct_and_stdin(temp_site: Path) -> None:
-    """Single-command and stdin submissions stamp the reserved <direct>/<stdin> rows (R3)."""
+    """Single-command and stdin submissions stamp the reserved <direct>/<stdin> rows."""
     import os
     from subprocess import run, PIPE
 
@@ -316,7 +316,7 @@ print('OK')
 @mark.integration
 def test_source_stamp_non_seekable_input_streams_all(temp_site: Path) -> None:
     """A non-seekable named input (piped /dev/stdin) streams every task instead of being
-    drained by the upfront read; it is stamped with the reserved <stdin> source (R3, R4)."""
+    drained by the upfront read; it is stamped with the reserved <stdin> source."""
     import os
     from subprocess import run, PIPE
     if not os.path.exists('/dev/stdin'):
@@ -346,7 +346,7 @@ print('OK')
 @mark.integration
 def test_source_stamp_count_matches_cr_only_newlines(temp_site: Path) -> None:
     """The recorded task_count matches the tasks actually submitted regardless of newline
-    convention — the count read uses the Loader's own universal-newline decoding (R1, R4)."""
+    convention — the count read uses the Loader's own universal-newline decoding."""
     taskfile = temp_site / 'cr.in'
     with open(str(taskfile), mode='wb') as stream:
         stream.write(b'echo a\recho b\recho c\r')  # classic-Mac CR-only line endings
@@ -368,11 +368,11 @@ print('OK')
     assert stdout == 'OK'
 
 
-# --- Re-submission source gate: hs submit matrix (R3 exempt, R5-R10) --------------------------------
+# --- Re-submission source gate: hs submit matrix ---------------------------------------------------
 
 @mark.integration
 def test_gate_refuse_resubmit_identical(temp_site: Path) -> None:
-    """Re-submitting an identical named file with no flag is refused, naming the prior (R5)."""
+    """Re-submitting an identical named file with no flag is refused, naming the prior."""
     taskfile = create_taskfile_echo(temp_site, count=4)
     rc, _, stderr = main(['hs', 'submit', '-f', str(taskfile), '-g0'])
     assert rc == exit_status.success, stderr
@@ -388,7 +388,7 @@ def test_gate_refuse_resubmit_identical(temp_site: Path) -> None:
 
 @mark.integration
 def test_gate_refuse_changed_suggests_update(temp_site: Path) -> None:
-    """A changed file at a seen path with no flag is refused, suggesting --update (R6)."""
+    """A changed file at a seen path with no flag is refused, suggesting --update."""
     taskfile = create_taskfile_echo(temp_site, count=2)
     rc, _, stderr = main(['hs', 'submit', '-f', str(taskfile), '-g0'])
     assert rc == exit_status.success, stderr
@@ -402,7 +402,7 @@ def test_gate_refuse_changed_suggests_update(temp_site: Path) -> None:
 
 @mark.integration
 def test_gate_warns_incomplete_prior(temp_site: Path) -> None:
-    """When fewer tasks landed than recorded, detection warns of an incomplete prior (R7)."""
+    """When fewer tasks landed than recorded, detection warns of an incomplete prior."""
     taskfile = create_taskfile_echo(temp_site, count=4)
     rc, _, stderr = main(['hs', 'submit', '-f', str(taskfile), '-g0'])
     assert rc == exit_status.success, stderr
@@ -417,7 +417,7 @@ print('OK')
     assert rc == 0, stderr
     assert stdout == 'OK'
 
-    # Re-detect: no flag still refuses (R5), and now also warns about the incomplete prior (R7).
+    # Re-detect: no flag still refuses, and now also warns about the incomplete prior.
     rc, stdout, stderr = main(['hs', 'submit', '-f', str(taskfile), '-g0'])
     assert rc == exit_status.bad_argument
     assert_output(r'WARNING .* appears incomplete: 2 of 4 tasks present.*', stderr, 1)
@@ -425,7 +425,7 @@ print('OK')
 
 @mark.integration
 def test_gate_dedup_update_not_reported_incomplete(temp_site: Path) -> None:
-    """A de-duplicated --update is not later misreported as an incomplete prior (R7 regression).
+    """A de-duplicated --update is not later misreported as an incomplete prior (regression).
 
     --update records the new source's expected count as the *full* file count but stamps only the
     novel tasks onto it — the deduped ones stay under earlier same-path sources. Completeness is
@@ -437,7 +437,7 @@ def test_gate_dedup_update_not_reported_incomplete(temp_site: Path) -> None:
     create_taskfile_echo(temp_site, count=6)  # same path, two new lines
     assert main(['hs', 'submit', '-f', str(taskfile), '-g0', '--update'])[0] == exit_status.success
 
-    # Re-detect the now-complete v2: no flag refuses it as a duplicate (R5) but must NOT warn.
+    # Re-detect the now-complete v2: no flag refuses it as a duplicate but must NOT warn.
     rc, stdout, stderr = main(['hs', 'submit', '-f', str(taskfile), '-g0'])
     assert rc == exit_status.bad_argument, stderr
     assert_output(r'appears incomplete', stderr, 0)   # the F2 false-positive is gone
@@ -446,7 +446,7 @@ def test_gate_dedup_update_not_reported_incomplete(temp_site: Path) -> None:
 
 @mark.integration
 def test_gate_repeat_submits_all_again(temp_site: Path) -> None:
-    """--repeat ingests a new source and submits all tasks again, even on an identical match (R8)."""
+    """--repeat ingests a new source and submits all tasks again, even on an identical match."""
     taskfile = create_taskfile_echo(temp_site, count=4)
     assert main(['hs', 'submit', '-f', str(taskfile), '-g0'])[0] == exit_status.success
 
@@ -458,7 +458,7 @@ def test_gate_repeat_submits_all_again(temp_site: Path) -> None:
 
 @mark.integration
 def test_gate_update_submits_only_novel(temp_site: Path) -> None:
-    """--update creates a new source but submits only task identities not already present (R9)."""
+    """--update creates a new source but submits only task identities not already present."""
     taskfile = create_taskfile_echo(temp_site, count=4)
     assert main(['hs', 'submit', '-f', str(taskfile), '-g0'])[0] == exit_status.success
 
@@ -466,7 +466,7 @@ def test_gate_update_submits_only_novel(temp_site: Path) -> None:
     create_taskfile_echo(temp_site, count=6)  # overwrites task.in at the same path
     rc, stdout, stderr = main(['hs', 'submit', '-f', str(taskfile), '-g0', '--update'])
     assert rc == exit_status.success, stderr
-    # Loader de-dup tally (R18): four already present, two submitted.
+    # Loader de-dup tally: four already present, two submitted.
     assert_output(r'INFO .* 4 tasks already present; submitting 2 new tasks$', stderr, 1)
     assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['6'], NO_OUTPUT)
 
@@ -474,7 +474,7 @@ def test_gate_update_submits_only_novel(temp_site: Path) -> None:
 @mark.integration
 def test_gate_update_on_unseen_path_submits_all(temp_site: Path) -> None:
     """--update on a never-before-seen path has an empty lineage, so nothing is skipped and all
-    tasks are submitted — `--update` degrades to a plain submit when there is no prior source (R9 edge)."""
+    tasks are submitted — `--update` degrades to a plain submit when there is no prior source (edge case)."""
     taskfile = create_taskfile_echo(temp_site, count=4)
     rc, stdout, stderr = main(['hs', 'submit', '-f', str(taskfile), '-g0', '--update'])
     assert rc == exit_status.success, stderr
@@ -484,7 +484,7 @@ def test_gate_update_on_unseen_path_submits_all(temp_site: Path) -> None:
 
 @mark.integration
 def test_gate_update_repeat_contradictory() -> None:
-    """--update and --repeat together are contradictory and rejected before any work (R10)."""
+    """--update and --repeat together are contradictory and rejected before any work."""
     assert main_lines(['hs', 'submit', '-f', 'x.in', '-g0', '--update', '--repeat']) == (
         exit_status.bad_argument, NO_OUTPUT, ['CRITICAL [hypershell] Cannot combine --update with --repeat']
     )
@@ -492,7 +492,7 @@ def test_gate_update_repeat_contradictory() -> None:
 
 @mark.integration
 def test_gate_direct_and_stdin_exempt(temp_site: Path) -> None:
-    """Single-command <direct> and streamed <stdin> submissions are exempt from gating (R3)."""
+    """Single-command <direct> and streamed <stdin> submissions are exempt from gating."""
     import os
     from subprocess import run, PIPE
     # <direct>: an identical single command submitted twice — both succeed, no refusal.

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -424,6 +424,27 @@ print('OK')
 
 
 @mark.integration
+def test_gate_dedup_update_not_reported_incomplete(temp_site: Path) -> None:
+    """A de-duplicated --update is not later misreported as an incomplete prior (R7 regression).
+
+    --update records the new source's expected count as the *full* file count but stamps only the
+    novel tasks onto it — the deduped ones stay under earlier same-path sources. Completeness is
+    therefore measured across the lineage; a subsequent detection of the (complete) version must
+    not cry wolf. Before the fix this warned a spurious 'appears incomplete: 2 of 6'.
+    """
+    taskfile = create_taskfile_echo(temp_site, count=4)
+    assert main(['hs', 'submit', '-f', str(taskfile), '-g0'])[0] == exit_status.success
+    create_taskfile_echo(temp_site, count=6)  # same path, two new lines
+    assert main(['hs', 'submit', '-f', str(taskfile), '-g0', '--update'])[0] == exit_status.success
+
+    # Re-detect the now-complete v2: no flag refuses it as a duplicate (R5) but must NOT warn.
+    rc, stdout, stderr = main(['hs', 'submit', '-f', str(taskfile), '-g0'])
+    assert rc == exit_status.bad_argument, stderr
+    assert_output(r'appears incomplete', stderr, 0)   # the F2 false-positive is gone
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['6'], NO_OUTPUT)
+
+
+@mark.integration
 def test_gate_repeat_submits_all_again(temp_site: Path) -> None:
     """--repeat ingests a new source and submits all tasks again, even on an identical match (R8)."""
     taskfile = create_taskfile_echo(temp_site, count=4)

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Final, Dict
 
 # Standard libs
+import sys
 from pathlib import Path
 
 # External libs
@@ -16,7 +17,7 @@ from pytest import mark
 from cmdkit.app import exit_status
 
 # Internal libs
-from tests import main, main_lines, NO_OUTPUT, create_taskfile_echo, assert_output, UUID_PATTERN
+from tests import main, main_lines, NO_OUTPUT, create_taskfile, create_taskfile_echo, assert_output, UUID_PATTERN
 from hypershell.submit import SubmitApp
 from hypershell.data.model import Task
 
@@ -235,3 +236,133 @@ def test_inline_memory_tag_parses_units_to_bytes() -> None:
     assert Task.new(args='echo', tag={'memory': '2000'}).memory == 2000
     assert Task.new(args='echo', tag={'memory': 4096}).memory == 4096
     assert Task.new(args='echo').memory is None
+
+
+# Small script run in a subprocess so the engine binds to the temp-site environment.
+_STAMP_QUERY: Final[str] = """
+from hypershell.data.model import Task, Source, DIRECT_SOURCE_ID, STDIN_SOURCE_ID
+tasks = Task.query().all()
+named = [s for s in Source.query().all() if s.path not in ('<direct>', '<stdin>')]
+assert len(tasks) == 3, f'tasks={len(tasks)}'
+assert len(named) == 1, f'named sources={len(named)}'
+src = named[0]
+assert src.task_count == 3, f'recorded count={src.task_count}'
+assert src.fingerprint and len(src.fingerprint) == 32, f'md5={src.fingerprint!r}'
+assert src.path.startswith('/'), f'path not absolute: {src.path}'
+assert all(t.source == src.id for t in tasks), [t.source for t in tasks]
+assert all(t.fingerprint for t in tasks), 'unstamped fingerprint'
+assert len({t.fingerprint for t in tasks}) == 3, 'expected distinct fingerprints'
+print('OK', src.task_count)
+"""
+
+
+@mark.integration
+def test_source_stamp_named_file(temp_site: Path) -> None:
+    """A named-file submit records one Source row and stamps every task (R1, R3, R4)."""
+
+    # Real tasks: echo a/b/c. Non-tasks (excluded from the count): blank, comment-only,
+    # and an inline-tag-only line (sets a global tag, produces no task).
+    taskfile = create_taskfile(temp_site, [
+        'echo a',
+        '',
+        '# just a comment',
+        '# HYPERSHELL: phase:1',
+        'echo b',
+        'echo c',
+    ])
+
+    rc, stdout, stderr = main(['hs', 'submit', '-f', str(taskfile)])
+    assert rc == exit_status.success, stderr
+    # R18 upfront-ingest log: found N + md5, and the excluded lines are not counted.
+    assert_output(r'INFO .* Found 3 tasks in .* \(md5=[0-9a-f]{32}\)$', stderr, 1)
+    assert_output(r'INFO .* Submitted 3 tasks$', stderr, 1)
+
+    rc, stdout, stderr = main([sys.executable, '-c', _STAMP_QUERY])
+    assert rc == 0, stderr
+    assert stdout == 'OK 3'
+
+
+@mark.integration
+def test_source_stamp_reserved_direct_and_stdin(temp_site: Path) -> None:
+    """Single-command and stdin submissions stamp the reserved <direct>/<stdin> rows (R3)."""
+    import os
+    from subprocess import run, PIPE
+
+    # <direct>: a single positional command needs no stdin.
+    rc, _, stderr = main(['hs', 'submit', 'echo', 'solo'])
+    assert rc == exit_status.success, stderr
+
+    # <stdin>: pipe two commands in; `main` does not feed stdin, so drive it directly.
+    proc = run(['hs', 'submit', '-f', '-'], input=b'echo pipe1\necho pipe2\n',
+               stdout=PIPE, stderr=PIPE, env=os.environ)
+    assert proc.returncode == exit_status.success, proc.stderr.decode()
+
+    query = """
+from hypershell.data.model import Task, Source, DIRECT_SOURCE_ID, STDIN_SOURCE_ID
+by_source = {}
+for t in Task.query().all():
+    by_source.setdefault(t.source, []).append(t.args)
+assert sorted(by_source.get(DIRECT_SOURCE_ID, [])) == ['echo solo'], by_source
+assert sorted(by_source.get(STDIN_SOURCE_ID, [])) == ['echo pipe1', 'echo pipe2'], by_source
+reserved = Source.query().filter(Source.id.in_([DIRECT_SOURCE_ID, STDIN_SOURCE_ID])).all()
+assert {s.path for s in reserved} == {'<direct>', '<stdin>'}, reserved
+print('OK')
+"""
+    rc, stdout, stderr = main([sys.executable, '-c', query])
+    assert rc == 0, stderr
+    assert stdout == 'OK'
+
+
+@mark.integration
+def test_source_stamp_non_seekable_input_streams_all(temp_site: Path) -> None:
+    """A non-seekable named input (piped /dev/stdin) streams every task instead of being
+    drained by the upfront read; it is stamped with the reserved <stdin> source (R3, R4)."""
+    import os
+    from subprocess import run, PIPE
+    if not os.path.exists('/dev/stdin'):
+        from pytest import skip
+        skip('no /dev/stdin on this platform')
+
+    # stdin is a pipe here, so /dev/stdin is non-seekable — the upfront count MUST NOT
+    # re-read (and drain) it. Before the fix this submitted 0 tasks with a bogus Source row.
+    proc = run(['hs', 'submit', '-f', '/dev/stdin'], input=b'echo one\necho two\necho three\n',
+               stdout=PIPE, stderr=PIPE, env=os.environ)
+    assert proc.returncode == exit_status.success, proc.stderr.decode()
+
+    query = """
+from hypershell.data.model import Task, Source, STDIN_SOURCE_ID
+tasks = Task.query().all()
+assert len(tasks) == 3, f'expected 3 tasks, got {len(tasks)}'
+assert all(t.source == STDIN_SOURCE_ID for t in tasks), [t.source for t in tasks]
+named = [s for s in Source.query().all() if s.path not in ('<direct>', '<stdin>')]
+assert named == [], named  # no bogus named source for the ephemeral /dev/stdin path
+print('OK')
+"""
+    rc, stdout, stderr = main([sys.executable, '-c', query])
+    assert rc == 0, stderr
+    assert stdout == 'OK'
+
+
+@mark.integration
+def test_source_stamp_count_matches_cr_only_newlines(temp_site: Path) -> None:
+    """The recorded task_count matches the tasks actually submitted regardless of newline
+    convention — the count read uses the Loader's own universal-newline decoding (R1, R4)."""
+    taskfile = temp_site / 'cr.in'
+    with open(str(taskfile), mode='wb') as stream:
+        stream.write(b'echo a\recho b\recho c\r')  # classic-Mac CR-only line endings
+
+    rc, stdout, stderr = main(['hs', 'submit', '-f', str(taskfile)])
+    assert rc == exit_status.success, stderr
+    assert_output(r'INFO .* Found 3 tasks in .*', stderr, 1)
+
+    query = """
+from hypershell.data.model import Task, Source
+tasks = Task.query().all()
+named = [s for s in Source.query().all() if s.path not in ('<direct>', '<stdin>')]
+assert len(named) == 1, named
+assert named[0].task_count == len(tasks) == 3, (named[0].task_count, len(tasks))
+print('OK')
+"""
+    rc, stdout, stderr = main([sys.executable, '-c', query])
+    assert rc == 0, stderr
+    assert stdout == 'OK'

--- a/tests/test_submit_json.py
+++ b/tests/test_submit_json.py
@@ -288,7 +288,7 @@ def test_cluster_from_json(temp_site: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# `--from-json` re-submission gate (submit R5/R8/R9; cluster R12)
+# `--from-json` re-submission gate (same matrix as a plain FILE)
 # ---------------------------------------------------------------------------
 # A JSON source keys on abspath(FILE)[@node] + the file's content md5, exactly like a
 # line file, so the shared apply_source_gate covers it unchanged. Group 0 is pinned so
@@ -296,7 +296,7 @@ def test_cluster_from_json(temp_site: Path) -> None:
 
 @mark.integration
 def test_from_json_gate_refuses_resubmit(temp_site: Path) -> None:
-    """Submitting the same JSON plan twice with no flag is refused (R5)."""
+    """Submitting the same JSON plan twice with no flag is refused."""
     plan = create_json_taskfile(temp_site, {'chunks': [{'seqid': 'Chr1'}, {'seqid': 'Chr2'}]})
     argv = ['hs', 'submit', f'--from-json={plan}@chunks', '-g', '0', '--template', 'echo {seqid}']
     rc, _, stderr = main(argv)
@@ -313,7 +313,7 @@ def test_from_json_gate_refuses_resubmit(temp_site: Path) -> None:
 
 @mark.integration
 def test_from_json_gate_repeat_resubmits_all(temp_site: Path) -> None:
-    """--repeat ingests the JSON plan as a new source and submits every task again (R8)."""
+    """--repeat ingests the JSON plan as a new source and submits every task again."""
     plan = create_json_taskfile(temp_site, {'chunks': [{'seqid': 'Chr1'}, {'seqid': 'Chr2'}]})
     argv = ['hs', 'submit', f'--from-json={plan}@chunks', '-g', '0', '--template', 'echo {seqid}']
     assert main(argv)[0] == exit_status.success
@@ -324,7 +324,7 @@ def test_from_json_gate_repeat_resubmits_all(temp_site: Path) -> None:
 
 @mark.integration
 def test_from_json_gate_update_adds_novel_only(temp_site: Path) -> None:
-    """--update on an edited JSON plan submits only records not already present (R9)."""
+    """--update on an edited JSON plan submits only records not already present."""
     plan = create_json_taskfile(temp_site, {'chunks': [{'seqid': 'Chr1'}, {'seqid': 'Chr2'}]})
     argv = ['hs', 'submit', f'--from-json={plan}@chunks', '-g', '0', '--template', 'echo {seqid}']
     assert main(argv)[0] == exit_status.success
@@ -341,7 +341,7 @@ def test_from_json_gate_update_adds_novel_only(temp_site: Path) -> None:
 
 @mark.integration
 def test_from_json_gate_cluster_restart_idempotent(temp_site: Path) -> None:
-    """hsx --from-json ... --restart runs the plan and is idempotent on requeue (R12).
+    """hsx --from-json ... --restart runs the plan and is idempotent on requeue.
 
     Also exercises the removed --from-json + --restart incompatibility (this run no longer
     errors) and the co-running-submitter scheduler guard (novel tasks against a DB of prior

--- a/tests/test_submit_json.py
+++ b/tests/test_submit_json.py
@@ -285,3 +285,81 @@ def test_cluster_from_json(temp_site: Path) -> None:
     )
     rc, stdout, _ = main(['hs', 'list', 'id', '-t', 'seqid:Chr1', '-f', 'plain'])
     assert rc == exit_status.success and len(stdout.splitlines()) == 1
+
+
+# ---------------------------------------------------------------------------
+# `--from-json` re-submission gate (submit R5/R8/R9; cluster R12)
+# ---------------------------------------------------------------------------
+# A JSON source keys on abspath(FILE)[@node] + the file's content md5, exactly like a
+# line file, so the shared apply_source_gate covers it unchanged. Group 0 is pinned so
+# the per-task fingerprint (which includes group) is stable across the two submits.
+
+@mark.integration
+def test_from_json_gate_refuses_resubmit(temp_site: Path) -> None:
+    """Submitting the same JSON plan twice with no flag is refused (R5)."""
+    plan = create_json_taskfile(temp_site, {'chunks': [{'seqid': 'Chr1'}, {'seqid': 'Chr2'}]})
+    argv = ['hs', 'submit', f'--from-json={plan}@chunks', '-g', '0', '--template', 'echo {seqid}']
+    rc, _, stderr = main(argv)
+    assert rc == exit_status.success, stderr
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['2'], NO_OUTPUT)
+
+    # Same path, same content -> refused, naming the prior source; nothing new committed.
+    rc, stdout, stderr = main(argv)
+    assert rc == exit_status.bad_argument
+    assert stdout == ''
+    assert_output(r'CRITICAL .* was already submitted as source .*', stderr, 1)
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['2'], NO_OUTPUT)
+
+
+@mark.integration
+def test_from_json_gate_repeat_resubmits_all(temp_site: Path) -> None:
+    """--repeat ingests the JSON plan as a new source and submits every task again (R8)."""
+    plan = create_json_taskfile(temp_site, {'chunks': [{'seqid': 'Chr1'}, {'seqid': 'Chr2'}]})
+    argv = ['hs', 'submit', f'--from-json={plan}@chunks', '-g', '0', '--template', 'echo {seqid}']
+    assert main(argv)[0] == exit_status.success
+    rc, _, stderr = main(argv + ['--repeat'])
+    assert rc == exit_status.success, stderr
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['4'], NO_OUTPUT)
+
+
+@mark.integration
+def test_from_json_gate_update_adds_novel_only(temp_site: Path) -> None:
+    """--update on an edited JSON plan submits only records not already present (R9)."""
+    plan = create_json_taskfile(temp_site, {'chunks': [{'seqid': 'Chr1'}, {'seqid': 'Chr2'}]})
+    argv = ['hs', 'submit', f'--from-json={plan}@chunks', '-g', '0', '--template', 'echo {seqid}']
+    assert main(argv)[0] == exit_status.success
+
+    # Rewrite the same path with one extra record; --update adds only the novel one.
+    create_json_taskfile(temp_site, {'chunks': [{'seqid': 'Chr1'}, {'seqid': 'Chr2'}, {'seqid': 'Chr3'}]})
+    rc, _, stderr = main(argv + ['--update'])
+    assert rc == exit_status.success, stderr
+    assert_output(r'submitting 1 new tasks', stderr, 1)
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['3'], NO_OUTPUT)
+    _, args, _ = main_lines(['hs', 'list', 'args', '-f', 'plain'])
+    assert sorted(args) == ['echo Chr1', 'echo Chr2', 'echo Chr3']
+
+
+@mark.integration
+def test_from_json_gate_cluster_restart_idempotent(temp_site: Path) -> None:
+    """hsx --from-json ... --restart runs the plan and is idempotent on requeue (R12).
+
+    Also exercises the removed --from-json + --restart incompatibility (this run no longer
+    errors) and the co-running-submitter scheduler guard (novel tasks against a DB of prior
+    completed tasks).
+    """
+    plan = create_json_taskfile(temp_site, {'chunks': [
+        {'seqid': 'Chr1', 'chunk_id': 'c1'},
+        {'seqid': 'Chr2', 'chunk_id': 'c2'},
+    ]})
+    argv = ['hsx', f'--from-json={plan}@chunks', '--template', 'echo {seqid} {chunk_id}',
+            '-N', '2', '--restart']
+    rc, stdout, stderr = main(argv)
+    assert rc == exit_status.success, stderr
+    assert sorted(stdout.splitlines()) == ['Chr1 c1', 'Chr2 c2']
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['2'], NO_OUTPUT)
+
+    # Requeue: fingerprint matches, every task already present -> nothing new submitted or run.
+    rc, stdout, stderr = main(argv)
+    assert rc == exit_status.success, stderr
+    assert stdout == ''
+    assert main_lines(['hs', 'list', '--count']) == (exit_status.success, ['2'], NO_OUTPUT)


### PR DESCRIPTION
## Summary

Makes task re-submission safe *by construction*. HyperShell now records a **source** row per ingested named file (unique UUID, absolute path, content fingerprint, task count, timestamp) and stamps every task with a stable **identity fingerprint** (canonical hash of pre-template args + group + tags). `hs submit` and `hsx`/`hs cluster` consult these to detect prior submissions cheaply and either refuse, de-duplicate, or proceed — so a first-time user can drop `hsx <taskfile> --restart` into a Slurm job and requeue freely: each run submits only the tasks that never landed and lets the existing revert-interrupted flow re-run anything mid-flight, never duplicating work. `--update` submits only the novel tasks after a file changes; `--repeat` runs the whole file again; contradictory/ambiguous intent is refused with an actionable message. Detection is index-backed for billions–trillions of rows and well-logged. Reserved sources `<direct>` (single command) and `<stdin>` (streamed) are exempt from gating.

**Goal** → [`GOAL.md`](https://github.com/hypershell/hypershell/blob/02aefea32423c41095d5759e5ea5acd82d75a4ff/spec/cli-cluster-restart-repeat-update/GOAL.md) (locked contract, R1–R18) · **Design** → [`PLAN.md`](https://github.com/hypershell/hypershell/blob/02aefea32423c41095d5759e5ea5acd82d75a4ff/spec/cli-cluster-restart-repeat-update/PLAN.md) · **Research** → [`research/00-digest.md`](https://github.com/hypershell/hypershell/blob/02aefea32423c41095d5759e5ea5acd82d75a4ff/spec/cli-cluster-restart-repeat-update/research/00-digest.md) (+ briefs 01–09) · **Review** → [`REVIEW.md`](https://github.com/hypershell/hypershell/blob/02aefea32423c41095d5759e5ea5acd82d75a4ff/spec/cli-cluster-restart-repeat-update/REVIEW.md)

## Phases

| Phase | Name | Satisfies |
|---|---|---|
| P1 | Schema + fingerprint core (Source entity, Task.source/fingerprint, indices) | R1, R2, R17 |
| P2 | Submit-flow stamping seam (GatedSource, Loader stamp+dedup) | R3, R4 |
| P3 | `hs submit` gate matrix + count-warn + logging | R5–R10, R18 |
| P4 | `hsx` gate matrix + file-aware restart | R11–R16 |
| P5 | Gate `--from-json` in both apps | R4/R5/R8/R9 |
| P6 | Presentation (source display) + man pages | R18 |

## Verification

- Full suite **354 passed** (`uv run pytest`); Sphinx build clean (pre-existing warnings only).
- `EXPLAIN QUERY PLAN` at 300k rows: source count / de-dup lookups are index-backed, not full scans (R17).
- Real-CLI drives in temp sites — `hs submit` R5/R6/R8/R9/R10; `hsx -N1` R11/R12 (idempotent restart)/R14/R15; `--from-json` gating; in-memory guard writes 0 rows; `<direct>`/`<stdin>` exempt.
- Adversarial review (`REVIEW.md`): 2 CONFIRMED findings (R17 full-scan, R7 false-positive after de-dup) remediated (F1 `f876000`, F2 `698580a`) and re-verified with regression tests.

## Docs & completions (same-commit rule)

`docs/_include/{submit,cluster}_*.rst`, `share/bash_completion.d/hs`, `share/zsh/site-functions/_hs`, and `share/man/man1/*.1` — all updated for `--repeat`/`--update`/`--from-json` and the revised `--restart` narrative.

> ⚠️ Scale validation (10M+ rows on Anvil/HPC; PostgreSQL/TimescaleDB query plans) is in progress out-of-band — the SQLite-only plan checks here can't cover PG/Timescale.

`Refs #37` — targets `develop` (not the default `master`), so this will **not** auto-close the issue on merge; close it manually when the change ships to `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
