### PR TITLE
[fix] De-flake test_group_failed_task_with_retries via authoritative DB state

### DIFF
--- a/spec/deflake-group-retry-test/GOAL.md
+++ b/spec/deflake-group-retry-test/GOAL.md
@@ -1,0 +1,112 @@
+# GOAL — De-flake `test_group_failed_task_with_retries`
+
+> **Origin spec.** The *what* and *why* — the locked contract `hs-review` grades against.
+> The *how* lives in [`PLAN.md`](PLAN.md) and [`TECH.md`](TECH.md) (written by `hs-plan`).
+
+- **slug:** deflake-group-retry-test
+- **kind:** fix
+- **appetite:** medium — diagnosis-gated. Hardening the test alone is small; if first-principles
+  analysis exposes a genuine product output-loss defect, fixing that is larger (the human has
+  accepted that scope — see Clarifications).
+
+## Problem
+
+The integration test `tests/test_groups.py::test_group_failed_task_with_retries` fails
+intermittently in CI on GitHub while passing reliably on the maintainer's local machine. It was
+first assumed to be a Python 3.14-only issue, but PR #52 (2026-07-20) failed it on **Python
+3.11** too, which points at a load/timing sensitivity of the *hosted runner*, not a
+version-specific bug. Because it cannot be reproduced locally, it must be reasoned about from
+first principles from the CI evidence — a green local run tells us nothing.
+
+A flaky test in the required matrix blocks PRs and erodes trust in the suite: contributors can't
+tell a real regression from noise, and re-running CI to get a pass is not a fix.
+
+**What the CI log actually shows** (`logs_80518241903/5_tests (3.11).txt`, lines 633–692) —
+and it contradicts the original hypothesis. The *timing/ordering* assertion the test was thought
+to be fragile on — `assert group_idx < n2_idx` (group 0's retried task completes before group 1's
+task) — **passed**, as did the `Non-zero exit status` count (exactly 2), the group-transition
+message, and `rc == success`. The **only** assertion that failed was line 143:
+
+```
+assert sorted(stdout.strip().splitlines()) == ['0', '1', '2']   # got ['0', '2']
+```
+
+Task `n:1`'s stdout (`"1"`) is missing from the captured cluster stdout — even though the task
+provably *succeeded*: it failed exactly twice (`[ $TASK_ATTEMPT -eq 3 ]` false on attempts 1–2),
+then on attempt 3 the `&& echo 1` branch ran (exit 0), which is the *only* path that yields the
+observed group transition + success. So the subprocess produced `"1"`, but it was lost from the
+captured stream. Because `"2"` (a *later*, group-1 task) is present while `"1"` (earlier) is
+absent, this is not tail-truncation at shutdown — it is a specific line dropped under load.
+
+The test is therefore fragile in two ways: (1) it scrapes task stdout from the cluster process
+and assumes every task's output is captured completely and in order, which does not hold under
+CI concurrency/load; and (2) it verifies group-phase ordering by comparing raw log-line indices,
+which is inherently timing-sensitive. The open question — and the reason this needs real
+diagnosis — is whether the missing line is merely a test-harness capture assumption, or a genuine
+product defect (task output dropped under load).
+
+## Outcome / vision
+
+`test_group_failed_task_with_retries` passes reliably across the full CI matrix (Python
+3.11–3.14) on constrained/lagging hosted runners, **without weakening what it verifies** about
+group-based retry behavior. The true root cause of the dropped `"1"` is understood from first
+principles from the CI evidence. If that root cause is a fragile test assumption, the test is
+rebuilt to assert on authoritative task state; if it is a genuine product defect (task output
+lost under concurrent load), that defect is root-caused and fixed rather than masked. The
+maintainer's acceptance signal is a green run of this job on the PR's CI (it cannot be confirmed
+locally).
+
+## Acceptance criteria (the contract)
+
+- **R1** — The test SHALL verify the group-retry contract (a failing task is retried within its
+  group until it succeeds, and the group advances only afterward) from **authoritative task
+  state** — database rows, `exit_status`, attempt/row counts, completion — as the primary source
+  of truth, rather than relying on scraped process stdout for correctness.
+- **R2** — WHEN a failing task is retried until it succeeds, the test SHALL confirm the task
+  terminally succeeded (`exit_status == 0`) and that the expected number of task rows exist
+  (original attempt + retries), independent of what appears on captured stdout.
+- **R3** — The test SHALL still assert the ordering guarantee (group 1 does not begin until the
+  retried task in group 0 completes) using a signal robust to CI load, not a fragile comparison
+  of raw log-line indices, wherever that is achievable without losing the guarantee.
+- **R4** — IF first-principles diagnosis determines task stdout is genuinely dropped or lost
+  under concurrent load (a product defect, not a test assumption), THEN that defect SHALL be
+  root-caused and fixed — not merely hidden by changing an assertion.
+- **R5** — The fix SHALL NOT weaken the behavioral coverage of group-based retries: the retried
+  task must still be shown to fail, then succeed, and gate the group transition.
+- **R6** — WHEN run in CI across Python 3.11–3.14 on constrained runners, the test (and any
+  product change made under R4) SHALL pass reliably, with no timing- or capture-induced flakes.
+
+## Non-goals (no-gos)
+
+- De-flaking other timing-sensitive tests (e.g. `test_group_parallel_execution_within_group`'s
+  wall-clock `elapsed > 10` assertion). If the same robust pattern trivially applies, noting it is
+  welcome, but reworking those tests is a possible follow-up, not this unit of work.
+- Changing group-gating / scheduler advancement semantics or the retry model (new-row,
+  `attempt+1`, group stall-on-failure). Those invariants are load-bearing and out of scope.
+- Broadly refactoring how task stdout is routed or printed, beyond the minimum required to fix a
+  *confirmed* output-loss defect under R4.
+- Introducing a general test-retry / flaky-test plugin or reruns to paper over instability.
+
+## Clarifications
+
+- **Q:** If root-cause analysis shows task stdout is genuinely dropped under load (a real product
+  defect, not just a fragile test assumption), is fixing the product defect in scope for this
+  fix? — **A:** Yes. Fix the product bug too; a larger appetite is accepted. Test-hardening that
+  masks a real defect is not acceptable. (resolved 2026-07-20)
+- **Note (reframing):** The CI failure is *missing task stdout*, not the group-phase
+  timing/ordering assertion (which passed). The original "it's a timing test" framing is only
+  partly right — the stdout-scraping assumption is the proximate failure; the log-index ordering
+  check is a secondary fragility.
+
+## Related materials
+
+- Failing CI job: PR #52, job "tests (3.11)"; local log
+  `~/Downloads/logs_80518241903/5_tests (3.11).txt` (failure block: lines 633–692).
+- Test under repair: `tests/test_groups.py:116` (`test_group_failed_task_with_retries`).
+- Behavioral contract to preserve: AGENTS.md — "Task lifecycle contract" (retry model,
+  `CANCEL_STATUS`, group-gating via `Task.increment_group`) and "Concurrency model".
+- Likely code touchpoints for R4 diagnosis (to be confirmed by `hs-plan`, do not presume):
+  `client.py` (`TaskExecutor`, subprocess capture), `server.py` (`Scheduler` writeback/console
+  print), `core/queue.py` (`completed` queue), `data/model.py` (task-state queries).
+- Test harness: `tests/__init__.py` (`main`, `main_lines`, `assert_output`, `create_taskfile`),
+  `tests/conftest.py` (`temp_site`).

--- a/spec/deflake-group-retry-test/META.md
+++ b/spec/deflake-group-retry-test/META.md
@@ -33,3 +33,17 @@
   emit a `diagnosis: required` hint (or accept `appetite: medium`) so the gate is explicit rather
   than relying on the planner to notice.
 - **Confidence:** high · **Effort:** small
+
+## F2 — `temp_site.sh` doesn't isolate cwd, so verify drives leak files into the repo
+`origin=hs-build:P1 severity=low category=tooling status=open target=.agents/factory/bin/temp_site.sh`
+- **What happened:** a CLI cross-check run via `temp_site.sh sh -c "… > t.in; …"` wrote `t.in` to the
+  repo root (not the throwaway site), and `hs-build` Step 7's `git add -A` silently committed it; I
+  had to `del` it and amend.
+- **Skill cause:** `temp_site.sh` isolates env (`HYPERSHELL_SITE`/`HYPERSHELL_DATABASE_FILE`) but
+  never `cd`s into `$site`, so any relative file write in a verify/cross-check command escapes the
+  "throwaway site" into the working tree — unlike the pytest `temp_site` fixture, which contains
+  writes. `hs-build`'s blanket `git add -A` then sweeps the stray into the atomic commit.
+- **Recommended fix:** add `cd "$site"` in `temp_site.sh` before `"$@"` (and note it in the docstring)
+  so relative writes stay contained; optionally have `hs-build` Step 7 warn on files outside the
+  phase's declared `Touches:` set before `git add -A`.
+- **Confidence:** high · **Effort:** small

--- a/spec/deflake-group-retry-test/META.md
+++ b/spec/deflake-group-retry-test/META.md
@@ -1,0 +1,35 @@
+# META — De-flake `test_group_failed_task_with_retries`
+
+> **Harness feedback log** for this feature — the producer artifact of the factory's self-improvement
+> loop. Silence is the default; the bar is *was this the skill's fault?*
+
+- **slug:** deflake-group-retry-test
+
+## What worked well
+
+- `hs-plan:3` — the parallel read-only research fan-out (three briefs: output-path / test-harness /
+  design-intent) converged cleanly and independently on the same "no product defect" verdict, which
+  is exactly the confidence a diagnosis-gated fix needs. The three-way split (product code / test
+  harness / docs+history) had no overlap and left no gap.
+
+## Friction findings
+
+<!-- Real findings are appended below this line by the lifecycle skills. -->
+
+## F1 — `kind: fix` research-skip rule misfires for diagnostic fixes
+`origin=hs-plan:3 severity=medium category=steering status=open target=.claude/skills/hs-plan/SKILL.md`
+- **What happened:** Step 3 says for `kind: fix` (and `appetite: small`) to *skip the research
+  fan-out* and "do at most a couple of targeted reads yourself." This fix's `GOAL.md` explicitly
+  demanded first-principles root-cause diagnosis of an unknown failure (test-fragility vs. a real
+  product output-loss bug the human had opted into fixing). Following the rule literally would have
+  produced a test-only guess without ever confirming there was no product defect — the opposite of
+  what the GOAL required. I had to override the rule and run a full fan-out.
+- **Skill cause:** the research gate keys on `kind`/`appetite`, but those are proxies for the real
+  question — *is the root cause known?* A `kind: fix` can be a "diagnostic fix" whose whole value is
+  the investigation; the skill offers no carve-out for it (and the GOAL's non-canonical
+  `appetite: medium — diagnosis-gated` had no clean mapping either).
+- **Recommended fix:** in Step 3, add a branch: *if the GOAL's root cause is unknown or it explicitly
+  requests diagnosis, run the fan-out regardless of `kind`/`appetite`.* Optionally let `hs-feature`
+  emit a `diagnosis: required` hint (or accept `appetite: medium`) so the gate is explicit rather
+  than relying on the planner to notice.
+- **Confidence:** high · **Effort:** small

--- a/spec/deflake-group-retry-test/PLAN.md
+++ b/spec/deflake-group-retry-test/PLAN.md
@@ -1,0 +1,136 @@
+# PLAN — De-flake `test_group_failed_task_with_retries`
+
+> **Status:** Draft for review · **Last updated:** 2026-07-20
+> **Authoritative technical design.** The *how*. Vision/contract is [`GOAL.md`](GOAL.md);
+> the phased executable roadmap is [`TECH.md`](TECH.md). Backing detail is in
+> [`research/`](research/). Every design element traces to a GOAL R-ID.
+
+## 1. Summary
+
+First-principles diagnosis (three read-only research briefs, see
+[`research/00-digest.md`](research/00-digest.md)) shows the CI failure is **not** a HyperShell
+defect: task console output is a documented best-effort echo written *directly* to the inherited
+stdout fd, with no HyperShell code path that buffers, relays, or stores it — the database is the
+source of truth. The missing `"1"` is lost at the OS/CI-runner boundary, and the test was wrong to
+treat merged console stdout as a complete, ordered oracle. The fix is therefore **test-only and
+small**: rebuild `test_group_failed_task_with_retries` to assert on authoritative task state via
+`hs list`, keeping the robust single-writer *stderr* log assertions. This honors the human's
+"fix the product bug too" decision — we investigated and found no product bug (GOAL R4's antecedent
+is unmet), and say so rather than silently narrowing scope.
+
+## 2. Design
+
+Single-file change: `tests/test_groups.py`, function `test_group_failed_task_with_retries`
+(lines 115–146). No `src/` change — the product behaves correctly and as documented.
+
+**Keep** (robust — read `stderr`, the single-writer serialized log stream; all passed in CI):
+- `rc == exit_status.success`.
+- `assert_output(r'Non-zero exit status', stderr, 2)` — the two failed attempts.
+- `assert_output(r'Completed task group 0 - starting task group 1', stderr, 1)` — the transition.
+- The ordering proof `group_idx < n2_idx` (index of the group-transition log line vs. n:2's
+  `Completed task (<id>)` log line). Both come from `stderr`; group-gating already guarantees this
+  ordering, so it is not timing-fragile.
+
+**Replace** the fragile stdout scrape (`assert sorted(stdout.strip().splitlines()) == ['0','1','2']`,
+`test_groups.py:143`) and the trailing count check with authoritative `hs list` queries against the
+per-test SQLite DB (the server has written back by the time `hs cluster` returns):
+
+- `hs list -c` → `5` (n:0 = 1 row, n:1 = 3-row retry chain, n:2 = 1 row).
+- `hs list -c -t n:1` → `3` (chain length; retries copy the tag, `model.py:620-627`).
+- `hs list -c -t n:1 -F` → `2` (superseded failed rows; `-F` = `exit_status != 0`, `task.py:516`).
+- `hs list exit_status -t n:1 -S` → `['0']` and `hs list attempt -t n:1 -S` → `['3']` — the key
+  oracle: n:1 terminally **succeeded on its 3rd attempt**. Because the task is
+  `[ $TASK_ATTEMPT -eq 3 ] && echo 1`, a `0` exit is only reachable when `echo 1` runs, so this
+  proves the output was produced **without** scraping stdout (no `--capture` needed).
+- `hs list exit_status -t n:2 -S` → `['0']` and `hs list group -t n:2` → `['1']` — n:2 ran, in
+  group 1.
+- `hs list -c -R` → `0` — nothing left incomplete (no interrupted/orphaned rows).
+
+A short declarative comment will explain *why* stdout is not asserted (best-effort concurrent echo;
+DB is source of truth) so the next reader does not "restore" the scrape.
+
+### Requirement → design map
+
+| R-ID | Design element(s) that satisfy it |
+|------|-----------------------------------|
+| R1   | Correctness assertions move to authoritative DB state via `hs list` (counts, `exit_status`, `attempt`, `group`); stdout is no longer an oracle. |
+| R2   | `hs list exit_status/attempt -t n:1 -S` → `['0']`/`['3']` + `hs list -c` → `5` prove terminal success and row count independent of captured stdout. |
+| R3   | Ordering kept via the `stderr` group-transition vs. n:2-completion log indices (single-writer stream), backed by group-gating semantics — robust to runner load. |
+| R4   | Diagnosis (research 00–03) determined there is **no** product output-loss defect; antecedent unmet, so no `src/` change. Recorded transparently, not silently. |
+| R5   | DB assertions are strictly stronger than the old scrape (chain length, exact success attempt, failure count, group), so retry coverage is preserved/deepened. |
+| R6   | Test no longer depends on the non-deterministic merged stdout stream, removing the CI-load flake at its source; acceptance is green CI on the PR across 3.11–3.14. |
+
+## 3. Invariant gate (AGENTS.md constitution check)
+
+Checked against [`invariants.md`](../../.agents/factory/invariants.md) before research and again
+after this design. Touched sections and compliance:
+
+- **§1 Task lifecycle** — assertions read state via the nullable-column predicates exactly as
+  `hs list` exposes them (`-C` = `exit_status != null` = done; `-R` = `exit_status == null` =
+  remaining; `-X` = `CANCEL_STATUS`). We add no new query logic and put none in FSM code — we only
+  *call the CLI*. Honored.
+- **§3 Retry model** — assertions rely on the new-row/`attempt+1`/tag-copy chain (3 rows for n:1)
+  and read `attempt`/`exit_status`; nothing mutates the chain or the `attempts == max_retries + 1`
+  relationship. Honored (read-only).
+- **§12 Project conventions** — the test stays `@mark.integration`; uses `cmdkit.app.exit_status`
+  constants (already imported); uses `main`/`main_lines`/`assert_output` helpers. No CLI/behavior
+  change → no `docs/_include` or `share/` updates required. Honored.
+
+§4–§11 (server modes, concurrency, shutdown ordering, resources, signals, transport, config,
+cluster) are **not touched** — no `src/` change.
+
+### Deviation justifications
+
+| Deviation | Why needed | Simpler alternative rejected because |
+|-----------|-----------|--------------------------------------|
+| —         | —         | — |
+
+None. (Considered and rejected — see Risks: adding `--capture` to prove literal `"1"`.)
+
+## 4. Rabbit holes (resolved)
+
+- **Is the missing line a real product defect (dropped task output)?** → No. HyperShell never
+  buffers/relays/stores console output; with `DEFAULT_NUM_THREADS = 1` a single executor writes
+  sequentially to one pipe drained to EOF, so no in-process loss is possible; docs declare console
+  echo best-effort and the DB canonical. ([`research/01-output-path.md`](research/01-output-path.md),
+  [`research/03-design-intent-history.md`](research/03-design-intent-history.md)).
+- **What can we assert on instead, and are the filters retried-aware?** → `hs list` filters are
+  plain `exit_status` predicates (no `retried` exclusion), so superseded rows are counted; a full
+  verified assertion menu exists. `main()` runs the CLI as a subprocess against the per-test DB, so
+  `hs list` after `hs cluster` sees the writeback. ([`research/02-test-harness.md`](research/02-test-harness.md)).
+- **Regression or environment?** → Environment. No churn in the test or output path; CI is serial
+  (no xdist), so it is runner load, not a code change. ([`research/03-design-intent-history.md`](research/03-design-intent-history.md)).
+
+## 5. Risks & open questions
+
+- **Not locally reproducible.** The flake is CI-runner-bound; a green local run proves *determinism*
+  (no stdout dependence) but not the CI fix. **Mitigation:** the rewritten test has zero dependence
+  on the flaky stream, so it is immune by construction; final acceptance is a green CI run on the PR
+  (the human's stated gate).
+- **Rejected alternative — `--capture` for literal content proof.** We could run with `--capture`
+  and assert `hs info <id> --stdout == '1'` to prove the exact bytes. Rejected: it adds surface for
+  no gain — `exit_status == 0 ∧ attempt == 3` already proves `echo 1` ran, and `--capture` changes
+  the scenario under test. Noted so a reviewer knows it was considered.
+- **Residual unknown (non-blocking):** the exact OS/runner mechanism that drops one sequential-pipe
+  line is undetermined; it does not affect the fix.
+- **Out of scope (GOAL non-goals), flagged for follow-up:** ~15 other assertions scrape task stdout
+  the same way (`research/00-digest.md` lists them) and `test_groups.py:292` uses a wall-clock
+  bound. This fix is the pilot; a follow-up can apply the same state-based pattern.
+
+## 6. Verification strategy
+
+- **Primary:** run the rewritten test in a repeat loop to confirm determinism under local load, plus
+  the full group suite:
+  `uv run pytest -v tests/test_groups.py::test_group_failed_task_with_retries --count=20` is *not*
+  available (no `pytest-repeat`); instead loop in shell:
+  `for i in $(seq 1 20); do uv run pytest -q tests/test_groups.py::test_group_failed_task_with_retries || break; done`
+  then `uv run pytest -q tests/test_groups.py`.
+- **Cross-check the oracle by driving the real CLI** in a throwaway site (mirrors the test's DB
+  assertions), e.g. via `.agents/factory/bin/temp_site.sh` running the 3-task file with `-r 3` and
+  then the `hs list` queries above, confirming `5 / 3 / 2 / ['0'] / ['3'] / 0`.
+- **Full regression:** `uv run pytest -q` locally.
+- **Acceptance:** green `tests` job across Python 3.11–3.14 on the PR CI.
+
+---
+
+*Backing research: [`research/00-digest.md`](research/00-digest.md).*

--- a/spec/deflake-group-retry-test/REVIEW.md
+++ b/spec/deflake-group-retry-test/REVIEW.md
@@ -1,0 +1,59 @@
+# REVIEW — De-flake `test_group_failed_task_with_retries`
+
+> Adversarial QA by `hs-review`, run in an isolated/clean context. The correctness pass grades the
+> branch diff against [`GOAL.md`](GOAL.md) + the AGENTS.md invariants **only** — it does not see
+> `PLAN.md`/`TECH.md` (avoids grading-its-own-homework / plan-sycophancy). Every finding cites an
+> **executed** command, not an assertion.
+
+- **Reviewed commit:** 1f3737c6dfea5a0c6c25014f41993b2f2e627c03  ·  **Base:** develop  ·  **Date:** 2026-07-21
+- **Verdict:** approved
+- **Cycle:** 1 of ≤3 — mirrors `review.cycle` in `TECH.md`
+
+## Verification run
+
+Commands actually executed and their outcomes (the spine of the review):
+
+- Blind reviewer diff: `git diff develop...HEAD -- . ':(exclude)spec/'` → one non-spec file changed
+  (`tests/test_groups.py`, `test_group_failed_task_with_retries`); **no `src/` change**.
+- `for i in $(seq 1 10); do uv run pytest -q tests/test_groups.py::test_group_failed_task_with_retries; done`
+  → 10/10 PASS (reviewer). Independent orchestrator re-run → 8/8 PASS. Local determinism strong.
+- `uv run pytest -q tests/test_groups.py` → 11 passed (reviewer).
+- First-principles source read for R4: `client.py:671-672` (`redirect_output = … or sys.stdout`),
+  `client.py:772-773` (`Popen(stdout=self.redirect_output)`), `client.py:757-761` (`--capture` routes
+  to per-task files) — task console stdout is a best-effort direct write to the inherited shared fd;
+  not relayed/buffered/stored; the DB is canonical for task *state*.
+- `git status --porcelain` → empty at reviewer hand-back and after the sanity pass (clean tree).
+
+## Requirement → evidence matrix
+
+| R-ID | Implemented by (file/commit) | Verified how | Status |
+|------|------------------------------|--------------|--------|
+| R1 — verify contract from authoritative task state, not scraped stdout | `tests/test_groups.py` (1f3737c) — scrape replaced with `hs list` queries; cluster stdout discarded (`rc, _, stderr = …`) | 10/10 + 8/8 target runs green; full file 11 passed | ✅ |
+| R2 — terminal `exit_status==0` + expected row count independent of stdout | `hs list -c == ['5']`, `-c -t n:1 == ['3']`, `exit_status -t n:1 -S == ['0']`, `attempt -t n:1 -S == ['3']` | Test passes; retries copy parent tag so `-t n:1` matches the chain | ✅ |
+| R3 — assert ordering with a robust signal, not fragile raw log-line indices, where achievable | Retained `group_idx < n2_idx` over the single-writer serialized stderr | Defensible: the group-transition line is a true happens-before the group-1 schedule (`server.py` `increment_group`); GOAL's CI evidence shows the ordering assertion *passed* (the flake was stdout), so this is not the flake source | ✅ |
+| R4 — IF stdout genuinely dropped under load is a product defect, fix it | n-a — antecedent unmet; diff correctly makes no `src/` change | Source read shows console stdout is best-effort direct-to-fd echo, not committed-data loss; DB canonical → no product defect to fix | ✅ (n-a) |
+| R5 — do not weaken group-retry coverage (fail → succeed → gate transition) | `assert_output('Non-zero exit status', stderr, 2)`, `-c -t n:1 -F == ['2']`, `-S` exit 0 on attempt 3, transition-count == 1 + ordering | Coverage preserved/strengthened; test passes | ✅ |
+| R6 — pass reliably across CI 3.11–3.14 on constrained runners | Removes the load-sensitive stdout scrape (root cause); remaining assertions are on serialized-stream/DB state | **CI-bound** — strong local determinism (10/10 + 8/8), but hosted-runner matrix green is the maintainer's acceptance signal, unverifiable locally | ⏳ CI-bound |
+
+Unmapped changes (possible scope creep): **none**. Every assertion maps to R1/R2/R3/R5; R4 is a
+correct no-op. Other group tests that still scrape stdout were untouched (out of GOAL scope).
+
+## Findings
+
+**None.** No correctness bugs, no AGENTS.md invariant violations, no requirement gaps, no scope
+creep. The change is test-only and touches no high-blast-radius core file.
+
+## Human-gate triggers
+
+None. No CONFIRMED finding (there are none), and the diff touches no high-blast-radius core file
+(`data/model.py`, `server.py`, `client.py`, `core/queue|tls|fsm|thread|signal.py`,
+`cluster/remote|ssh.py`) and no security/DB-lifecycle invariant — it is a test-only change.
+
+## Notes
+
+- **R6 is the residual risk and it is CI-bound by design.** GOAL and TECH both state the flake is not
+  locally reproducible, so the true acceptance gate is a green `tests` job across Python 3.11–3.14 on
+  the PR. Local evidence (root cause removed + strong determinism) is necessary but not sufficient;
+  the maintainer's PR-CI sign-off closes R6.
+- `hs cluster -r 3` → `max_retries=3` → `attempts=4`, but n:1 succeeds on attempt 3, so the chain
+  caps at 3 rows / 2 failures — consistent with every row/failure-count assertion.

--- a/spec/deflake-group-retry-test/TECH.md
+++ b/spec/deflake-group-retry-test/TECH.md
@@ -7,7 +7,7 @@ status: in_review
 branch: fix/deflake-group-retry-test
 base: develop
 current_phase: done
-last_updated: '2026-07-20'
+last_updated: '2026-07-21'
 phases:
 - id: P1
   name: Rebuild the test on authoritative DB state
@@ -26,10 +26,10 @@ phases:
   verify: for i in $(seq 1 15); do uv run pytest -q tests/test_groups.py::test_group_failed_task_with_retries
     || exit 1; done && uv run pytest -q tests/test_groups.py
 review:
-  last_reviewed_commit: ''
-  verdict: none
+  last_reviewed_commit: 1f3737c6dfea5a0c6c25014f41993b2f2e627c03
+  verdict: approved
   blocked_reason: ''
-  cycle: 0
+  cycle: 1
 ---
 # TECH.md — De-flake `test_group_failed_task_with_retries`
 

--- a/spec/deflake-group-retry-test/TECH.md
+++ b/spec/deflake-group-retry-test/TECH.md
@@ -3,7 +3,7 @@ slug: deflake-group-retry-test
 title: De-flake test_group_failed_task_with_retries
 kind: fix
 appetite: small
-status: in_review
+status: done
 branch: fix/deflake-group-retry-test
 base: develop
 current_phase: done

--- a/spec/deflake-group-retry-test/TECH.md
+++ b/spec/deflake-group-retry-test/TECH.md
@@ -1,30 +1,36 @@
 ---
 slug: deflake-group-retry-test
-title: "De-flake test_group_failed_task_with_retries"
+title: De-flake test_group_failed_task_with_retries
 kind: fix
 appetite: small
-status: in_progress
+status: in_review
 branch: fix/deflake-group-retry-test
 base: develop
-current_phase: P1
-last_updated: "2026-07-20"
+current_phase: done
+last_updated: '2026-07-20'
 phases:
-  - id: P1
-    name: "Rebuild the test on authoritative DB state"
-    status: pending
-    satisfies: [R1, R2, R3, R4, R5, R6]
-    depends_on: []
-    parallel: false
-    hammerable: false
-    hill: downhill
-    verify: "for i in $(seq 1 15); do uv run pytest -q tests/test_groups.py::test_group_failed_task_with_retries || exit 1; done && uv run pytest -q tests/test_groups.py"
+- id: P1
+  name: Rebuild the test on authoritative DB state
+  status: done
+  satisfies:
+  - R1
+  - R2
+  - R3
+  - R4
+  - R5
+  - R6
+  depends_on: []
+  parallel: false
+  hammerable: false
+  hill: downhill
+  verify: for i in $(seq 1 15); do uv run pytest -q tests/test_groups.py::test_group_failed_task_with_retries
+    || exit 1; done && uv run pytest -q tests/test_groups.py
 review:
-  last_reviewed_commit: ""
+  last_reviewed_commit: ''
   verdict: none
-  blocked_reason: ""
+  blocked_reason: ''
   cycle: 0
 ---
-
 # TECH.md — De-flake `test_group_failed_task_with_retries`
 
 The **context engine and finite-state machine** for building this fix. The YAML frontmatter above
@@ -61,33 +67,33 @@ contract entirely from authoritative task state + the single-writer stderr log s
 dependence on the non-deterministic merged task-stdout stream — removing the CI-load flake at its
 source while strengthening coverage.
 
-- [ ] Edit **only** `tests/test_groups.py`, function `test_group_failed_task_with_retries`
+- [x] Edit **only** `tests/test_groups.py`, function `test_group_failed_task_with_retries`
       (lines 115–146). Keep the task list, `create_taskfile`, and the `hs cluster … -r 3` invocation
       unchanged (preserve the exact scenario).
-- [ ] **Keep** the robust `stderr`/`rc` assertions: `rc == exit_status.success`;
+- [x] **Keep** the robust `stderr`/`rc` assertions: `rc == exit_status.success`;
       `assert_output(r'Non-zero exit status', stderr, 2)`;
       `assert_output(r'Completed task group 0 - starting task group 1', stderr, 1)`; and the
       `group_idx < n2_idx` ordering proof (both indices come from `stderr`, the serialized log).
-- [ ] **Remove** the fragile stdout scrape at line 143
+- [x] **Remove** the fragile stdout scrape at line 143
       (`assert sorted(stdout.strip().splitlines()) == list(map(str, range(len(tasks))))`) and the
       trailing `hs list -c == ['5']` line; replace with authoritative `hs list` queries (via
       `main`/`main_lines`, all against the per-test DB the server has already written back):
-  - [ ] `main_lines(['hs','list','-c'])` → `['5']` (n:0=1, n:1=3-row chain, n:2=1).
-  - [ ] `main_lines(['hs','list','-c','-t','n:1'])` → `['3']` (retry chain length).
-  - [ ] `main_lines(['hs','list','-c','-t','n:1','-F'])` → `['2']` (superseded failed rows;
+  - [x] `main_lines(['hs','list','-c'])` → `['5']` (n:0=1, n:1=3-row chain, n:2=1).
+  - [x] `main_lines(['hs','list','-c','-t','n:1'])` → `['3']` (retry chain length).
+  - [x] `main_lines(['hs','list','-c','-t','n:1','-F'])` → `['2']` (superseded failed rows;
         `-F` = `exit_status != 0`).
-  - [ ] `main_lines(['hs','list','exit_status','-t','n:1','-S'])` → `['0']` **and**
+  - [x] `main_lines(['hs','list','exit_status','-t','n:1','-S'])` → `['0']` **and**
         `main_lines(['hs','list','attempt','-t','n:1','-S'])` → `['3']` — key oracle: n:1 succeeded
         on attempt 3, which (given `[ $TASK_ATTEMPT -eq 3 ] && echo 1`) proves `echo 1` ran without
         scraping stdout.
-  - [ ] `main_lines(['hs','list','exit_status','-t','n:2','-S'])` → `['0']` **and**
+  - [x] `main_lines(['hs','list','exit_status','-t','n:2','-S'])` → `['0']` **and**
         `main_lines(['hs','list','group','-t','n:2'])` → `['1']` (n:2 ran, in group 1).
-  - [ ] `main_lines(['hs','list','-c','-R'])` → `['0']` (nothing incomplete).
-  - [ ] Use `NO_OUTPUT` for the stderr slot in `main_lines` comparisons, matching existing tests.
-- [ ] Add a short **declarative** comment stating *why* stdout is not asserted (best-effort
+  - [x] `main_lines(['hs','list','-c','-R'])` → `['0']` (nothing incomplete).
+  - [x] Use `NO_OUTPUT` for the stderr slot in `main_lines` comparisons, matching existing tests.
+- [x] Add a short **declarative** comment stating *why* stdout is not asserted (best-effort
       concurrent console echo; the database is the source of truth) so a future reader does not
       reinstate the scrape. Do **not** embed spec R-IDs (AGENTS.md comment rule).
-- [ ] Confirm the exact `hs list` field names / flags against `src/hypershell/task.py`
+- [x] Confirm the exact `hs list` field names / flags against `src/hypershell/task.py`
       (`exit_status`, `attempt`, `group` positionals; `-t/--with-tag`, `-c/--count`, `-F/--failed`,
       `-S/--succeeded`, `-R/--remaining`) before relying on them — fix any drift.
 - **Verify:** `for i in $(seq 1 15); do uv run pytest -q tests/test_groups.py::test_group_failed_task_with_retries || exit 1; done && uv run pytest -q tests/test_groups.py`

--- a/spec/deflake-group-retry-test/TECH.md
+++ b/spec/deflake-group-retry-test/TECH.md
@@ -1,0 +1,111 @@
+---
+slug: deflake-group-retry-test
+title: "De-flake test_group_failed_task_with_retries"
+kind: fix
+appetite: small
+status: in_progress
+branch: fix/deflake-group-retry-test
+base: develop
+current_phase: P1
+last_updated: "2026-07-20"
+phases:
+  - id: P1
+    name: "Rebuild the test on authoritative DB state"
+    status: pending
+    satisfies: [R1, R2, R3, R4, R5, R6]
+    depends_on: []
+    parallel: false
+    hammerable: false
+    hill: downhill
+    verify: "for i in $(seq 1 15); do uv run pytest -q tests/test_groups.py::test_group_failed_task_with_retries || exit 1; done && uv run pytest -q tests/test_groups.py"
+review:
+  last_reviewed_commit: ""
+  verdict: none
+  blocked_reason: ""
+  cycle: 0
+---
+
+# TECH.md — De-flake `test_group_failed_task_with_retries`
+
+The **context engine and finite-state machine** for building this fix. The YAML frontmatter above
+is the resume ground-truth (read it with
+`uv run python .agents/factory/bin/next_phase.py spec/deflake-group-retry-test/TECH.md`).
+
+- **Vision / requirements (locked):** [`GOAL.md`](GOAL.md) — R-IDs are the contract.
+- **Authoritative design:** [`PLAN.md`](PLAN.md).
+- **Backing research:** [`research/00-digest.md`](research/00-digest.md) + briefs 01–03.
+
+## Why one phase
+
+First-principles diagnosis (research 00–03) established there is **no product defect**: task console
+output is a documented best-effort echo (`Popen(stdout=sys.stdout)`, no relay/buffer/store;
+`DEFAULT_NUM_THREADS = 1`; docs declare the DB canonical). GOAL R4's antecedent is unmet, so there
+is **no `src/` change** — only the fragile test is rebuilt onto authoritative task state. That is a
+single, independently-verifiable vertical slice.
+
+## Conventions (apply to the phase)
+
+- Commit conventions, style, and invariants come from [`AGENTS.md`](../../AGENTS.md); curated
+  footguns in [`.agents/factory/invariants.md`](../../.agents/factory/invariants.md).
+- One atomic commit containing **both** the test change and this `TECH.md` state change. Subject:
+  `[fix] Build deflake-group-retry-test P1: …`. **No `Co-Authored-By` trailer.**
+- No CLI/behavior change → **no** `docs/_include/*.rst` or `share/` updates (invariant §12 does not
+  trigger here).
+
+---
+
+## Phase P1 — Rebuild the test on authoritative DB state
+**Satisfies:** R1, R2, R3, R4, R5, R6 · **Depends on:** —
+**Goal:** `tests/test_groups.py::test_group_failed_task_with_retries` verifies the group-retry
+contract entirely from authoritative task state + the single-writer stderr log stream, with **zero**
+dependence on the non-deterministic merged task-stdout stream — removing the CI-load flake at its
+source while strengthening coverage.
+
+- [ ] Edit **only** `tests/test_groups.py`, function `test_group_failed_task_with_retries`
+      (lines 115–146). Keep the task list, `create_taskfile`, and the `hs cluster … -r 3` invocation
+      unchanged (preserve the exact scenario).
+- [ ] **Keep** the robust `stderr`/`rc` assertions: `rc == exit_status.success`;
+      `assert_output(r'Non-zero exit status', stderr, 2)`;
+      `assert_output(r'Completed task group 0 - starting task group 1', stderr, 1)`; and the
+      `group_idx < n2_idx` ordering proof (both indices come from `stderr`, the serialized log).
+- [ ] **Remove** the fragile stdout scrape at line 143
+      (`assert sorted(stdout.strip().splitlines()) == list(map(str, range(len(tasks))))`) and the
+      trailing `hs list -c == ['5']` line; replace with authoritative `hs list` queries (via
+      `main`/`main_lines`, all against the per-test DB the server has already written back):
+  - [ ] `main_lines(['hs','list','-c'])` → `['5']` (n:0=1, n:1=3-row chain, n:2=1).
+  - [ ] `main_lines(['hs','list','-c','-t','n:1'])` → `['3']` (retry chain length).
+  - [ ] `main_lines(['hs','list','-c','-t','n:1','-F'])` → `['2']` (superseded failed rows;
+        `-F` = `exit_status != 0`).
+  - [ ] `main_lines(['hs','list','exit_status','-t','n:1','-S'])` → `['0']` **and**
+        `main_lines(['hs','list','attempt','-t','n:1','-S'])` → `['3']` — key oracle: n:1 succeeded
+        on attempt 3, which (given `[ $TASK_ATTEMPT -eq 3 ] && echo 1`) proves `echo 1` ran without
+        scraping stdout.
+  - [ ] `main_lines(['hs','list','exit_status','-t','n:2','-S'])` → `['0']` **and**
+        `main_lines(['hs','list','group','-t','n:2'])` → `['1']` (n:2 ran, in group 1).
+  - [ ] `main_lines(['hs','list','-c','-R'])` → `['0']` (nothing incomplete).
+  - [ ] Use `NO_OUTPUT` for the stderr slot in `main_lines` comparisons, matching existing tests.
+- [ ] Add a short **declarative** comment stating *why* stdout is not asserted (best-effort
+      concurrent console echo; the database is the source of truth) so a future reader does not
+      reinstate the scrape. Do **not** embed spec R-IDs (AGENTS.md comment rule).
+- [ ] Confirm the exact `hs list` field names / flags against `src/hypershell/task.py`
+      (`exit_status`, `attempt`, `group` positionals; `-t/--with-tag`, `-c/--count`, `-F/--failed`,
+      `-S/--succeeded`, `-R/--remaining`) before relying on them — fix any drift.
+- **Verify:** `for i in $(seq 1 15); do uv run pytest -q tests/test_groups.py::test_group_failed_task_with_retries || exit 1; done && uv run pytest -q tests/test_groups.py`
+  (15 consecutive green runs prove local determinism; the full groups file guards against
+  regressions). Optionally cross-check by driving the CLI in a throwaway site:
+  `.agents/factory/bin/temp_site.sh sh -c "printf 'echo 0  #HYPERSHELL: n:0 group:0\n[ \$TASK_ATTEMPT -eq 3 ] && echo 1  #HYPERSHELL: n:1 group:0\necho 2  #HYPERSHELL: n:2 group:1\n' > t.in && uv run hs cluster t.in -r 3 >/dev/null 2>&1; uv run hs list -c; uv run hs list attempt -t n:1 -S"`
+  → expect `5` then `3`.
+- **Touches:** `tests/test_groups.py` (only), `spec/deflake-group-retry-test/TECH.md` (state).
+
+---
+
+## How `hs-build` drives this
+
+1. `next_phase.py` prints P1 as the next actionable phase.
+2. Pre-flight: clean tree, on `fix/deflake-group-retry-test`, `develop` reachable.
+3. Execute every `[ ]` above (consult `PLAN.md` / `research/` for detail).
+4. Run the `verify:` command — never advance on a checkbox alone.
+5. Mark P1 `done`, `--touch`; one `[fix]` commit; stop and report.
+
+**Acceptance is CI-bound:** the flake is not locally reproducible, so the true gate is a green
+`tests` job across Python 3.11–3.14 on the PR (the human's stated sign-off).

--- a/spec/deflake-group-retry-test/research/00-digest.md
+++ b/spec/deflake-group-retry-test/research/00-digest.md
@@ -1,0 +1,87 @@
+# Research digest — deflake-group-retry-test
+
+Consolidated decisions from the three briefs. Where briefs diverged, a single recommendation is
+given here. Backing detail: [`01-output-path.md`](01-output-path.md),
+[`02-test-harness.md`](02-test-harness.md), [`03-design-intent-history.md`](03-design-intent-history.md).
+
+## Verdict: no product defect — the fix is test-only
+
+All three lines of evidence converge: the missing `"1"` is **not** a HyperShell defect. Console
+task-output is a documented best-effort echo, not an authoritative record.
+
+- **No relay/buffer/store in HyperShell code.** Task subprocesses are spawned with
+  `Popen(..., stdout=self.redirect_output)` where, with the default `capture=False`,
+  `redirect_output` **is** `sys.stdout` (`client.py:671`, `:772-774`). Output bytes go straight
+  from the child to the inherited fd. No HyperShell thread ever re-prints task stdout; the
+  `completed`-queue result carries only metadata (`exit_status`, timing), never output bytes
+  (`server.py:456-466`). So there is no code path that could drop a line.
+- **`DEFAULT_NUM_THREADS = 1`** (`client.py:1067`) — this test spawns a *single* executor writing
+  `0\n`, `1\n`, `2\n` sequentially to one ordered pipe that the test's `subprocess.run(stdout=PIPE)`
+  (`tests/__init__.py:30`) drains to EOF. In-process, a mid-stream line **cannot** be lost. The
+  loss is therefore at the OS/stdio/CI-runner boundary — environmental, and it can't be pinned from
+  code alone (residual open question, see below).
+- **Docs say so.** `docs/getting_started.rst:74-75`: task stdout/stderr are "joined and written out
+  **directly**" — no completeness/ordering claim; `--capture` is the way to keep per-task output.
+  `docs/security.rst:334`, `docs/alternatives.rst:45`: "the database is the source of truth."
+- **Not a regression.** Test added in `0844bf1` (2025-12-23, task-groups feature), body unchanged
+  since; the console-echo path has no recent churn; no prior flaky/timing/output-loss commits exist.
+- **CI shape rules out a test-runner fix.** Matrix Py 3.11–3.14 on `ubuntu-latest`, invoked
+  `uv run --python <ver> pytest -v` — **no xdist, no rerun plugin**, serial. The load is the
+  constrained hosted runner plus each integration test's own full-cluster concurrency.
+
+**Consequence for GOAL R4:** its antecedent ("IF diagnosis determines task stdout is genuinely
+dropped by a product defect") is **not met**. The correct, contract-honoring resolution is
+test-hardening (R1/R2/R3/R5/R6). The user's "fix the product bug too" decision stands — there is
+simply no product bug to fix, and we say so transparently rather than silently doing test-only.
+
+## The fix: assert on authoritative task state, not scraped stdout
+
+Replace the fragile `assert sorted(stdout.strip().splitlines()) == ['0','1','2']`
+(`test_groups.py:143`) with database assertions via `hs list` / `hs info`. Keep the robust
+stderr/log assertions (the log stream is single-writer and passed in CI).
+
+**Filter semantics verified** (`task.py:515-524`) — plain `exit_status` predicates, **no `retried`
+exclusion**, so superseded rows are counted:
+
+| `-F/--failed` | `-S/--succeeded` | `-C/--completed` | `-R/--remaining` | `-X/--cancelled` |
+|---|---|---|---|---|
+| `exit_status != 0` | `exit_status == 0` | `exit_status != null` | `exit_status == null` | `== CANCEL_STATUS` |
+
+Retry rows copy the parent's `tag`/`group`/`fingerprint`/`source` (`model.py:620-627`), so `-t n:1`
+matches the whole 3-row chain. The authoritative assertion menu:
+
+| Assertion | Proves | Value |
+|---|---|---|
+| `hs list -c` | total rows | `5` (n:0=1, n:1=3, n:2=1) |
+| `hs list -c -t n:1` | chain length | `3` (attempts 1,2,3) |
+| `hs list -c -t n:1 -F` | failures | `2` (attempts 1,2 exit 1) — matches "Non-zero exit status" ×2 |
+| `hs list exit_status -t n:1 -S` | terminal success | `['0']` |
+| `hs list attempt -t n:1 -S` | **succeeded on 3rd attempt** | `['3']` — key oracle |
+| `hs list -c -R` | nothing incomplete | `0` |
+| `hs list exit_status -t n:2 -S` + `hs list group -t n:2` | n:2 ran in group 1 | `['0']`, `['1']` |
+
+**Content proof is unnecessary** (`--capture` not needed): the command
+`[ $TASK_ATTEMPT -eq 3 ] && echo 1` can only exit `0` on attempt 3 — the `&&` chain means
+`exit_status == 0` for that task *is* proof `echo 1` ran. So `exit_status==0 ∧ attempt==3` proves
+n:1 produced its output, without touching stdout. This also preserves R5 (behavioral coverage is
+stronger, not weaker, than the old scrape).
+
+**Ordering (R3):** keep the existing `group_idx < n2_idx` check — it reads **stderr** (the
+single-writer log stream), which is robust and passed in CI; the fragility was stdout, not stderr.
+Group-gating semantics already guarantee group 1 cannot start until group 0 completes, so the
+presence of the transition message + n:2's success is itself an ordering proof.
+
+## Scope guards (from GOAL non-goals)
+
+The same stdout-scraping assumption exists across ~15 other assertions
+(`test_groups.py:39,61,82,167,186,224,287`, `test_cluster.py:248,257`,
+`test_restart.py:35,54,102,118,157`, `test_submit_json.py:275,358`, `test_cancel.py:68,93`) and the
+wall-clock `elapsed > 10` at `test_groups.py:292`. These are **out of scope** here (GOAL non-goals) —
+this fix is the pilot; the pattern is a follow-up.
+
+## Residual open question
+
+The precise CI byte-loss trigger (why a single sequential-writer pipe drops one mid-stream line on a
+loaded hosted runner) could not be determined from code. It does **not** need to be: the rewritten
+test does not depend on that stream at all, so it is immune regardless of the trigger. Final
+acceptance is a green CI run on the PR (the flake is not locally reproducible).

--- a/spec/deflake-group-retry-test/research/01-output-path.md
+++ b/spec/deflake-group-retry-test/research/01-output-path.md
@@ -1,0 +1,121 @@
+# 01 — Task-output lifecycle: subprocess stdout → `hs cluster` stdout
+
+Scope: `tests/test_groups.py::test_group_failed_task_with_retries` flake — the successful
+retry's line (`"1"`) is missing from captured `hs cluster` stdout while a later line (`"2"`)
+survives. Traced the full output path for a first-attempt task and a retry row.
+
+## Verdict (root cause + confidence)
+
+**(b) — this is an inherent property of HyperShell's best-effort console echo; the test is
+asserting on a stream it must not treat as an ordered, complete, authoritative record.**
+Confidence: high on the mechanism/classification; medium on the *exact* byte-loss trigger.
+
+Default task stdout is **not captured and re-printed by any HyperShell thread**. Each task's
+shell subprocess is spawned with `stdout=sys.stdout` (`client.py:671`, `client.py:772-774`), so
+its `fileno()` (fd 1 of the `hs cluster` process — an OS pipe under the test's
+`subprocess.run(..., stdout=PIPE)`, `tests/__init__.py:30`) is inherited and the child writes
+**directly** to that fd. The parent never buffers, orders, flushes, or relays those bytes;
+delivery is entirely a property of the OS pipe + each independent subprocess's libc/stdio flush.
+This passthrough runs completely outside the control plane (DB + queues) that determines
+success, so console stdout carries **no delivery guarantee tied to task completion**. The test's
+line 143 assertion (`sorted(stdout.splitlines()) == ['0','1','2']`) scrapes that best-effort
+stream and is the fragile part; the test's other assertions (row counts, group-transition log
+lines, DB `id` lookups) are on authoritative state and are sound.
+
+Important honesty note: for this *exact* invocation (default `-N1`, no `--capture`, normal
+exit-0 on attempt 3) the **in-process code path cannot lose a single mid-stream line via the
+pipe** — one executor writes `0\n`,`1\n`,`2\n` sequentially to one ordered FIFO that
+`communicate()` drains to EOF. That strongly implies the actual byte loss is at the
+OS/stdio/CI-runner boundary (see Open questions), which *reinforces* the verdict: the console is
+outside HyperShell's guarantees, so the test should not depend on it.
+
+## The output path, step by step
+
+First-attempt task (e.g. `echo 0`):
+1. Server `Scheduler` loads rows from DB and posts a bundle on `scheduled`
+   (`server.py:206-257`); `Task.next` selects by group/attempts.
+2. Client `ClientScheduler` pulls the bundle, pushes each `Task` to the local inbound queue
+   (`client.py:206-261`).
+3. `TaskExecutor.start_task` builds env (incl. `TASK_ATTEMPT`, `TASK_OUTPATH`) and spawns the
+   subprocess: `Popen(self.task.command, shell=True, stdout=self.redirect_output,
+   stderr=self.redirect_errors, ...)` (`client.py:756-774`). With `capture=False` (default),
+   `self.redirect_output` is `sys.stdout` (`client.py:671`) — the child writes `0\n` straight to
+   fd 1. **No copy is retained.**
+4. `wait_task` blocks on `process.wait()`, records `exit_status`/`completion_time`/`duration`
+   (`client.py:779-795`). Output bytes are neither read nor stored.
+5. The completed `Task` (metadata only) goes outbound → `ClientCollector` bundles it →
+   `completed` queue → server `Receiver.update_tasks` writes it back to the DB and logs
+   `Completed task (…)`; on non-zero exit it logs `Non-zero exit status` and optionally writes
+   `task.args` to `redirect_failures` (**args, not output**) (`server.py:456-466`).
+
+`hs cluster` default routing: `ClusterApp.output_stream` = `sys.stdout` unless `-o PATH`
+(`cluster/__init__.py:424-426`), threaded through `run_local` → `LocalCluster` → `ClientThread`
+→ `TaskExecutor.redirect_output` (`cluster/__init__.py:292`, `cluster/local.py:241`,
+`client.py:1232`). So default = **inherit the cluster's stdout fd**, never capture-then-reprint.
+
+Retry row (attempt 3 of `n:1`, `[ $TASK_ATTEMPT -eq 3 ] && echo 1`): a retry is a *new row*
+(attempt+1) scheduled by the server exactly like any other task; it flows through steps 1–5
+**identically**. `TASK_ATTEMPT=3` comes from the row's `attempt` field via `task_env`
+(`client.py:439-460`), so the shell runs `echo 1`, writes `1\n` to fd 1, exits 0. There is **no
+distinct retry code path** for output — same `Popen(stdout=sys.stdout)`.
+
+Why a retry's line is *more exposed* nonetheless: it is produced late, only after two failed
+attempts plus the server's group-gating backoff (`server.py:224-241`), i.e. right before the
+`Completed task group 0 - starting task group 1` transition. It therefore lands nearest the
+group boundary and the eventual shutdown drain — the window where any flush/ordering weakness is
+most likely to bite. (Note it is still *before* `echo 2`, so tail-truncation is excluded, as the
+symptom confirms.)
+
+## Where a line can be dropped (hazard enumeration)
+
+1. **Pure fd inheritance, zero relay** (`client.py:671,772-774`): the parent has no buffer,
+   flush, or ordering control over task bytes; they exist only if the OS pipe delivers them.
+2. **Multiple unsynchronized writers**: with `-N>1` or multiple clients, N independent shell
+   processes share one stdout fd with no app-level lock. Writes ≤ `PIPE_BUF` (64 KiB) are atomic
+   but inter-process order is arbitrary; larger writes interleave. (Not the direct trigger here:
+   this test is `-N1` and lines are sequential.)
+3. **Subprocess killed before stdio flush**: on timeout/shutdown the executor escalates
+   SIGINT→SIGTERM→SIGKILL (`client.py:865-884`); a signal-killed child loses buffered stdout.
+   (Not this case — attempt 3 exits 0 normally, which flushes.)
+4. **Pipe = block-buffered (not a TTY)**: under `subprocess.run(stdout=PIPE)` the child's stdout
+   is block-buffered; short lines only reach the pipe at child exit. Reliable for normal exit,
+   fragile for abnormal termination.
+5. **Broken-pipe fd redirect** (`core/exceptions.py:99-114`): `handle_broken_pipe` does
+   `os.dup2(devnull, sys.stdout.fileno())`, silently discarding *subsequent* stdout. Only fires
+   on `BrokenPipeError` (early reader close, e.g. `hsx | head`); `communicate()` reads to EOF, so
+   not triggered here — but it would drop *later*, not *earlier*, lines.
+6. **Shutdown/exit race**: if the cluster process closed the pipe write end before a lagging
+   child flushed. Guarded here by `process.wait()` before the executor advances, so not the
+   in-process cause.
+
+None of 1–6 cleanly drops an *earlier* line while keeping a *later* one under `-N1` + normal
+exit — hence the environmental suspicion below.
+
+## Authoritative record of task output (for test hardening)
+
+- **Success/timing/exit are authoritative in the DB.** `Receiver` persists the `Task` row via
+  `Task.update_all(... to_dict())` (`server.py:456-459`): `exit_status`, `completion_time`,
+  `duration`, `attempt`, etc. Assert on these (e.g. `hs list`, `hs info ID`), not console text.
+- **Task output *text* is NOT stored by default.** Without `--capture`/`-o`, stdout is *only*
+  echoed to the console fd and kept nowhere. It is persisted to a file **only** under
+  `--capture`: `task.outpath = {default_path.lib}/task/{id}.out`, opened per-task and recorded on
+  the row (`client.py:453,757-761`; dir created in `core/platform.py:119`). `hs info ID --stdout`
+  reads `task.outpath` (`task.py:195-231,255`). So a robust content assertion requires
+  `hsx --capture …` then reading the `.out` file or `hs info ID --stdout` — a real, flushed,
+  per-task file rather than a shared console pipe.
+
+Recommended hardening: keep the DB/row-count/group-order assertions; replace the
+`stdout.splitlines() == ['0','1','2']` scrape with either (a) DB-only assertions (already largely
+present), or (b) a `--capture` run asserting per-task `.out` contents.
+
+## Open questions
+
+- **Exact byte-loss trigger under CI.** The `-N1`, exit-0 in-process path can't drop a
+  mid-stream pipe line; the loss likely originates at the OS/stdio/CI-runner or test-harness
+  layer (e.g. runner fd handling, or pytest-xdist worker effects). `main()` PIPEs the child's
+  stdout directly to the test process (`tests/__init__.py:30`), so pytest's own capture should
+  *not* touch it — worth confirming under `-n auto`.
+- Does any CI wrapper wrap/replace the child's stdout with something non-fd-backed (which would
+  send `Popen` down a different handle path)? Not observed in-repo.
+- Whether raising executor concurrency or bundle timing on the loaded runner changes ordering
+  enough to expose hazard #2 even at nominal `-N1` (e.g. leftover subprocesses). Believed no.

--- a/spec/deflake-group-retry-test/research/02-test-harness.md
+++ b/spec/deflake-group-retry-test/research/02-test-harness.md
@@ -1,0 +1,115 @@
+# Research 02 — Test Harness & Robust-Assertion Menu
+
+Scope: what `tests/` gives a rebuilt `test_group_failed_task_with_retries`, and the
+authoritative (non-stdout-scraping) signals it can assert on.
+
+## How `main()` captures output — the root of the flake
+
+`tests/__init__.py:28` `main(argv)` runs the CLI as a **real subprocess**:
+
+```python
+proc = run(argv, stdout=PIPE, stderr=PIPE, env=os.environ)   # tests/__init__.py:30
+return (proc.returncode, proc.stdout.decode().strip(), proc.stderr.decode().strip())
+```
+
+- **Not** `redirect_stdout`, **not** `capsys`, **not** in-process. `hs cluster` is a
+  separate process; server + client threads live inside it and inherit its stdout.
+- By default the client runs tasks with **`capture=False`**, so `redirect_output =
+  sys.stdout` (`client.py:671`) and every task subprocess's stdout is wired **directly to
+  the cluster process's stdout fd** (`Popen(..., stdout=self.redirect_output ...)`,
+  `client.py:773`). With `-N>1` many task subprocesses share that one fd concurrently.
+- So the captured `stdout` is a **concurrent merge of N task subprocess fds**. A missing
+  line ("1") is a lost/interleaved write on that shared fd under a race — the buffer is
+  inherently non-deterministic and not a reliable oracle. This is exactly the flake.
+- `main_lines` (`:38`) just splits/str ips `main()`'s output; `assert_output(pattern,
+  output, count, groups)` (`:48`) regex-counts matching **lines** (`n == count`);
+  `NO_OUTPUT = ['']` (`:25`) is the empty-stderr sentinel; `create_taskfile` (`:59`) /
+  `create_taskfile_echo` (`:68`, writes `echo {n} # HYPERSHELL: ... n:{n}`) build inputs.
+
+**Implication for the rebuild:** stop asserting on merged cluster stdout for per-task
+content; assert on DB rows written back by the server (authoritative, single-writer).
+
+## Fixtures (`tests/conftest.py`)
+
+- `isolate_environment()` (`:23`) runs at **import** (`:39`) and via the autouse
+  `clean_env` fixture (`:42`) before **every** test: scrubs all `HYPERSHELL_*`, sets
+  `HYPERSHELL_CONFIG_FILE=''` and `HYPERSHELL_SERVER_PORT=free_port()` (`:16` binds an
+  ephemeral loopback port — no cross-test collisions).
+- `temp_site` (`:48`) makes a tmp dir and sets `HYPERSHELL_SITE`,
+  `HYPERSHELL_DATABASE_FILE=<site>/local.db`, `HYPERSHELL_LOGGING_LEVEL=DEBUG`. The DB is a
+  per-test SQLite file; `hs list`/`hs info` in the same test see the rows the cluster wrote.
+- DEBUG logging is why the existing assertions can grep `DEBUG [hypershell.server]
+  Completed task (...)` from stderr (stderr carries logs; stdout carries task output).
+
+## Robust-signal menu (assert on these, not stdout)
+
+Task columns encoding outcome (`data/model.py:256-336`): `exit_status` (int, nullable),
+`attempt` (int), `retried` (bool), `group` (int), `previous_id`/`next_id` (UNIQUE retry
+chain), `completion_time`, `outpath`, `tag` (JSON; carries `n:` labels). Retries are **new
+rows** copying the parent `tag`, `group`, `fingerprint`, `source` (`model.py:620-627`), so
+**every row in n:1's retry chain still matches `-t n:1`** (3 rows here).
+
+`hs list` interface (`task.py:552-673`): positional FIELD names (any of `Task.columns`),
+`-t/--with-tag`, `-g/--group`, `-c/--count`, `-s/--order-by FIELD [--desc]`,
+`-f plain|csv|json|table|normal`, and status aliases `-F/--failed` (`exit_status!=0`),
+`-S/--succeeded` (`==0`), `-C/--completed` (`!=null`), `-R/--remaining` (`==null`),
+`-X/--cancelled` (`==-1`), `--retries` (`attempt>1`), `--signal NAME`, `-w COND`.
+
+| Assertion | Proves |
+|---|---|
+| `main_lines(['hs','list','-c'])` == `['5']` | 2 base tasks + 3 rows for n:1 (attempts) |
+| `main_lines(['hs','list','-c','-t','n:1'])` == `['3']` | n:1 ran exactly 3 attempts (chain length) |
+| `main_lines(['hs','list','exit_status','-t','n:1','-s','attempt'])` == `['1','...','0']`? see note | per-attempt outcome ordered by attempt |
+| `main_lines(['hs','list','exit_status','-t','n:1','-S'])` == `['0']` | exactly one attempt of n:1 succeeded |
+| `main_lines(['hs','list','attempt','-t','n:1','-S'])` == `['3']` | the success was the 3rd attempt |
+| `main_lines(['hs','list','-c','-t','n:1','-F'])` == `['2']` | 2 failed attempts (matches the 2 "Non-zero exit status" logs) |
+| `main_lines(['hs','list','retried','-t','n:1','-s','attempt'])` first two `true` | failed rows are chained/retired |
+| `main_lines(['hs','list','exit_status','-t','n:2','-S'])` == `['0']` | group-1 task n:2 completed successfully |
+| `main_lines(['hs','list','group','-t','n:2'])` == `['1']` | n:2 is in group 1 (ran after group 0 drained) |
+| `main_lines(['hs','list','-c','-R'])` == `['0']` | nothing left unscheduled/incomplete |
+
+Note: the exact `exit_status` of the two failed attempts is the shell's `[ ... ] && echo`
+exit (1), but assert `!=0` via `-F`/`--failed` rather than a literal to stay robust.
+`-s/--order-by` maps straight to `ORDER BY <col>` (`task.py:504-511`); plain format joins
+fields by tab. Ordering the *group-transition-before-n:2* check can also be recast: n:2's
+`schedule_time` > every group-0 row's `completion_time` (all authoritative timestamps),
+instead of grepping log-line indices.
+
+## Output-content question ("did the 3rd attempt actually emit `1`?")
+
+By default there is **no authoritative record of task stdout content**. With
+`capture=False`, output streams to the shared process fd and **`outpath` stays NULL** (only
+set when capturing — `client.py:757-760`). So "1" exists *only* in the flaky merged buffer.
+
+To make content authoritative, run the cluster with **`--capture`**: each task's stdout goes
+to `<site>/lib/task/<id>.out` and the row's `outpath` is populated (`client.py:757`,
+`task.py:274`). Then verify via `hs info <id> --stdout` (`task.py:196,233` reads `outpath`;
+same-host so no SFTP — `client_host == HOSTNAME`, `task.py:238`). Flow: get the succeeding
+row's id with `hs list id -t n:1 -S`, then `hs info <id> --stdout` == `'1'`. This is the
+only robust way to assert the *content* `1` was produced by the successful attempt.
+(`hs list outpath -t n:1 -S` also confirms the file exists.) If content-proof is
+out of scope, `... -S` giving `exit_status==0` on `attempt==3` already proves the winning
+attempt ran to success — the command's own `[ $TASK_ATTEMPT -eq 3 ]` guard means exit 0 is
+only reachable on attempt 3, i.e. the echo path.
+
+## Exemplar robust assertions in the tree
+
+- `tests/test_cancel.py:43` `assert main_lines(['hs','list','exit_status','-t','n:1'])[1]
+  == ['-1']` and `:99` `... 'attempt','-t','n:2'])[1] == ['1']` (asserts no retry copy).
+- `tests/test_cluster.py:183` `assert main_lines(['hs','list','exit_status','-f','plain',
+  '-s','submit_time']) == (exit_status.success, ['0']*4, NO_OUTPUT)` — status per task from DB.
+- `tests/test_update.py:38-40` `main_lines(['hs','list','exit_status','-t','n:0'])[1] ==
+  ['null']` / `['-15']` / `['0']` — per-tag exit-status probes.
+- Same file already uses `main_lines(['hs','list','-c']) == (success, ['5'], NO_OUTPUT)`
+  (`test_groups.py:146`) — the count check is the one robust assertion it already had.
+
+## Open questions
+
+1. Is `--capture` acceptable in this test (it changes the run path slightly and writes
+   per-task files under `temp_site`)? Needed only if content-of-`1` must be proven.
+2. Does the plan want to keep any stderr log-count assertions (`DEBUG ... Completed task`,
+   `Non-zero exit status` x2, group-transition x1)? Those passed in CI and read from the
+   single-writer log stream, so they are far less flaky than task stdout — reasonable to keep.
+3. With `-r 3`, confirm the intended chain length is 3 rows for n:1 (attempts 1,2,3);
+   `attempts == max_retries + 1` semantics (AGENTS.md) suggest `-r 3` allows up to 4 rows,
+   but the command succeeds on attempt 3 so only 3 are created — assert `<=` if brittle.

--- a/spec/deflake-group-retry-test/research/03-design-intent-history.md
+++ b/spec/deflake-group-retry-test/research/03-design-intent-history.md
@@ -1,0 +1,79 @@
+# Research 03 — Design intent & prior art: is console task-output guaranteed?
+
+## Design intent verdict: console task-output is a CONVENIENCE echo, not a guarantee
+
+The docs are consistent: the **database is the canonical source of truth**; task `stdout`/`stderr`
+is a stream written **directly** to the console fd (or a file via `--capture`/`-o`), with **no
+documented completeness- or ordering guarantee**.
+
+- `docs/getting_started.rst:74-75`: *"By default, all command `stdout` and `stderr` are joined and
+  written out directly. Capture individual task `stdout` and `stderr` with ``--capture``."*
+  ("joined and written out directly" = merged onto one stream, no per-task framing/ordering claim.)
+- `docs/security.rst:70-73`: *"Task ``stdout`` and ``stderr`` do *not* [travel through the queue] —
+  they are written to disk on the client ... and retrieved on demand over SFTP ... when the operator
+  runs ``hs task info --stdout``"* — i.e. the retrievable, authoritative copy is on disk, not the console.
+- `docs/security.rst:334`: *"The database (SQLite or PostgreSQL) is the canonical source of truth"*;
+  `docs/alternatives.rst:45`: *"the database is the source of truth"*.
+- `docs/cli/cluster.rst` / `cluster/__init__.py:105`: `-o, --output PATH  File path for task outputs
+  (default: <stdout>)` — file redirect is the deliberate way to capture reliably; `<stdout>` is the default.
+
+**Mechanism confirms "directly" is literal** (code = ground truth): each task subprocess inherits the
+client's real fd — `client.py:772-773` `Popen(..., stdout=self.redirect_output, stderr=self.redirect_errors ...)`
+where `redirect_output = redirect_output or sys.stdout` (`client.py:671`), and the cluster passes a
+**single** `output_stream = sys.stdout` (`cluster/__init__.py:426`, wired at `:292`) to **all N executor
+threads**. So N concurrent children share one fd (fd 1); Python never buffers/forwards/locks task output.
+Nothing in the design promises every line is captured — the guaranteed copy is the DB row (+ `--capture`
+file). This squarely supports GOAL R1 (assert on authoritative task state, not scraped stdout).
+
+## History findings
+
+- **Test origin:** `0844bf1` (2025-12-23) `[feature] Add task groups for dependency management` added
+  `tests/test_groups.py` **including `test_group_failed_task_with_retries`**. `git blame -L 115,147`
+  shows the test body is **unchanged since `0844bf1`** — never touched for flakiness/timing.
+- Only later touches to the file: `655c7f2` (copyright years) and `b27ee58` (#50 re-submission gating —
+  added `--restart`-based tests; retry test untouched).
+- **No prior flaky/output-loss work exists.** `git log --grep`: `flak` → only `1044b22` (this goal);
+  `timing`/`intermittent`/`buffer`/`stdout`(re tests) → **none**. `flush` → `ed9b34d` `[fix] Ensure tasks
+  are flushed for queue-only submission before shutdown` (submit-side, unrelated to task stdout). `race`
+  hits are harness/broken-pipe, not this.
+- **Console-echo path is NOT a recent regression.** Churn on the `Popen(stdout=...)` / `redirect_output`
+  path: `415d21f` (resource tracking), `a6a613d` (task-level capture), `523e4f9` (Add IO redirects),
+  `2ede301` (full rewrite) — all predate task groups; the redirect model is old and stable. The separate
+  `server.py:465` `print(task.args, file=self.redirect_failures)` is the **failed-task-args** echo (not
+  task stdout), last touched `e629a90`. Nothing recent explains new flakiness → points to runner load,
+  not a code change.
+
+## CI invocation
+
+- `.github/workflows/tests.yml`: `runs-on: ubuntu-latest`, `timeout-minutes: 20`, `fail-fast: false`,
+  **matrix Python `3.11 3.12 3.13 3.14`**.
+- Command: **`uv run --python ${{ matrix.python-version }} pytest -v`** — **no `-n auto` / no pytest-xdist**,
+  no `--forked`, no rerun plugin. Pytest runs **serially**; the "load" is the **constrained 2-core hosted
+  runner itself**, not xdist. Each integration test still spins a full cluster (server + client + N executor
+  threads + subprocesses), so intra-test concurrency is where the loss surfaces. Matches GOAL evidence
+  (failed on both 3.11 and 3.14 → runner load, not a version bug).
+
+## Other fragile tests (blast radius — R-noted, mostly non-goals)
+
+Same latent stdout-scraping assumption (`assert sorted(stdout...) == [...]`):
+- `tests/test_groups.py:39, 61, 82, 143, 186, 224, 287` — every group test scrapes cluster stdout.
+- `tests/test_groups.py:167` `assert '2' not in stdout` (inverse scrape; asserts absence, lower risk).
+- `tests/test_cluster.py:248, 257` — `sorted(stdout...) == range(1,9)` / `{0,1,2,3}`.
+- `tests/test_restart.py:35, 54, 102, 118, 157` — `sorted(stdout...) == [...]`.
+- `tests/test_submit_json.py:275, 358` — `sorted(stdout.splitlines()) == [...]`.
+- `tests/test_cancel.py:68, 93` — `'RUN_2' not in stdout` (absence assertion).
+
+Wall-clock / log-index timing (GOAL explicit non-goals):
+- `tests/test_groups.py:292` `assert elapsed > 4 + 3*2` (>10s) — lower-bound, robust direction on slow runners.
+- `tests/test_groups.py:137-139` — the repair target's own `group_idx < n2_idx` raw-log-line-index compare
+  (secondary fragility; **passed** in the failing run per GOAL, but R3 wants a load-robust signal).
+
+## Open questions
+
+1. Where exactly is `"1"` lost — the shared-fd child write (client), or the test harness `main()` capture
+   of the subprocess/pipe? (Research 01/02 territory; design says the DB row is authoritative regardless.)
+2. Under R4, is a real fix even warranted, or is "directly to fd, best-effort" the documented contract and
+   the test the only thing to change? Docs support the latter (console echo is never promised complete).
+3. If a product fix is pursued, would it touch the shared-`sys.stdout`-across-N-executors design
+   (`cluster/__init__.py:292,426`) — which the GOAL marks as out-of-scope beyond the minimum for a
+   *confirmed* defect?

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -123,27 +123,42 @@ def test_group_failed_task_with_retries(temp_site: Path) -> None:
     ]
 
     taskfile = create_taskfile(temp_site, tasks)
-    rc, stdout, stderr = main(['hs', 'cluster', str(taskfile), '-r', '3'])
+    # Task stdout is deliberately ignored: it is a best-effort concurrent echo to the shared
+    # console fd, so a line can be dropped or reordered under load. The database is the source
+    # of truth, so correctness is asserted from authoritative task state (via `hs list`) below.
+    rc, _, stderr = main(['hs', 'cluster', str(taskfile), '-r', '3'])
     assert rc == exit_status.success
     logs = stderr.strip().splitlines()
-    
-    # Task n:1 should fail the first 2 times
+
+    # Task n:1 fails its first two attempts. The log stream is single-writer (serialized), so
+    # unlike task stdout its line counts are reliable under load.
     assert_output(r'Non-zero exit status', stderr, 2)
-    
-    # Group should transition after retries
+
+    # Group 0 transitions to group 1 exactly once, only after n:1's retries complete.
     assert_output(r'Completed task group 0 - starting task group 1', stderr, 1)
+
+    # Ordering: the group transition is logged before group 1's task (n:2) completes.
     rc, stdout_2, _ = main(['hs', 'list', 'id', '-t', 'n:2'])
     n2_id = stdout_2.strip()
     n2_idx, *_ = [i for i, line in enumerate(logs) if f'Completed task ({n2_id})' in line]
     group_idx, *_ = [i for i, line in enumerate(logs) if 'Completed task group 0 - starting task group 1' in line]
     assert group_idx < n2_idx
 
-    
-    # Task n:2 should still complete
-    assert sorted(stdout.strip().splitlines()) == list(map(str, range(len(tasks))))
+    # Five rows exist: n:0, the three-row retry chain for n:1, and n:2. Retries copy the parent's
+    # tag, so `-t n:1` matches the whole chain.
+    assert main_lines(['hs', 'list', '-c']) == (exit_status.success, ['5'], NO_OUTPUT)
+    assert main_lines(['hs', 'list', '-c', '-t', 'n:1']) == (exit_status.success, ['3'], NO_OUTPUT)
+    assert main_lines(['hs', 'list', '-c', '-t', 'n:1', '-F']) == (exit_status.success, ['2'], NO_OUTPUT)
 
-    # There should be 5 total tasks after 2 retries on n:1
-    assert main_lines(['hs', 'list', '-c']) == (exit_status.success, ['5', ], NO_OUTPUT)
+    # n:1 terminally succeeded on its 3rd attempt. `[ $TASK_ATTEMPT -eq 3 ] && echo 1` can only
+    # exit 0 when `echo 1` runs, so a successful attempt 3 proves the output was produced.
+    assert main_lines(['hs', 'list', 'exit_status', '-t', 'n:1', '-S']) == (exit_status.success, ['0'], NO_OUTPUT)
+    assert main_lines(['hs', 'list', 'attempt', '-t', 'n:1', '-S']) == (exit_status.success, ['3'], NO_OUTPUT)
+
+    # n:2 ran in group 1 and succeeded; nothing is left incomplete.
+    assert main_lines(['hs', 'list', 'exit_status', '-t', 'n:2', '-S']) == (exit_status.success, ['0'], NO_OUTPUT)
+    assert main_lines(['hs', 'list', 'group', '-t', 'n:2']) == (exit_status.success, ['1'], NO_OUTPUT)
+    assert main_lines(['hs', 'list', '-c', '-R']) == (exit_status.success, ['0'], NO_OUTPUT)
 
 
 @mark.integration


### PR DESCRIPTION
## Summary

Rebuilds the flaky integration test `tests/test_groups.py::test_group_failed_task_with_retries` to
assert the group-based-retry contract from **authoritative task state** (`hs list` over the database)
instead of scraping the cluster process's merged stdout.

The test flaked in CI (PR #52 failed it on Python 3.11, not just 3.14) but never locally. First-principles
diagnosis — a three-way read-only research fan-out over the output path, the test harness, and the design
intent/history — converged independently on **no product defect**: a task's console stdout is a
best-effort concurrent echo to the shared console fd (`Popen(stdout=sys.stdout)`, no relay/buffer/store),
so a line can be dropped or reordered under runner load while the **database stays canonical** for task
state. The proximate CI failure was exactly this — task `n:1`'s `"1"` missing from captured stdout even
though the task provably succeeded. GOAL **R4**'s antecedent (a genuine output-loss product defect) is
therefore **unmet**, so this change is **test-only — no `src/` change**.

The rebuilt test keeps every robust signal (serialized single-writer stderr counts, the group-transition
message, the ordering proof) and adds authoritative DB oracles that prove the retried task failed twice,
then succeeded on attempt 3 (`[ $TASK_ATTEMPT -eq 3 ] && echo 1`), gating the group transition — without
ever scraping stdout.

## Goal

[`spec/deflake-group-retry-test/GOAL.md`](https://github.com/hypershell/hypershell/blob/d074c0da924d53fb21e6f4d575b1ca646a171a59/spec/deflake-group-retry-test/GOAL.md) — the locked contract (R1–R6).

## Design

[`spec/deflake-group-retry-test/PLAN.md`](https://github.com/hypershell/hypershell/blob/d074c0da924d53fb21e6f4d575b1ca646a171a59/spec/deflake-group-retry-test/PLAN.md) (historical design record). Authoritative FSM: [`TECH.md`](https://github.com/hypershell/hypershell/blob/d074c0da924d53fb21e6f4d575b1ca646a171a59/spec/deflake-group-retry-test/TECH.md).

## Research (historical)

- [`00-digest.md`](https://github.com/hypershell/hypershell/blob/d074c0da924d53fb21e6f4d575b1ca646a171a59/spec/deflake-group-retry-test/research/00-digest.md)
- [`01-output-path.md`](https://github.com/hypershell/hypershell/blob/d074c0da924d53fb21e6f4d575b1ca646a171a59/spec/deflake-group-retry-test/research/01-output-path.md)
- [`02-test-harness.md`](https://github.com/hypershell/hypershell/blob/d074c0da924d53fb21e6f4d575b1ca646a171a59/spec/deflake-group-retry-test/research/02-test-harness.md)
- [`03-design-intent-history.md`](https://github.com/hypershell/hypershell/blob/d074c0da924d53fb21e6f4d575b1ca646a171a59/spec/deflake-group-retry-test/research/03-design-intent-history.md)

## Phases completed

| Phase | Name | Satisfies |
|-------|------|-----------|
| P1 | Rebuild the test on authoritative DB state | R1, R2, R3, R4, R5, R6 |

## Verification

Blind adversarial review ([`REVIEW.md`](https://github.com/hypershell/hypershell/blob/d074c0da924d53fb21e6f4d575b1ca646a171a59/spec/deflake-group-retry-test/REVIEW.md)) returned a **clean pass** — 0 findings, no scope creep, no
high-blast-radius core touched.

- `for i in $(seq 1 15); do uv run pytest -q tests/test_groups.py::test_group_failed_task_with_retries; done` → green (reviewer 10/10, orchestrator sanity 8/8).
- `uv run pytest -q tests/test_groups.py` → 11 passed.
- Requirement matrix R1/R2/R3/R5 verified by executed command; R4 is a correct no-op (antecedent unmet, confirmed by source read of `client.py` output path).
- **R6 is CI-bound by design** — the flake is not locally reproducible, so the true acceptance gate is a
  green `tests` job across Python 3.11–3.14 on **this PR's** CI.

## Docs & completions

N/A — test-only change, no CLI/behavior change, so the same-commit `docs/_include/*.rst` + `share/`
completions rule is not triggered.

## 🔧 Harness feedback

Toolchain notes from the factory self-improvement loop (process-only; applied later via `/hs-harness`):

- **What worked well** — the `hs-plan` parallel read-only research fan-out (output-path / test-harness /
  design-intent) converged cleanly and independently on the "no product defect" verdict, with no overlap
  and no gap — exactly the confidence a diagnosis-gated fix needs.
- **F1 · medium · steering** — `hs-plan`'s `kind: fix` research-skip rule misfires for *diagnostic* fixes:
  the gate keys on `kind`/`appetite`, but the real question is *is the root cause known?* This GOAL
  explicitly demanded first-principles diagnosis, so the fan-out had to be run against the rule.
- **F2 · low · tooling** — `temp_site.sh` isolates env but never `cd`s into the site, so a relative file
  write in a verify/cross-check command escapes into the working tree (swept up by `hs-build`'s
  `git add -A`).

## Context

- Failing CI job: PR #52, "tests (3.11)". This PR targets `develop`; `spec/deflake-group-retry-test/` is
  retained as the dated design record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
