### PR TITLE
[fix] Make log-lock sidecars ephemeral; harden fork fd-leak and lockless-FS fallback

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -289,6 +289,23 @@ If you set an explicit ``path`` it is honored verbatim, with one exception: for 
 ``client`` role — which is launched en masse across a cluster — the hostname is appended so
 the mass-launched clients still never share a file.
 
+Each active slot is guarded by an adjacent ``<file>.lock`` *sidecar*. The sidecar carries the
+owning process's identity — its process id, start time, short hostname, and run instance —
+written while the advisory lock is held, so any later process can tell whether a *live* process
+still holds the slot. Sidecars are ephemeral: a process removes its own on a clean exit, and the
+next process to win the canonical slot sweeps any left behind by a crash — removing only the
+``.lock`` file, **never** any ``.log`` data. A lock file lingering without a live owner is
+therefore harmless and self-healing, not a sign that anything is wrong. (The non-distributed
+``main`` role is never host-scoped and never pruned.)
+
+The numbered ``<role>-<host>-2.log``, ``-3``, … files produced by *genuinely concurrent*
+same-host processes are legitimate per-rank output and are **never** deleted, truncated, or
+merged — one client per rank (e.g. under ``srun`` with one client per GPU) is expected, not a
+fault. Relatedly, revisiting a host at a *lower* concurrency than a previous run can leave an
+earlier rank's rotated or compressed files (e.g. ``client-<host>-3.20260101.log.gz``) with no
+active writer; these dangling rotated leaves are legitimate and are left untouched — remove them
+yourself if you no longer need them.
+
 |
 
 Parameters

--- a/spec/logging-file-slot-reclaim/GOAL.md
+++ b/spec/logging-file-slot-reclaim/GOAL.md
@@ -1,0 +1,108 @@
+# GOAL — Reclaim per-host log-file slots on shared HPC filesystems
+
+> **Origin spec.** The *what* and *why* — the locked contract `hs-review` grades against.
+> The *how* lives in [`PLAN.md`](PLAN.md) and [`TECH.md`](TECH.md) (written by `hs-plan`).
+> Keep this at the right altitude: solved and bounded, but not over-specified — leave design
+> freedom for the plan. Edit requirements here; do **not** silently drift them during build.
+
+- **slug:** logging-file-slot-reclaim
+- **kind:** fix
+- **appetite:** small
+
+## Problem
+
+HyperShell's file-based logging gives long-running / distributed roles (`server`, `client`,
+`cluster`, `submit`) a **per-host** log file — a client on host `a123.cluster.edu` logs to
+`client-a123.log` — and enforces a single-writer invariant with an advisory `flock` on a
+per-file `.lock` sidecar. When a slot is contended, the process falls through to
+`client-a123-2.log`, `client-a123-3.log`, …, so the file count is meant to be bounded by *peak
+concurrency on a host*, not by the *total number of processes ever launched* (which matters
+under autoscaling, where a host cycles through many short-lived client generations).
+
+In real-world use on our Gautschi HPC cluster this is not what happens. On both `/home` (ZFS)
+and `/scratch` (Lustre), the canonical per-host path is **never reclaimed**: successive client
+generations keep falling through to fresh `-N` slots, and the `.lock` sidecars and `-N.log`
+files **proliferate without bound** — exactly the "one file per process ever launched" failure
+the slot scheme was designed to prevent. The lock is either never released or never seen as
+released across the network filesystem. It is not yet confirmed whether this reproduces on a
+local filesystem; the code comment's assumption that "same-host advisory locks are reliable
+even on shared network filesystems" is the prime suspect (Lustre commonly needs an explicit
+`flock` mount option; without it `flock` may error or be node-local, and `_try_lock` treats a
+lock **error** identically to a lock **conflict**, forcing every process onto a new slot).
+
+The concrete pain: an autoscaling client fleet running for hours or days silently fills the log
+directory with thousands of near-empty `client-<host>-<N>.log` and `.lock` files, on precisely
+the shared filesystems (ZFS/Lustre) HPC users are told to use.
+
+## Outcome / vision
+
+On the filesystems HyperShell actually runs on in production — including Lustre and ZFS — the
+per-host log-slot scheme behaves as designed: a freed canonical per-host path is **reclaimed**
+by the next generation, so a host that runs one client at a time trends toward **a single log
+file per host** rather than an ever-growing pile. The file count stays bounded by real
+concurrency, not by cumulative launches. The root cause is understood and documented (not just
+patched), and the artifacts that have already accumulated (orphaned `.lock` sidecars and stale
+`-N.log` slots whose owning process is gone) are reaped. The single-writer safety intent is
+preserved to whatever degree the underlying filesystem permits, with the trade-off made
+deliberately rather than by accident.
+
+## Acceptance criteria (the contract)
+
+- **R1** — The investigation SHALL identify and document (in `TECH.md`) the root cause of
+  non-reclamation and unbounded proliferation on Lustre and ZFS, including whether it
+  reproduces on a local POSIX filesystem, before a fix is committed.
+- **R2** — WHEN a client process starts on a host and no live process holds the canonical
+  per-host log path, the logging subsystem SHALL reclaim that canonical path (e.g.
+  `client-<host>.log`) rather than falling through to a new `-N` slot.
+- **R3** — WHEN a canonical per-host path is reclaimed under R2, the logging subsystem SHALL
+  **append** to the existing file, preserving prior generations' log history (subject to normal
+  rotation), and SHALL NOT truncate it.
+- **R4** — WHILE multiple client generations are launched serially on one host over time (the
+  autoscaling case), the number of `*.log` and `*.lock` files for that host SHALL remain
+  bounded by peak concurrent processes on the host, NOT by the cumulative count of processes
+  ever launched.
+- **R5** — IF advisory locking is unavailable or unreliable on the target filesystem, THEN the
+  logging subsystem SHALL still keep the per-host file count bounded (it SHALL NOT degenerate to
+  one file per process). *The specific mechanism — graceful degradation to a reused per-host
+  path vs. a bounded, self-reaping distinct-file scheme — is deferred to `/hs-plan` once the
+  root cause is confirmed.*
+- **R6** — The fix SHALL reap orphaned artifacts: stale `.lock` sidecars and `-N.log` slots
+  whose owning process is no longer alive SHALL be reclaimable/removable rather than reserved
+  forever.
+- **R7** — The single-writer intent SHALL be honored wherever the filesystem supports it: two
+  genuinely concurrent same-host processes SHALL NOT silently corrupt each other's log via
+  interleaved writes on a filesystem where locking works.
+- **R8** — The change SHALL NOT regress the cross-host safety property (distinct hosts keep
+  distinct files via the baked-in hostname) nor the non-distributed `main`-role default, and
+  SHALL preserve the existing Windows (`msvcrt`) and no-locking (`_LOCKING = False`) fallbacks.
+
+## Non-goals (no-gos)
+
+- Redesigning the logging architecture beyond the per-host file-slot / lock scheme (no new log
+  backends, no change to the queue-based handler, rotation policy, or log formats).
+- Changing the role model (`DISTRIBUTED_ROLES`, `role_from_command`, `main`-role sharing) or the
+  choice to bake the short hostname into the filename.
+- Fixing HPC filesystem mount configuration (e.g. mandating a Lustre `flock` mount option) —
+  HyperShell must behave acceptably regardless, but we do not own the site's mount options.
+- A background reaper daemon or cross-run garbage-collection service; orphan reaping (R6) is
+  expected to happen opportunistically at slot-claim time, not as a separate long-lived process.
+- Distributed coordination of a shared log across hosts (each host remains independent).
+
+## Clarifications
+
+- **Q:** On reclaiming a freed canonical per-host path, append or truncate? — **A:** Append,
+  preserving history (rotation still bounds size) (resolved 2026-07-23).
+- **Q:** When advisory locking is unsupported/unreliable on the filesystem, degrade to a reused
+  per-host path (accepting possible interleave) or preserve strict single-writer with bounded
+  distinct files? — **A:** Require only that proliferation stays bounded (R5); defer the
+  mechanism choice to `/hs-plan` after the root cause is confirmed (resolved 2026-07-23).
+- **Q:** Reap already-accumulated orphaned `.lock` and `-N.log` files as part of this fix? —
+  **A:** Yes, in scope (R6) (resolved 2026-07-23).
+
+## Related materials
+
+- Source: `src/hypershell/core/logging.py` — `claim_file_slot`, `_try_lock`, `resolve_log_path`,
+  `default_file_for`, `role_from_command` (~lines 640–723); `FILE_LOCK` rotation lock (~line 355).
+- Observed on: Gautschi HPC cluster — `/home` (ZFS), `/scratch` (Lustre).
+- Context: autoscaling client fleets (`cluster/remote.py` `AutoScalingCluster`) cycle many
+  short-lived client generations per host — the workload that makes non-reclamation visible.

--- a/spec/logging-file-slot-reclaim/GOAL.md
+++ b/spec/logging-file-slot-reclaim/GOAL.md
@@ -1,4 +1,4 @@
-# GOAL — Reclaim per-host log-file slots on shared HPC filesystems
+# GOAL — Ephemeral log-lock sidecars + hardening (per-host log-file hygiene)
 
 > **Origin spec.** The *what* and *why* — the locked contract `hs-review` grades against.
 > The *how* lives in [`PLAN.md`](PLAN.md) and [`TECH.md`](TECH.md) (written by `hs-plan`).
@@ -7,102 +7,119 @@
 
 - **slug:** logging-file-slot-reclaim
 - **kind:** fix
-- **appetite:** small
+- **appetite:** small (→ small-medium)
+
+> **Re-scoped 2026-07-23 after investigation.** The original premise — "the per-host log-slot
+> scheme never reclaims the canonical path on Lustre/ZFS and proliferates files without bound" —
+> was **refuted by ground-truth evidence**. `flock` acquire, conflict-detection, and
+> **reclaim+append all work** on both Lustre and ZFS; the `client-<host>-N.log` files the
+> maintainer saw were **legitimate concurrent clients** (one per rank under
+> `--launcher=srun`, e.g. one client per GPU), plus a `SIGINT`/`SIGTERM` quirk in an external
+> management script that was unknowingly overlapping client generations. See
+> [`research/09-revised-design.md`](research/09-revised-design.md) (supersedes
+> [`research/00-digest.md`](research/00-digest.md)). This GOAL now targets the *real* residual
+> issues that the investigation surfaced.
 
 ## Problem
 
-HyperShell's file-based logging gives long-running / distributed roles (`server`, `client`,
-`cluster`, `submit`) a **per-host** log file — a client on host `a123.cluster.edu` logs to
-`client-a123.log` — and enforces a single-writer invariant with an advisory `flock` on a
-per-file `.lock` sidecar. When a slot is contended, the process falls through to
-`client-a123-2.log`, `client-a123-3.log`, …, so the file count is meant to be bounded by *peak
-concurrency on a host*, not by the *total number of processes ever launched* (which matters
-under autoscaling, where a host cycles through many short-lived client generations).
+Per-host file logging works as designed: distributed roles get `<role>-<host>.log`, a single
+writer is enforced by an advisory `flock` on a `<path>.lock` sidecar, and concurrent same-host
+clients correctly fall through to `-2.log`, `-3.log`, … (bounded by peak concurrency). Three real
+issues remain, none of which is a reclaim bug:
 
-In real-world use on our Gautschi HPC cluster this is not what happens. On both `/home` (ZFS)
-and `/scratch` (Lustre), the canonical per-host path is **never reclaimed**: successive client
-generations keep falling through to fresh `-N` slots, and the `.lock` sidecars and `-N.log`
-files **proliferate without bound** — exactly the "one file per process ever launched" failure
-the slot scheme was designed to prevent. The lock is either never released or never seen as
-released across the network filesystem. It is not yet confirmed whether this reproduces on a
-local filesystem; the code comment's assumption that "same-host advisory locks are reliable
-even on shared network filesystems" is the prime suspect (Lustre commonly needs an explicit
-`flock` mount option; without it `flock` may error or be node-local, and `_try_lock` treats a
-lock **error** identically to a lock **conflict**, forcing every process onto a new slot).
-
-The concrete pain: an autoscaling client fleet running for hours or days silently fills the log
-directory with thousands of near-empty `client-<host>-<N>.log` and `.lock` files, on precisely
-the shared filesystems (ZFS/Lustre) HPC users are told to use.
+1. **The `.lock` sidecars are permanent and alarming.** They are 0-byte, carry no owner
+   information, and are never removed — so a log directory accumulates `.lock` files that look
+   like something is wrong and give no way to tell whether a *live* process actually holds a
+   slot. Operators expect a lock file to be ephemeral: present while the owner runs, gone when it
+   stops.
+2. **A latent fd-inheritance lock leak for `server`/`cluster` roles.** `initialize_logging()`
+   runs before any process creation, so the flock'd sidecar descriptor is open when
+   `BaseManager.start()` (`core/queue.py`) forks the queue-manager child on Linux's default
+   `fork` start method. The child inherits and *shares* that lock's open-file-description, so a
+   `SIGKILL`/OOM'd parent can leave the slot **ghost-locked** until the child also dies. (Clients
+   never fork a manager, so client slots are unaffected — consistent with the evidence.)
+3. **A latent proliferation bug on a genuinely lockless filesystem.** `_try_lock` treats *every*
+   `OSError` as contention, and both the no-locking and exhausted-slots branches fall back to a
+   per-PID path (`<root>-<pid>.log`) — i.e. one file per process. On a filesystem that truly does
+   not support `flock` (e.g. Lustre actually mounted `noflock`), this would proliferate. Not the
+   maintainer's current symptom, but a real footgun to close while we are here.
 
 ## Outcome / vision
 
-On the filesystems HyperShell actually runs on in production — including Lustre and ZFS — the
-per-host log-slot scheme behaves as designed: a freed canonical per-host path is **reclaimed**
-by the next generation, so a host that runs one client at a time trends toward **a single log
-file per host** rather than an ever-growing pile. The file count stays bounded by real
-concurrency, not by cumulative launches. The root cause is understood and documented (not just
-patched), and the artifacts that have already accumulated (orphaned `.lock` sidecars and stale
-`-N.log` slots whose owning process is gone) are reaped. The single-writer safety intent is
-preserved to whatever degree the underlying filesystem permits, with the trade-off made
-deliberately rather than by accident.
+Lock sidecars behave like well-mannered PID/socket files: created while a client runs, carrying
+the owner's identity, and removed when the client stops (best-effort on clean exit; swept on the
+next start for crashes). No accumulation across clean restarts, and an operator can always tell
+whether a real live process holds a slot. The `server`/`cluster` fd-leak is closed so a killed
+parent never ghost-locks its slot. On a lockless filesystem the file count stays bounded instead
+of growing per-process. Throughout, the behaviors that already work — reclaim+append on a healthy
+FS, distinct files for genuinely-concurrent same-host clients, cross-host isolation — are
+**preserved and regression-tested**, and legitimate `-N.log` data is **never** deleted or merged.
 
 ## Acceptance criteria (the contract)
 
-- **R1** — The investigation SHALL identify and document (in `TECH.md`) the root cause of
-  non-reclamation and unbounded proliferation on Lustre and ZFS, including whether it
-  reproduces on a local POSIX filesystem, before a fix is committed.
-- **R2** — WHEN a client process starts on a host and no live process holds the canonical
-  per-host log path, the logging subsystem SHALL reclaim that canonical path (e.g.
-  `client-<host>.log`) rather than falling through to a new `-N` slot.
-- **R3** — WHEN a canonical per-host path is reclaimed under R2, the logging subsystem SHALL
-  **append** to the existing file, preserving prior generations' log history (subject to normal
-  rotation), and SHALL NOT truncate it.
-- **R4** — WHILE multiple client generations are launched serially on one host over time (the
-  autoscaling case), the number of `*.log` and `*.lock` files for that host SHALL remain
-  bounded by peak concurrent processes on the host, NOT by the cumulative count of processes
-  ever launched.
-- **R5** — IF advisory locking is unavailable or unreliable on the target filesystem, THEN the
-  logging subsystem SHALL still keep the per-host file count bounded (it SHALL NOT degenerate to
-  one file per process). *The specific mechanism — graceful degradation to a reused per-host
-  path vs. a bounded, self-reaping distinct-file scheme — is deferred to `/hs-plan` once the
-  root cause is confirmed.*
-- **R6** — The fix SHALL reap orphaned artifacts: stale `.lock` sidecars and `-N.log` slots
-  whose owning process is no longer alive SHALL be reclaimable/removable rather than reserved
-  forever.
-- **R7** — The single-writer intent SHALL be honored wherever the filesystem supports it: two
-  genuinely concurrent same-host processes SHALL NOT silently corrupt each other's log via
-  interleaved writes on a filesystem where locking works.
-- **R8** — The change SHALL NOT regress the cross-host safety property (distinct hosts keep
-  distinct files via the baked-in hostname) nor the non-distributed `main`-role default, and
-  SHALL preserve the existing Windows (`msvcrt`) and no-locking (`_LOCKING = False`) fallbacks.
+- **R1** — The investigation finding SHALL be recorded (retained `research/`): the observed
+  proliferation was legitimate same-host concurrency, not a reclaim/lock failure, and reclaim+
+  append already works on Lustre and ZFS. Regression tests SHALL codify that correct behavior.
+- **R2** — Each per-host lock sidecar SHALL carry its owner's identity (process id + process
+  start-time + short hostname + app instance), written by the owner **while holding the advisory
+  lock**, so any later process can determine whether a *live* process holds the slot (start-time
+  defeats PID reuse; the baked-in hostname guarantees the PID is local and checkable).
+- **R3** — WHEN a process shuts down cleanly, it SHALL remove its own lock sidecar(s) on a
+  best-effort basis — after its file logging has stopped and **while still holding the lock** —
+  so sidecars do not accumulate across clean restarts.
+- **R4** — WHEN a process starts and resolves its log slot, it SHALL prune stale sibling lock
+  sidecars (those with no live holder), **acquiring each sidecar's lock before removing it**, and
+  SHALL NOT remove a sidecar that a live process holds.
+- **R5** — The system SHALL NEVER delete, truncate, or rewrite `-N.log` data files or their
+  rotated/compressed lineage. Concurrent-rank logs are legitimate output.
+- **R6** — IF a distributed role forks a queue-manager child (`server`/`cluster`), THEN the
+  inherited log-slot lock descriptor SHALL be closed in the child, so the lock releases when the
+  true owner exits (no ghost lock from a killed parent).
+- **R7** — WHEN acquiring a slot lock fails, the system SHALL advance to the next `-N` slot ONLY
+  on genuine contention (`EAGAIN`/`EWOULDBLOCK`); IF advisory locking is unavailable (any other
+  lock error, or no locking support), THEN it SHALL reuse the canonical per-host path (append)
+  rather than a per-PID path, keeping the file count bounded.
+- **R8** — The change SHALL preserve existing correct behavior: canonical reclaim+append on a
+  healthy filesystem, cross-host file isolation (hostname in filename), the non-distributed
+  `main` role, and the Windows (`msvcrt`) and no-locking fallbacks. The safety invariant **"only
+  unlink a sidecar while holding its lock"** SHALL hold everywhere (no inode-reuse races).
+- **R9** — The file-based-logging documentation SHALL note that (a) per-host `-N.log` files are
+  expected under legitimate same-host concurrency, (b) sidecars are ephemeral and carry owner
+  identity, and (c) revisiting a host at lower concurrency can leave earlier ranks' rotated
+  leaves dangling — which is legitimate.
 
 ## Non-goals (no-gos)
 
-- Redesigning the logging architecture beyond the per-host file-slot / lock scheme (no new log
-  backends, no change to the queue-based handler, rotation policy, or log formats).
-- Changing the role model (`DISTRIBUTED_ROLES`, `role_from_command`, `main`-role sharing) or the
-  choice to bake the short hostname into the filename.
-- Fixing HPC filesystem mount configuration (e.g. mandating a Lustre `flock` mount option) —
-  HyperShell must behave acceptably regardless, but we do not own the site's mount options.
-- A background reaper daemon or cross-run garbage-collection service; orphan reaping (R6) is
-  expected to happen opportunistically at slot-claim time, not as a separate long-lived process.
-- Distributed coordination of a shared log across hosts (each host remains independent).
+- **Deleting, merging, or concatenating `-N.log` data** (explicitly rejected — legitimate logs).
+- **Single-file-per-host** logging (one shared appending file for all same-host clients):
+  correctness-breaking with rotation (`FILE_LOCK` is process-local → compress-under-writer data
+  loss), risks torn lines on Lustre, and violates single-writer.
+- **A PID-record "override a held `flock` to force reclaim" mechanism** — unnecessary; reclaim
+  already works. The PID record is for liveness/diagnostics and safe pruning only.
+- Fixing the external box-manager `SIGINT`/`SIGTERM` behavior that overlaps client generations
+  (separate work the maintainer will do later).
+- Cross-process rotation coordination; a new config knob; changing the role model or the
+  hostname-in-filename scheme.
 
 ## Clarifications
 
-- **Q:** On reclaiming a freed canonical per-host path, append or truncate? — **A:** Append,
-  preserving history (rotation still bounds size) (resolved 2026-07-23).
-- **Q:** When advisory locking is unsupported/unreliable on the filesystem, degrade to a reused
-  per-host path (accepting possible interleave) or preserve strict single-writer with bounded
-  distinct files? — **A:** Require only that proliferation stays bounded (R5); defer the
-  mechanism choice to `/hs-plan` after the root cause is confirmed (resolved 2026-07-23).
-- **Q:** Reap already-accumulated orphaned `.lock` and `-N.log` files as part of this fix? —
-  **A:** Yes, in scope (R6) (resolved 2026-07-23).
+- **Q:** Is the observed `-N.log` proliferation a reclaim bug? — **A:** No; it is legitimate
+  same-host concurrency (confirmed by log-timestamp forensics + a ZFS restart-reclaim test);
+  reclaim+append works on both filesystems (resolved 2026-07-23).
+- **Q:** Delete `-N.log` orphans on reap? — **A:** No — never delete legitimate rank logs; the
+  reap target is the `.lock` sidecar only (resolved 2026-07-23).
+- **Q:** How to handle leftover `.lock` sidecars? — **A:** Ephemeral lifecycle: best-effort
+  unlink at clean shutdown + flock-guarded prune at startup, with a PID+timestamp record
+  (resolved 2026-07-23).
+- **Q:** Fold in the latent errno/lockless-FS cleanup now? — **A:** Yes (R7) (resolved
+  2026-07-23).
 
 ## Related materials
 
-- Source: `src/hypershell/core/logging.py` — `claim_file_slot`, `_try_lock`, `resolve_log_path`,
-  `default_file_for`, `role_from_command` (~lines 640–723); `FILE_LOCK` rotation lock (~line 355).
-- Observed on: Gautschi HPC cluster — `/home` (ZFS), `/scratch` (Lustre).
-- Context: autoscaling client fleets (`cluster/remote.py` `AutoScalingCluster`) cycle many
-  short-lived client generations per host — the workload that makes non-reclamation visible.
+- Source: `src/hypershell/core/logging.py` (`_try_lock`, `claim_file_slot`, `resolve_log_path`,
+  `_slot_locks`, `initialize_logging`, rotation/compression machinery) and `src/hypershell/core/
+  queue.py` (`SecureManager`/`BaseManager.start()` fork seam, ~`:243-281`,`:385`).
+- Observed on: Gautschi HPC — `/scratch` (Lustre), `/home` (ZFS); autoscaling + `--launcher=srun`
+  one-client-per-GPU.
+- Investigation: [`research/04`](research/04-evidence-forensics.md)–[`research/11`](research/11-stress-reap.md);
+  synthesis [`research/09-revised-design.md`](research/09-revised-design.md).

--- a/spec/logging-file-slot-reclaim/PLAN.md
+++ b/spec/logging-file-slot-reclaim/PLAN.md
@@ -1,170 +1,169 @@
-# PLAN — Reclaim per-host log-file slots on shared HPC filesystems
+# PLAN — Ephemeral log-lock sidecars + hardening
 
-> **Status:** Draft for review · **Last updated:** 2026-07-23
+> **Status:** Draft for review · **Last updated:** 2026-07-23 (re-scoped)
 > **Authoritative technical design.** The *how*. Vision/contract is [`GOAL.md`](GOAL.md);
-> the phased executable roadmap is [`TECH.md`](TECH.md). Backing detail is in
-> [`research/`](research/). Every design element traces to a GOAL R-ID.
+> the phased executable roadmap is [`TECH.md`](TECH.md). Backing detail in [`research/`](research/)
+> — synthesis [`09-revised-design.md`](research/09-revised-design.md) supersedes the original
+> diagnosis in [`00-digest.md`](research/00-digest.md). Every design element traces to a GOAL R-ID.
 
 ## 1. Summary
 
-The proliferation is a single defect: `_try_lock` collapses *every* `flock` `OSError` into
-"slot contended," so on filesystems where advisory locking is unavailable (Lustre default
-`noflock` → `ENOSYS`; NFS-exported ZFS with flaky NLM → `ENOLCK`) each process generation walks
-past the canonical per-host log and manufactures a new file. The fix — entirely within
-`src/hypershell/core/logging.py`, no new config knob — teaches `_try_lock` to **distinguish a
-genuine conflict (`EAGAIN`/`EWOULDBLOCK`) from an unavailable lock**, **degrades to the reused
-canonical per-host path** (append) when locking is unavailable, and **opportunistically reaps
-orphaned `-N.log` slots**. On filesystems where `flock` works, reclaim-and-append *already*
-works (`mode='a'` + OS lock release on exit), so R7's strict single-writer is preserved
-untouched there. Small appetite: three coupled, coherent phases in one module + tests.
+Investigation refuted the original "never-reclaims / ENOSYS-exhaustion" diagnosis: `flock`
+acquire, conflict-detection, and reclaim+append all work on Lustre and ZFS, and the `-N.log`
+files were legitimate concurrent ranks. This plan therefore targets the *real* residual issues:
+make the `.lock` sidecars **ephemeral and self-describing** (PID+start-time record, best-effort
+drop at clean shutdown, flock-guarded prune of crash leftovers at startup — never touching
+`-N.log` data); **close the `server`/`cluster` fd-inheritance lock leak** in the forked
+queue-manager child; and **discriminate lock errnos** so a genuinely lockless filesystem degrades
+to canonical-append instead of a per-PID file. All while regression-testing the behaviors that
+already work. Contained to `src/hypershell/core/logging.py` plus a small `core/queue.py` fork
+seam. Appetite small → small-medium.
 
 ## 2. Design
 
-All changes are in `src/hypershell/core/logging.py`. The log path is **not** forwarded to
-launched clients (confirmed: all three argv builders in `cluster/{remote,ssh}.py` omit it; each
-client independently derives `client-<own-host>.log`), so no cluster/argv code is touched.
+### (a) Self-describing sidecars (R2) — `core/logging.py`
 
-**(a) errno discrimination — `_try_lock`.** Replace the bare `except OSError` (`logging.py:675`)
-with three outcomes:
-- **LOCKED** → return the held handle (unchanged success path).
-- **CONFLICT** — `errno ∈ {EAGAIN, EWOULDBLOCK}` (equivalently, `except BlockingIOError`). A live
-  sibling holds this slot → the caller advances to the next `-N` slot (preserves **R7**).
-- **UNSUPPORTED** — any other `OSError` (`ENOSYS`, `ENOLCK`, `EOPNOTSUPP`/`ENOTSUP`, `EINVAL`,
-  `EROFS`, …). Locking is unavailable on this FS → the caller must **not** walk slots.
-- `EINTR` → retry the same candidate.
-Signalled cleanly to `claim_file_slot` (e.g. `_try_lock` returns the handle, returns `None` for
-CONFLICT, and raises/sentinels `UNSUPPORTED`). Compare **symbolic `errno.*`** constants only
-(numbers differ macOS↔Linux); guard rare names with `getattr(errno, 'ENOTSUP', None)`. The
-`msvcrt` branch keeps its current conflict-only behavior; the `_LOCKING = False` branch is
-retained but redirected (below).
+Replace the 0-byte sidecar with an owner record. `_try_lock` currently does `open(mode='w')`
+(**truncating**) then `flock`. Change the acquire path so that, **after** winning the `flock`, the
+owner writes a single fixed-shape record — `{"v":1,"pid":…,"create_time":…,"host":…,"instance":…}`
+— then `flush()` (never `close()`; closing drops the lock, `logging.py:698`/`:710`). Probers open
+the sidecar **read-only** (`'r'`) and never truncate, so a losing probe can't blank the winner's
+record. `psutil` (already a core dep, `pyproject.toml`, used in `core/resource.py`) supplies
+`pid_exists` + `Process.create_time()` (wall-clock epoch → folds in boot time, defeats PID reuse
+with a ~2s tolerance; no boot-id needed). A missing/empty/legacy/unparseable record reads as
+"no live holder."
 
-**(b) degrade-to-canonical — `claim_file_slot`.** On the *first* UNSUPPORTED result, or when
-`_LOCKING is False`, stop iterating and return the **canonical** (n=1) per-host path — reused and
-appended (the handler already opens `mode='a'`, `logging.py:377`) — emitting **one** `warn` that
-advisory locking is unavailable. This replaces the `_LOCKING=False` PID-suffix return. The
-genuine-exhaustion branch (all 100 slots returned CONFLICT — i.e. 100 *real* concurrent live
-siblings on one host) legitimately **keeps** the PID-suffix fallback, since distinct files are
-the correct single-writer response there; with errno discrimination an unsupported FS degrades at
-n=1 and can never reach exhaustion.
+### (b) errno discrimination + degrade-to-canonical (R7) — `core/logging.py`
 
-**(c) reclaim + append (R2/R3).** No new mechanism: the existing "first lockable slot wins" loop
-already reclaims the canonical slot on a working-flock FS after the prior owner exits (OS drops
-the flock), and the handler appends. The degrade path (b) extends the same reuse+append to
-lockless filesystems.
+In `_try_lock`, classify the failure instead of swallowing all `OSError`: `EAGAIN`/`EWOULDBLOCK`
+(→ `BlockingIOError`) = genuine CONFLICT → caller advances a slot; `EINTR` → retry; any other
+`OSError` = UNSUPPORTED. In `claim_file_slot`, on the first UNSUPPORTED (or `_LOCKING is False`)
+stop iterating and return the **canonical** per-host path (append), replacing the `<root>-<pid>`
+returns at `logging.py:713`. Genuine 100-way exhaustion (all `EAGAIN`) still legitimately
+PID-suffixes (real concurrency). Fix the false comment at `logging.py:660-666`.
 
-**(d) opportunistic orphan reap — new helper (R6).** Performed **only by the process that just
-won the canonical n=1 lock** (one reaper per host, naturally serialized), invoked at claim time
-alongside `recover_interrupted_compression` (`logging.py:837`). Enumerate directory entries
-matching the **exact `-N` slot shape** `client-<host>-<int>.log` (a compiled regex on
-`basename_without_ext`-scoped prefix, mirroring `recover_interrupted_compression`'s
-`prefix = basename_without_ext(log_file) + '.'` discipline, `logging.py:513-533`). For each: if
-`_try_lock(slot + '.lock')` returns LOCKED, the owner is gone → `os.remove` the orphaned
-`-N.log`; on CONFLICT/UNSUPPORTED, skip. **Never** touch the dot-separated rotation namespace
-(`client-<host>.<N>` / `.YYYYMMDD` / `.YYYYMMDD-HHMMSS`), the `.lock` sidecars, the freshly
-claimed file, or the `main` role.
+### (c) Ephemeral sidecar lifecycle (R3, R4, R5, R8) — `core/logging.py`
 
-**Deliberately not reaped** (inode-reuse safety + appetite): the `.lock` sidecars themselves
-(unlinking a sidecar another process may `flock` is a POSIX inode-reuse race → two writers), and
-an orphan slot's *own* rotated children. Sidecar count is bounded once `-N` growth stops.
+**The one safety invariant (R8):** *only ever unlink a sidecar while holding its `flock`.* This
+closes the inode-reuse race (unlinking a lock another process holds → they keep the old inode
+while a newcomer `open()`s a fresh one → two writers).
+
+- **Shutdown drop (R3):** a finalizer (an `atexit` hook registered when a slot is claimed, and/or
+  an explicit teardown in the app stop path) stops file logging (so no further writes), then for
+  each handle in `_slot_locks`: `unlink` the sidecar path *while still holding the lock*, then
+  `close`. Wrapped best-effort (`try/except OSError`). Covers clean exits; `SIGKILL`/OOM
+  necessarily skip it (handled by prune).
+- **Startup prune (R4):** the process that wins the **canonical** slot scans sibling
+  `client-<host>-N.log.lock` sidecars (exact dash-`N` shape, prefix-scoped like
+  `recover_interrupted_compression`, `logging.py:513-533`). For each: `flock(LOCK_EX|LOCK_NB)` —
+  acquired ⇒ no live holder ⇒ `unlink` the **sidecar only** while holding it, then release;
+  blocked ⇒ a live client holds it ⇒ skip. The record confirms staleness for diagnostics but the
+  `flock`-acquire is the safety gate. **`-N.log` data and the dot-separated rotation namespace are
+  never touched (R5).**
+
+### (d) `server`/`cluster` fd-leak hardening (R6) — `core/queue.py`
+
+`initialize_logging()` (`__init__.py:139`) runs before `SecureManager/BaseManager.start()`
+forks the manager child (`core/queue.py` ~`:243-281`,`:385`) under the default `fork` method, so
+the child inherits the role's slot-lock OFD and holds the lock alive. Close the inherited
+`_slot_locks` handles in the child via the existing post-fork initializer seam (`_tls_bootstrap`
+path) or `os.register_at_fork(after_in_child=…)`. `os.set_inheritable(False)` is **useless** here
+(it acts on exec, not fork). Guard as a no-op where there is no fork / on Windows.
 
 ### Requirement → design map
 
-| R-ID | Design element(s) that satisfy it |
-|------|-----------------------------------|
-| R1 | Root cause documented in [`research/00-digest.md`](research/00-digest.md) + briefs (errno conflation; Lustre `noflock`→`ENOSYS`, NFS→`ENOLCK`); TECH P1 adds a local repro test that forces the errno path and confirms local working-flock does **not** reproduce. |
-| R2 | (c) existing reclaim loop + (b) degrade both return the canonical n=1 path when no live holder exists. |
-| R3 | Handler opens `mode='a'` (`logging.py:377`); reclaim/degrade reuse the canonical name → append, never truncate. |
-| R4 | (b) degrade bounds to 1 file/host on lockless FS; (c) reclaim bounds to peak concurrency on working FS; (d) reap removes accumulated orphans. Verified by the serial-generations count assertion. |
-| R5 | (a)+(b) errno discrimination + degrade-to-canonical keep the count bounded when locking is unavailable (resolves GOAL Q2: hybrid mechanism). |
-| R6 | (d) opportunistic reap of orphaned `-N.log` by the canonical-lock holder. |
-| R7 | (a) CONFLICT (`EAGAIN`/`EWOULDBLOCK`) still advances the slot loop → distinct files for genuinely concurrent same-host writers where `flock` works. |
-| R8 | `msvcrt` branch retained; `_LOCKING=False` degrades to canonical (still host-scoped) not PID; `main` role stays un-host-scoped and is never reaped; cross-host names differ by baked-in hostname. |
+| R-ID | Design element(s) |
+|------|-------------------|
+| R1 | Retained `research/04-11` + `09`; P4 regression tests codify reclaim/append/concurrency. |
+| R2 | (a) owner record written under the held lock; `psutil` liveness. |
+| R3 | (c) shutdown finalizer: stop logging → unlink-under-lock → close. |
+| R4 | (c) startup flock-guarded prune of stale sibling sidecars. |
+| R5 | (c) reap targets `.lock` only; `-N.log`/rotation namespace never touched. |
+| R6 | (d) close inherited `_slot_locks` in the forked manager child. |
+| R7 | (b) errno discrimination + degrade-to-canonical (kills the `:713` per-PID branch). |
+| R8 | only-unlink-under-held-lock invariant; msvcrt/`_LOCKING=False`/`main`/cross-host paths preserved; healthy-FS reclaim unchanged. |
+| R9 | P4 docs note in the file-logging section. |
 
 ## 3. Invariant gate (AGENTS.md constitution check)
 
 Checked against [`invariants.md`](../../.agents/factory/invariants.md) before research and again
-after this design. `core/logging.py` is **not** in the high-blast-radius list (§16).
+after this design.
 
-- **§5 (concurrency — background compression thread + `FILE_LOCK`)** — the reap runs at claim
-  time in `initialize_logging` (single-threaded, before the queue listener/compression thread do
-  meaningful work), touches only exact `client-<host>-<int>.log` data files, and never the
-  dot-separated rotation namespace that `RotatingFileHandler.rotate` manages under `FILE_LOCK`.
-  No new thread, no shared mutable state beyond the existing `_slot_locks` list.
-- **§11 (cluster orchestration — no shared client-argv builder)** — honored trivially: the fix
-  forwards **no** new argument; the log path is derived client-side and is not in any argv
-  builder, so `local/remote/ssh/autoscale` are untouched.
-- **§12 (same-commit conventions)** — internal-only change: **no** new CLI flag or config key ⇒
-  no `docs/_include/*.rst` or `share/` completion edits required. New tests are tagged
-  `@mark.unit` / `@mark.integration`; `errno.*` symbolic constants (not integer literals) are
-  used; Python 3.11–3.14 only (`fcntl`/`errno` are stdlib on all).
-- **R7/R8 (module's own single-writer + fallback contract)** — preserved where lockable;
-  consciously relaxed only on lockless filesystems, which is precisely what R5 authorizes.
+- **§5 (concurrency — background compression thread + `FILE_LOCK`)** — startup prune runs in
+  `initialize_logging` beside `recover_interrupted_compression`, before the compression thread
+  does real work; it touches only `.lock` sidecars, never the `FILE_LOCK`-managed rotation
+  namespace. The shutdown finalizer stops the `QueueListener` before unlinking.
+- **§9 / high-blast-radius `core/queue.py`** — R6/(d) edits `core/queue.py`, which **is** on the
+  high-blast-radius list (§16). Keep the change to closing inherited fds in the child; do not
+  touch the pickle-framed RPC, TLS context install, authkey, or handshake/fingerprint. A
+  CONFIRMED finding here forces a human review gate — expected; P3 is `parallel:false`, extra care.
+- **§11 (no shared client-argv builder)** — honored: no argument is forwarded to launched
+  clients; path derivation stays client-side. No argv-builder edits.
+- **§12 (same-commit conventions)** — no new CLI flag or config key ⇒ no `docs/_include/*.rst`
+  help-snippet or `share/` completion edits. R9 is prose in the logging docs (not CLI help).
+  New tests tagged `@mark.unit`/`@mark.integration`; symbolic `errno.*`; Python 3.11–3.14.
+- **R8 self-contract** — the only-unlink-under-held-lock invariant is the load-bearing safety
+  rule; every unlink site must be audited against it.
 
 ### Deviation justifications
 
 | Deviation | Why needed | Simpler alternative rejected because |
 |-----------|-----------|--------------------------------------|
-| —         | —         | — |
+| Unlink sidecars (vs. research 00/07 "never unlink") | Maintainer wants ephemeral sidecars; the inode-reuse hazard is fully closed by the only-unlink-while-holding-the-lock rule (adversarially confirmed in [`research/11`](research/11-stress-reap.md) Part 3) | "Never unlink + document" leaves the alarming accumulation the maintainer explicitly wants gone |
 
-No `invariants.md` invariant is bent. (The single-writer *relaxation* on lockless filesystems is
-the GOAL's R5, not an invariant deviation — recorded as an accepted trade-off in §5 Risks.)
+No `invariants.md` invariant is bent.
 
 ## 4. Rabbit holes (resolved)
 
-- **Why proliferation on *both* ZFS and Lustre, and not locally** → same errno-conflation defect
-  via two different errnos: Lustre `noflock`→`ENOSYS` (always), NFS/ZFS flaky NLM→`ENOLCK`; local
-  working-flock reclaims correctly (no bug) ([`research/01`](research/01-fs-lock-semantics.md),
-  [`research/02`](research/02-code-trace-signatures.md)).
-- **Which on-disk signature confirms it** → unsupported ⇒ PID-suffixed logs + fixed 100 `.lock` +
-  per-launch "Exhausted" warning; stale ⇒ sequential `-N.log` + growing `.lock`
-  ([`research/02`](research/02-code-trace-signatures.md)). A one-line `ls` on Gautschi confirms
-  which (not a blocker).
-- **How to detect "unsupported" vs "contended" portably** → only `{EAGAIN, EWOULDBLOCK}`
-  (`BlockingIOError`) is contention; symbolic `errno.*` (numbers differ by OS)
-  ([`research/01`](research/01-fs-lock-semantics.md)).
-- **Is reaping `.lock` files safe?** → No — POSIX inode-reuse race; reap only the `-N.log` data,
-  leave sidecars ([`research/03`](research/03-fix-surface-and-tests.md)).
-- **Does the fix need to touch cluster argv / add a knob?** → No to both; contained to
-  `core/logging.py` ([`research/02`](research/02-code-trace-signatures.md),
-  [`research/03`](research/03-fix-surface-and-tests.md)).
+- **Was there a reclaim bug at all?** No — legitimate concurrency; reclaim+append works on both
+  FS ([`research/04`](research/04-evidence-forensics.md), [`research/09`](research/09-revised-design.md);
+  confirmed by the maintainer's timestamp forensics + ZFS restart test).
+- **Is unlinking a sidecar safe?** Only under a held `flock`; that closes the inode-reuse race
+  ([`research/11`](research/11-stress-reap.md) Part 3).
+- **Do we need PID-override of a held lock?** No — reclaim works; the record is liveness/
+  diagnostics + safe-prune only. The override branch was adversarially shown to risk R7 on a
+  *healthy* FS ([`research/10`](research/10-stress-liveness.md) H1/H9) and is dropped.
+- **Where is the fd-leak, and does it hit clients?** `BaseManager.start()` fork; `server`/
+  `cluster` only — clients never fork a manager ([`research/05`](research/05-process-model-audit.md)).
+- **PID reuse / no boot-id / psutil dep?** `create_time()` folds boot time; `psutil>=7` already a
+  dep; pin ~2s tolerance ([`research/06`](research/06-liveness-design.md),
+  [`research/10`](research/10-stress-liveness.md) H8).
 
 ## 5. Risks & open questions
 
-- **Interleaved writes on the degrade path (accepted, = R5).** When advisory locking is
-  unavailable, multiple *concurrent* same-host clients append to one file; `O_APPEND` write
-  atomicity is not guaranteed on Lustre for large records. This is the GOAL's explicit R5 choice
-  (bounded proliferation > strict single-writer on lockless FS). Documented; not mitigated.
-- **`.lock` sidecars are not reaped** (inode-reuse safety) — their count is bounded once `-N`
-  growth stops, but pre-existing orphan sidecars from the buggy version persist. Acceptable
-  (0-byte files); deeper GC is a Non-goal.
-- **Cannot CI-test real Lustre/ZFS.** Mitigation: unit tests inject the exact errnos
-  (`ENOSYS`/`ENOLCK` vs `EAGAIN`) to exercise both branches deterministically; integration test
-  asserts the bounded count via serial generations on the local FS.
-- **`_slot_locks` global leak** must be cleaned between in-process tests (autouse fixture) —
-  a test-hygiene requirement, called out so P1 doesn't produce flaky cross-test contamination.
-- **Confirmation (optional, non-blocking):** an `ls` of the log dir on Gautschi would confirm
-  which signature is in play; the fix cures both regardless.
+- **Torn/partial record read** — a prober reading mid-write must treat unparseable as "no live
+  holder"; a single fixed-shape `write()` + reader retry-once mitigates. Safety never depends on
+  the record alone — the `flock`-acquire is the gate ([`research/10`](research/10-stress-liveness.md) H1).
+- **`AccessDenied` on a reused PID owned by another user** (node-shared allocations) → read as
+  "alive," slot not pruned. Safe (never steals); document. Gautschi nodes are typically
+  exclusive ([`research/10`](research/10-stress-liveness.md) H6).
+- **PID namespaces / containers** break local PID checks; out of practical scope for MPI/Slurm
+  launchers; document ([`research/10`](research/10-stress-liveness.md) H7).
+- **Shutdown finalizer coverage** — `atexit` runs on clean exit and handled `KeyboardInterrupt`,
+  not on uncaught `SIGTERM`/`SIGKILL`; those leftovers are swept by the startup prune. Acceptable.
+- **`core/queue.py` blast radius** — R6 touches a high-blast-radius file; forces a human gate.
 
 ## 6. Verification strategy
 
-Prefer driving the real CLI in a throwaway site, backed by targeted unit tests that inject
-filesystem behavior:
+Prefer driving the real CLI in a throwaway site plus targeted unit tests that inject
+filesystem/liveness behavior:
 
-- **errno discrimination / degrade (P1):**
-  `uv run pytest -v tests/test_logging.py -k "slot or lock or degrade or unsupported"` — patch
-  `hypershell.core.logging.fcntl.flock` to raise `OSError(errno.ENOSYS)` / `OSError(errno.ENOLCK)`
-  (→ claim returns canonical) vs `OSError(errno.EAGAIN)` (→ claim returns `-2`); and
-  `monkeypatch.setattr('hypershell.core.logging._LOCKING', False)` (→ canonical). Autouse fixture
-  clears `_slot_locks`.
-- **reap (P2):** seed orphan `client-h-2.log`/`-3.log` (unlocked) + a *locked* `client-h-4.log`
-  and rotated `client-h.1`/`client-h.20260723` and `main.log`; assert only the unlocked orphans
-  are removed, everything else retained.
-- **bound end-to-end (P3):** drive the CLI and assert no proliferation across repeated runs:
-  `.agents/factory/bin/temp_site.sh sh -c "HYPERSHELL_LOGGING_FILE=enabled; for i in 1 2 3; do seq 20 | uv run hsx -t 'echo {}' -N2 >/dev/null; done; ls \"$HYPERSHELL_SITE\"/**/client-*.log 2>/dev/null | wc -l"`
-  (bounded, not growing with the loop) plus `uv run pytest -v -m integration tests/test_logging.py`.
-- **regression:** `uv run pytest -v tests/test_logging.py` (existing role/host-scope/reclaim tests
-  must stay green).
+- **errno/degrade (P1):** patch `hypershell.core.logging.fcntl.flock` to raise
+  `OSError(errno.ENOSYS)`/`ENOLCK` (→ canonical) vs `OSError(errno.EAGAIN)` (→ `-2`);
+  `monkeypatch.setattr('hypershell.core.logging._LOCKING', False)` (→ canonical). Assert the
+  record round-trips. Autouse fixture clears `_slot_locks`.
+- **sidecar lifecycle (P2):** claim → assert record present + owner alive; simulate clean exit →
+  assert own sidecar removed; seed a stale sibling `.lock` (dead PID, unlocked) + a *held* sibling
+  (in-test `flock`) + real `-N.log` data + rotated `client-h.20260723` → after a canonical claim,
+  assert only the unlocked stale sidecar is removed and **all `.log`/rotated files survive**.
+- **fd-leak (P3):** a POSIX-only test that `os.fork()`s after a claim and asserts the parent's
+  lock releases once the parent handle closes iff the child closed its inherited copy
+  (`skipif` Windows).
+- **e2e bound + regression (P4):** `.agents/factory/bin/temp_site.sh sh -c "HYPERSHELL_LOGGING_FILE=enabled; for i in 1 2 3; do seq 20 | uv run hsx -t 'echo {}' -N2 >/dev/null; done; find \"$HYPERSHELL_SITE\" -name '*.log.lock' | wc -l"`
+  (bounded; sidecars cleaned across clean restarts) + `uv run pytest -v tests/test_logging.py`
+  (existing reclaim/host-scope/role tests green).
 
 ---
 
-*Backing research: [`research/00-digest.md`](research/00-digest.md).*
+*Backing research: [`research/09-revised-design.md`](research/09-revised-design.md) (supersedes
+[`00-digest.md`](research/00-digest.md)); briefs [`04`](research/04-evidence-forensics.md)–[`11`](research/11-stress-reap.md).*

--- a/spec/logging-file-slot-reclaim/PLAN.md
+++ b/spec/logging-file-slot-reclaim/PLAN.md
@@ -1,0 +1,170 @@
+# PLAN — Reclaim per-host log-file slots on shared HPC filesystems
+
+> **Status:** Draft for review · **Last updated:** 2026-07-23
+> **Authoritative technical design.** The *how*. Vision/contract is [`GOAL.md`](GOAL.md);
+> the phased executable roadmap is [`TECH.md`](TECH.md). Backing detail is in
+> [`research/`](research/). Every design element traces to a GOAL R-ID.
+
+## 1. Summary
+
+The proliferation is a single defect: `_try_lock` collapses *every* `flock` `OSError` into
+"slot contended," so on filesystems where advisory locking is unavailable (Lustre default
+`noflock` → `ENOSYS`; NFS-exported ZFS with flaky NLM → `ENOLCK`) each process generation walks
+past the canonical per-host log and manufactures a new file. The fix — entirely within
+`src/hypershell/core/logging.py`, no new config knob — teaches `_try_lock` to **distinguish a
+genuine conflict (`EAGAIN`/`EWOULDBLOCK`) from an unavailable lock**, **degrades to the reused
+canonical per-host path** (append) when locking is unavailable, and **opportunistically reaps
+orphaned `-N.log` slots**. On filesystems where `flock` works, reclaim-and-append *already*
+works (`mode='a'` + OS lock release on exit), so R7's strict single-writer is preserved
+untouched there. Small appetite: three coupled, coherent phases in one module + tests.
+
+## 2. Design
+
+All changes are in `src/hypershell/core/logging.py`. The log path is **not** forwarded to
+launched clients (confirmed: all three argv builders in `cluster/{remote,ssh}.py` omit it; each
+client independently derives `client-<own-host>.log`), so no cluster/argv code is touched.
+
+**(a) errno discrimination — `_try_lock`.** Replace the bare `except OSError` (`logging.py:675`)
+with three outcomes:
+- **LOCKED** → return the held handle (unchanged success path).
+- **CONFLICT** — `errno ∈ {EAGAIN, EWOULDBLOCK}` (equivalently, `except BlockingIOError`). A live
+  sibling holds this slot → the caller advances to the next `-N` slot (preserves **R7**).
+- **UNSUPPORTED** — any other `OSError` (`ENOSYS`, `ENOLCK`, `EOPNOTSUPP`/`ENOTSUP`, `EINVAL`,
+  `EROFS`, …). Locking is unavailable on this FS → the caller must **not** walk slots.
+- `EINTR` → retry the same candidate.
+Signalled cleanly to `claim_file_slot` (e.g. `_try_lock` returns the handle, returns `None` for
+CONFLICT, and raises/sentinels `UNSUPPORTED`). Compare **symbolic `errno.*`** constants only
+(numbers differ macOS↔Linux); guard rare names with `getattr(errno, 'ENOTSUP', None)`. The
+`msvcrt` branch keeps its current conflict-only behavior; the `_LOCKING = False` branch is
+retained but redirected (below).
+
+**(b) degrade-to-canonical — `claim_file_slot`.** On the *first* UNSUPPORTED result, or when
+`_LOCKING is False`, stop iterating and return the **canonical** (n=1) per-host path — reused and
+appended (the handler already opens `mode='a'`, `logging.py:377`) — emitting **one** `warn` that
+advisory locking is unavailable. This replaces the `_LOCKING=False` PID-suffix return. The
+genuine-exhaustion branch (all 100 slots returned CONFLICT — i.e. 100 *real* concurrent live
+siblings on one host) legitimately **keeps** the PID-suffix fallback, since distinct files are
+the correct single-writer response there; with errno discrimination an unsupported FS degrades at
+n=1 and can never reach exhaustion.
+
+**(c) reclaim + append (R2/R3).** No new mechanism: the existing "first lockable slot wins" loop
+already reclaims the canonical slot on a working-flock FS after the prior owner exits (OS drops
+the flock), and the handler appends. The degrade path (b) extends the same reuse+append to
+lockless filesystems.
+
+**(d) opportunistic orphan reap — new helper (R6).** Performed **only by the process that just
+won the canonical n=1 lock** (one reaper per host, naturally serialized), invoked at claim time
+alongside `recover_interrupted_compression` (`logging.py:837`). Enumerate directory entries
+matching the **exact `-N` slot shape** `client-<host>-<int>.log` (a compiled regex on
+`basename_without_ext`-scoped prefix, mirroring `recover_interrupted_compression`'s
+`prefix = basename_without_ext(log_file) + '.'` discipline, `logging.py:513-533`). For each: if
+`_try_lock(slot + '.lock')` returns LOCKED, the owner is gone → `os.remove` the orphaned
+`-N.log`; on CONFLICT/UNSUPPORTED, skip. **Never** touch the dot-separated rotation namespace
+(`client-<host>.<N>` / `.YYYYMMDD` / `.YYYYMMDD-HHMMSS`), the `.lock` sidecars, the freshly
+claimed file, or the `main` role.
+
+**Deliberately not reaped** (inode-reuse safety + appetite): the `.lock` sidecars themselves
+(unlinking a sidecar another process may `flock` is a POSIX inode-reuse race → two writers), and
+an orphan slot's *own* rotated children. Sidecar count is bounded once `-N` growth stops.
+
+### Requirement → design map
+
+| R-ID | Design element(s) that satisfy it |
+|------|-----------------------------------|
+| R1 | Root cause documented in [`research/00-digest.md`](research/00-digest.md) + briefs (errno conflation; Lustre `noflock`→`ENOSYS`, NFS→`ENOLCK`); TECH P1 adds a local repro test that forces the errno path and confirms local working-flock does **not** reproduce. |
+| R2 | (c) existing reclaim loop + (b) degrade both return the canonical n=1 path when no live holder exists. |
+| R3 | Handler opens `mode='a'` (`logging.py:377`); reclaim/degrade reuse the canonical name → append, never truncate. |
+| R4 | (b) degrade bounds to 1 file/host on lockless FS; (c) reclaim bounds to peak concurrency on working FS; (d) reap removes accumulated orphans. Verified by the serial-generations count assertion. |
+| R5 | (a)+(b) errno discrimination + degrade-to-canonical keep the count bounded when locking is unavailable (resolves GOAL Q2: hybrid mechanism). |
+| R6 | (d) opportunistic reap of orphaned `-N.log` by the canonical-lock holder. |
+| R7 | (a) CONFLICT (`EAGAIN`/`EWOULDBLOCK`) still advances the slot loop → distinct files for genuinely concurrent same-host writers where `flock` works. |
+| R8 | `msvcrt` branch retained; `_LOCKING=False` degrades to canonical (still host-scoped) not PID; `main` role stays un-host-scoped and is never reaped; cross-host names differ by baked-in hostname. |
+
+## 3. Invariant gate (AGENTS.md constitution check)
+
+Checked against [`invariants.md`](../../.agents/factory/invariants.md) before research and again
+after this design. `core/logging.py` is **not** in the high-blast-radius list (§16).
+
+- **§5 (concurrency — background compression thread + `FILE_LOCK`)** — the reap runs at claim
+  time in `initialize_logging` (single-threaded, before the queue listener/compression thread do
+  meaningful work), touches only exact `client-<host>-<int>.log` data files, and never the
+  dot-separated rotation namespace that `RotatingFileHandler.rotate` manages under `FILE_LOCK`.
+  No new thread, no shared mutable state beyond the existing `_slot_locks` list.
+- **§11 (cluster orchestration — no shared client-argv builder)** — honored trivially: the fix
+  forwards **no** new argument; the log path is derived client-side and is not in any argv
+  builder, so `local/remote/ssh/autoscale` are untouched.
+- **§12 (same-commit conventions)** — internal-only change: **no** new CLI flag or config key ⇒
+  no `docs/_include/*.rst` or `share/` completion edits required. New tests are tagged
+  `@mark.unit` / `@mark.integration`; `errno.*` symbolic constants (not integer literals) are
+  used; Python 3.11–3.14 only (`fcntl`/`errno` are stdlib on all).
+- **R7/R8 (module's own single-writer + fallback contract)** — preserved where lockable;
+  consciously relaxed only on lockless filesystems, which is precisely what R5 authorizes.
+
+### Deviation justifications
+
+| Deviation | Why needed | Simpler alternative rejected because |
+|-----------|-----------|--------------------------------------|
+| —         | —         | — |
+
+No `invariants.md` invariant is bent. (The single-writer *relaxation* on lockless filesystems is
+the GOAL's R5, not an invariant deviation — recorded as an accepted trade-off in §5 Risks.)
+
+## 4. Rabbit holes (resolved)
+
+- **Why proliferation on *both* ZFS and Lustre, and not locally** → same errno-conflation defect
+  via two different errnos: Lustre `noflock`→`ENOSYS` (always), NFS/ZFS flaky NLM→`ENOLCK`; local
+  working-flock reclaims correctly (no bug) ([`research/01`](research/01-fs-lock-semantics.md),
+  [`research/02`](research/02-code-trace-signatures.md)).
+- **Which on-disk signature confirms it** → unsupported ⇒ PID-suffixed logs + fixed 100 `.lock` +
+  per-launch "Exhausted" warning; stale ⇒ sequential `-N.log` + growing `.lock`
+  ([`research/02`](research/02-code-trace-signatures.md)). A one-line `ls` on Gautschi confirms
+  which (not a blocker).
+- **How to detect "unsupported" vs "contended" portably** → only `{EAGAIN, EWOULDBLOCK}`
+  (`BlockingIOError`) is contention; symbolic `errno.*` (numbers differ by OS)
+  ([`research/01`](research/01-fs-lock-semantics.md)).
+- **Is reaping `.lock` files safe?** → No — POSIX inode-reuse race; reap only the `-N.log` data,
+  leave sidecars ([`research/03`](research/03-fix-surface-and-tests.md)).
+- **Does the fix need to touch cluster argv / add a knob?** → No to both; contained to
+  `core/logging.py` ([`research/02`](research/02-code-trace-signatures.md),
+  [`research/03`](research/03-fix-surface-and-tests.md)).
+
+## 5. Risks & open questions
+
+- **Interleaved writes on the degrade path (accepted, = R5).** When advisory locking is
+  unavailable, multiple *concurrent* same-host clients append to one file; `O_APPEND` write
+  atomicity is not guaranteed on Lustre for large records. This is the GOAL's explicit R5 choice
+  (bounded proliferation > strict single-writer on lockless FS). Documented; not mitigated.
+- **`.lock` sidecars are not reaped** (inode-reuse safety) — their count is bounded once `-N`
+  growth stops, but pre-existing orphan sidecars from the buggy version persist. Acceptable
+  (0-byte files); deeper GC is a Non-goal.
+- **Cannot CI-test real Lustre/ZFS.** Mitigation: unit tests inject the exact errnos
+  (`ENOSYS`/`ENOLCK` vs `EAGAIN`) to exercise both branches deterministically; integration test
+  asserts the bounded count via serial generations on the local FS.
+- **`_slot_locks` global leak** must be cleaned between in-process tests (autouse fixture) —
+  a test-hygiene requirement, called out so P1 doesn't produce flaky cross-test contamination.
+- **Confirmation (optional, non-blocking):** an `ls` of the log dir on Gautschi would confirm
+  which signature is in play; the fix cures both regardless.
+
+## 6. Verification strategy
+
+Prefer driving the real CLI in a throwaway site, backed by targeted unit tests that inject
+filesystem behavior:
+
+- **errno discrimination / degrade (P1):**
+  `uv run pytest -v tests/test_logging.py -k "slot or lock or degrade or unsupported"` — patch
+  `hypershell.core.logging.fcntl.flock` to raise `OSError(errno.ENOSYS)` / `OSError(errno.ENOLCK)`
+  (→ claim returns canonical) vs `OSError(errno.EAGAIN)` (→ claim returns `-2`); and
+  `monkeypatch.setattr('hypershell.core.logging._LOCKING', False)` (→ canonical). Autouse fixture
+  clears `_slot_locks`.
+- **reap (P2):** seed orphan `client-h-2.log`/`-3.log` (unlocked) + a *locked* `client-h-4.log`
+  and rotated `client-h.1`/`client-h.20260723` and `main.log`; assert only the unlocked orphans
+  are removed, everything else retained.
+- **bound end-to-end (P3):** drive the CLI and assert no proliferation across repeated runs:
+  `.agents/factory/bin/temp_site.sh sh -c "HYPERSHELL_LOGGING_FILE=enabled; for i in 1 2 3; do seq 20 | uv run hsx -t 'echo {}' -N2 >/dev/null; done; ls \"$HYPERSHELL_SITE\"/**/client-*.log 2>/dev/null | wc -l"`
+  (bounded, not growing with the loop) plus `uv run pytest -v -m integration tests/test_logging.py`.
+- **regression:** `uv run pytest -v tests/test_logging.py` (existing role/host-scope/reclaim tests
+  must stay green).
+
+---
+
+*Backing research: [`research/00-digest.md`](research/00-digest.md).*

--- a/spec/logging-file-slot-reclaim/REVIEW.md
+++ b/spec/logging-file-slot-reclaim/REVIEW.md
@@ -1,0 +1,97 @@
+# REVIEW — Ephemeral log-lock sidecars + fd-leak/errno hardening
+
+> Adversarial QA by `hs-review`, run in an isolated/clean context. The correctness pass grades the
+> branch diff against [`GOAL.md`](GOAL.md) + the AGENTS.md invariants **only** — it does not see
+> `PLAN.md`/`TECH.md` (avoids grading-its-own-homework / plan-sycophancy). Every finding cites an
+> **executed** command, not an assertion.
+
+- **Reviewed commit:** e9079df  ·  **Base:** develop  ·  **Date:** 2026-07-23
+- **Verdict:** approved
+- **Cycle:** 1 of ≤3 — mirrors `review.cycle` in `TECH.md`
+
+**Contract note.** `GOAL.md` was re-scoped mid-lifecycle (commit `26a2e1a`, 2026-07-23) — the
+original "reclaim bug" premise was refuted by investigation and the contract re-targeted to sidecar
+hygiene + fd-leak/errno hardening (R1–R9). The re-scope landed *after* planning but *before* any
+build phase, so the entire P1–P4 build targeted the current contract. Human confirmed grading
+against the re-scoped `GOAL.md` before this pass ran.
+
+## Verification run
+
+Commands actually executed and their outcomes (the spine of the review):
+
+**Blind reviewer (fresh subagent, spec-excluded diff):**
+- `uv run pytest -v tests/test_logging.py` → **36 passed** (2.52s)
+- `uv run pytest -v -m integration tests/test_logging.py` → **6 passed**, 30 deselected
+- `uv run pytest tests/test_server.py tests/test_client.py tests/test_cluster.py` → **86 passed**
+  (exercises the rewired `SecureManager.start`/fork seam)
+- `uv run pytest -v tests/test_queue_tls.py` → **39 passed**, incl. subprocess roundtrip +
+  framing/fingerprint (§9 intact)
+- `uv run sphinx-build docs docs/_build` → clean (only pre-existing `pkg_resources` deprecation; no
+  new `logging.rst` warnings)
+- CLI drive (throwaway `temp_site.sh`, `HYPERSHELL_LOGGING_FILE=enabled`): 3 serial `hsx`
+  generations → canonical `.log` reclaimed each generation, **0** `.lock` sidecars left behind
+  (R1/R3/R8); planted stale `-2.log.lock` + `-2.log`, rerun → stale sidecar swept, `-2.log` data
+  preserved (R4/R5)
+- `git status --porcelain` → empty (reviewer left tree clean)
+
+**Orchestrator independent checks:**
+- `git status --porcelain` → empty (confirmed clean before grading)
+- `uv run pytest -q tests/test_logging.py` → **36 passed** (2.42s) — re-ran independently
+- Read `git diff develop...HEAD -- src/hypershell/core/queue.py` by eye: change is confined to the
+  post-fork child (`close_inherited_slot_locks()` + `install_process_context` guarded on
+  `cfg is not None`) and unifying `start()` so the fd-close runs on **both** TLS and no-TLS forks.
+  RPC framing, authkey, `connect()`/handshake, and serializer registration are untouched — §9
+  honored.
+
+## Requirement → evidence matrix
+
+| R-ID | Implemented by (file) | Verified how | Status |
+|------|-----------------------|--------------|--------|
+| R1 | regression tests `test_serial_generations_reclaim_canonical_and_leave_no_sidecars`, `test_concurrent_holders_get_distinct_slots_and_data_survives` (`tests/test_logging.py`) | both pass; CLI drive confirms reclaim+append + legitimate concurrency | ✅ |
+| R2 | `write_lock_record` (`core/logging.py:686`) writes `{v,pid,create_time,host,instance}` under held lock | `test_lock_record_round_trips` passes (asserts v==1, pid, host, instance) | ✅ |
+| R3 | `finalize_logging` (`core/logging.py:876`) stops `queue_listener` then unlinks each sidecar under held lock; `atexit`-registered on first claim | `test_finalize_logging_drops_own_sidecar`, `test_clean_exit_removes_own_sidecar_via_atexit`; CLI drive (0 sidecars after 3 gens) | ✅ |
+| R4 | `prune_stale_sidecars`/`prune_one_sidecar` (`core/logging.py:925,948`), gated on winning canonical slot + `DISTRIBUTED_ROLES`; flock-acquire is the safety gate | `test_prune_removes_stale_unlocked_sidecar`, `test_prune_keeps_live_held_sibling_sidecar`; CLI drive | ✅ |
+| R5 | prune regex matches only `<root>-N<ext>.lock` (`core/logging.py:938`) | `test_prune_sidecar_never_touches_data_or_rotated_files`; CLI drive (`-2.log` survived intact) | ✅ |
+| R6 | `close_inherited_slot_locks` (`core/logging.py:906`) invoked in `_child_bootstrap` (`core/queue.py:251`) before serving | `test_forked_child_closing_inherited_lock_releases_parent_slot`; orchestrator read of queue.py diff + OFD/flock mechanism | ✅ |
+| R7 | `acquire_lock` (`core/logging.py:802`) returns False only on `EAGAIN`/`EWOULDBLOCK`, retries `EINTR`, raises `LockUnsupported` else; `claim_file_slot` degrades to canonical (not per-PID) | `test_unsupported_lock_errno_degrades_to_canonical` (ENOSYS/ENOLCK/EPERM), `test_no_locking_support_uses_canonical`, `test_contention_advances_to_next_slot` | ✅ |
+| R8 | reclaim+append, cross-host isolation, `main` never pruned (`main` ∉ `DISTRIBUTED_ROLES`), msvcrt/no-lock fallbacks, unlink-only-under-held-lock in finalize + prune | `test_main_role_never_prunes_sidecars`; CLI drive; suite green | ✅ |
+| R9 | `docs/logging.rst` adds the three notes (same-host `-N.log`, ephemeral owner-stamped sidecars, legitimate dangling rotated leaves) | `sphinx-build` clean | ✅ |
+
+Unmapped changes (possible scope creep): **none material.** Commit `e9079df` renames slot-lock
+internals (dropped leading underscores: `_slot_locks`→`slot_locks`, `_LOCKING`→`LOCKING`,
+`_try_lock`→`try_lock`/`acquire_lock`) and makes the platform branch explicit. These are in-scope
+cleanups of the R2/R6/R7/R8 machinery and match the project's documented style conventions (no
+leading-underscore "private" names; explicit platform branch over import-probing); tests updated in
+lockstep. Not gold-plating.
+
+## Findings
+
+**None.** No CONFIRMED or PLAUSIBLE findings survived refutation.
+
+Candidates the reviewer investigated and dropped under the refutation protocol:
+- *Inherited `atexit` finalizer double-runs / hangs the forked manager child* → dissolved:
+  `multiprocessing/popen_fork.py` calls `atexit._clear()` in the child before `_bootstrap` and exits
+  via `os._exit()`, so the inherited `finalize_logging` never runs in the child; the explicit
+  `close_inherited_slot_locks()` fd-close is the necessary-and-sufficient fix. Confirmed by CPython
+  source read + `test_forked_child_*` passing.
+- *§9 queue.py weakening* → dissolved: diff only closes inherited fds + guards
+  `install_process_context` on `cfg is not None`; framing/authkey/handshake/fingerprint untouched;
+  `test_queue_tls.py` (39) + cluster suite (86) pass. (Independently re-verified by orchestrator.)
+- *`write_lock_record` truncate not overwriting under append mode* → dissolved: `seek(0);truncate();
+  write` writes at offset 0; `test_lock_record_round_trips` + `test_losing_probe_does_not_blank_the_record` pass.
+- *`prune` crash on a lockless FS* → dissolved: `prune_one_sidecar` catches `LockUnsupported` and
+  bails harmlessly per sidecar.
+
+## Human-gate triggers
+
+The diff touches the high-blast-radius core (`core/queue.py`, `core/logging.py`), but the
+mandatory human sign-off gate fires only when a **CONFIRMED finding** touches that core. **No
+CONFIRMED findings → gate not triggered.** The `core/queue.py` change was nonetheless independently
+inspected by the orchestrator (see Verification run) and confirmed confined to the R6 post-fork
+fd-close with §9 intact.
+
+## Optional completeness sub-pass (separate reviewer; may see TECH.md)
+
+Not run (plain `/hs-review` invocation). All four planned phases (P1–P4) are `done` in `TECH.md` and
+every R-ID (R1–R9) maps to shipped, verified code; scope stayed within the small→small-medium
+appetite (4 files: `core/logging.py`, `core/queue.py`, `tests/test_logging.py`, `docs/logging.rst`).

--- a/spec/logging-file-slot-reclaim/TECH.md
+++ b/spec/logging-file-slot-reclaim/TECH.md
@@ -1,6 +1,6 @@
 ---
 slug: logging-file-slot-reclaim
-title: "Reclaim per-host log-file slots on shared HPC filesystems"
+title: "Ephemeral log-lock sidecars + fd-leak/errno hardening"
 kind: fix
 appetite: small
 status: in_progress
@@ -10,28 +10,37 @@ current_phase: P1
 last_updated: "2026-07-23"
 phases:
   - id: P1
-    name: "errno discrimination + degrade-to-canonical (core fix)"
+    name: "Self-describing sidecar record + errno discrimination + degrade-to-canonical"
     status: pending
-    satisfies: [R1, R2, R3, R5, R7, R8]
+    satisfies: [R2, R7, R8]
     depends_on: []
     parallel: false
     hammerable: false
     hill: uphill
-    verify: "uv run pytest -v tests/test_logging.py -k \"slot or lock or degrade or unsupported\""
+    verify: "uv run pytest -v tests/test_logging.py -k \"slot or lock or errno or degrade or record\""
   - id: P2
-    name: "Opportunistic orphan-slot reap"
+    name: "Ephemeral sidecar lifecycle (shutdown drop + flock-guarded startup prune)"
     status: pending
-    satisfies: [R6, R4]
+    satisfies: [R3, R4, R5]
     depends_on: [P1]
     parallel: false
     hammerable: false
     hill: uphill
-    verify: "uv run pytest -v tests/test_logging.py -k \"reap or orphan\""
+    verify: "uv run pytest -v tests/test_logging.py -k \"sidecar or prune or ephemeral or shutdown\""
   - id: P3
-    name: "End-to-end bounded-count verification (CLI-driven)"
+    name: "server/cluster fork fd-leak hardening (core/queue.py)"
     status: pending
-    satisfies: [R4, R8]
-    depends_on: [P1, P2]
+    satisfies: [R6]
+    depends_on: [P1]
+    parallel: false
+    hammerable: false
+    hill: uphill
+    verify: "uv run pytest -v tests/test_logging.py -k \"fork or leak or inherit or manager\""
+  - id: P4
+    name: "End-to-end bound + regression + docs note"
+    status: pending
+    satisfies: [R1, R8, R9]
+    depends_on: [P1, P2, P3]
     parallel: false
     hammerable: false
     hill: uphill
@@ -43,126 +52,130 @@ review:
   cycle: 0
 ---
 
-# TECH.md — Reclaim per-host log-file slots on shared HPC filesystems
+# TECH.md — Ephemeral log-lock sidecars + fd-leak/errno hardening
 
-The **context engine and finite-state machine** for building this fix. The YAML frontmatter
-is the resume ground-truth (read it with
-`uv run python .agents/factory/bin/next_phase.py spec/logging-file-slot-reclaim/TECH.md`); the
-per-phase checklists below are the work.
+Resume ground-truth is the YAML frontmatter (read with
+`uv run python .agents/factory/bin/next_phase.py spec/logging-file-slot-reclaim/TECH.md`).
 
-- **Vision / requirements (locked):** [`GOAL.md`](GOAL.md) — R-IDs are the contract.
+- **Vision / requirements (locked):** [`GOAL.md`](GOAL.md) — R-IDs are the contract (re-scoped
+  2026-07-23 after the reclaim-bug premise was refuted).
 - **Authoritative design:** [`PLAN.md`](PLAN.md).
-- **Backing research:** [`research/00-digest.md`](research/00-digest.md) + briefs 01–03.
+- **Backing research:** [`research/09-revised-design.md`](research/09-revised-design.md)
+  (supersedes [`00-digest.md`](research/00-digest.md)); briefs 04–11.
 
 ## Conventions (apply to every phase)
 
-- Invariants and house style come from [`AGENTS.md`](../../AGENTS.md) /
-  [`invariants.md`](../../.agents/factory/invariants.md). The whole fix is contained to
-  `src/hypershell/core/logging.py` + `tests/test_logging.py`.
-- One phase per `hs-build` invocation; one atomic commit with **both** code and the `TECH.md`
-  state change. Subjects: `[fix] Build logging-file-slot-reclaim P<n>: …`. **No `Co-Authored-By`.**
-- **No new CLI flag or config key** (internal-only) ⇒ **no** `docs/_include` / `share/` edits
-  (invariant §12). If a phase discovers a knob is truly needed, STOP and escalate — it would
-  change scope and force companion doc/completion edits.
-- Use symbolic `errno.*` constants, never integer literals (numbers differ macOS↔Linux).
-- Add an **autouse fixture** in `tests/test_logging.py` (P1) that closes and clears the module
-  global `_slot_locks` after each test — otherwise held handles leak across tests and cause flakes.
+- Invariants/house style from [`AGENTS.md`](../../AGENTS.md) /
+  [`invariants.md`](../../.agents/factory/invariants.md). Core changes live in
+  `src/hypershell/core/logging.py`; P3 also edits **`core/queue.py` (high-blast-radius §16)** —
+  touch only the post-fork child fd-close; leave RPC/TLS/authkey/handshake untouched.
+- One phase per `hs-build` invocation; one atomic commit (code + `TECH.md` state). Subjects:
+  `[fix] Build logging-file-slot-reclaim P<n>: …`. **No `Co-Authored-By`.**
+- **No new CLI flag / config key** ⇒ no `docs/_include` / `share/` edits. R9 is prose in the
+  file-logging docs (not CLI help). Symbolic `errno.*`, never integer literals.
+- **Load-bearing safety invariant (R8): only ever `unlink` a sidecar while holding its `flock`.**
+  Audit every unlink site against it.
+- Add an **autouse fixture** in `tests/test_logging.py` that closes + clears the module global
+  `_slot_locks` after each test (prevents held-handle leakage / cross-test flakes).
 
 ---
 
-## Phase P1 — errno discrimination + degrade-to-canonical (core fix)
-**Satisfies:** R1, R2, R3, R5, R7, R8 · **Depends on:** —
-**Goal:** teach the slot machinery to tell a genuine lock *conflict* from *unavailable* locking,
-and on unavailable locking reuse-and-append the canonical per-host path instead of manufacturing
-a new file — curing the primary proliferation bug end to end.
+## Phase P1 — Self-describing sidecar record + errno discrimination + degrade
+**Satisfies:** R2, R7, R8 · **Depends on:** —
+**Goal:** the sidecar carries its owner's identity, and lock failures are classified so a lockless
+FS degrades to canonical-append instead of a per-PID file — foundational for P2/P3.
 
-- [ ] In `_try_lock` (`logging.py:669-677`), replace the bare `except OSError` with errno
-      classification: success → return handle; `errno ∈ {errno.EAGAIN, errno.EWOULDBLOCK}`
-      (i.e. `BlockingIOError`) → **CONFLICT** (return `None`, meaning "advance a slot");
-      `errno == errno.EINTR` → retry the same candidate; **any other** `OSError` → **UNSUPPORTED**
-      (signal the caller to stop walking — e.g. raise a small module-internal `_LockUnavailable`
-      or return a distinct sentinel). Use `getattr(errno, 'ENOTSUP', None)`-style guards only if
-      you enumerate names; the "everything else = unsupported" default avoids that.
-- [ ] Keep the `msvcrt` branch behavior as conflict-only (its `OSError` still means contended);
-      keep the `_LOCKING = False` guard.
-- [ ] In `claim_file_slot` (`logging.py:701-713`): on CONFLICT advance to the next `-N` slot
-      (unchanged); on the **first** UNSUPPORTED, or when `_LOCKING is False`, stop and return the
-      **canonical** (n=1) per-host path, emitting exactly one `warn(...)` that advisory locking is
-      unavailable so files are shared per host. Leave the genuine-exhaustion (all-100-CONFLICT)
-      branch returning the PID suffix — that is real 100-way concurrency where a distinct file is
-      correct. Remove the `_LOCKING=False` PID-suffix return in favor of the canonical degrade.
-- [ ] Update the false comment at `logging.py:660-666` to state the real contract (fall through
-      only on genuine contention; degrade to the shared canonical path when locking is
-      unavailable). Declarative statement of the invariant, no spec ids.
-- [ ] Confirm reclaim+append needs no code change: the handler already opens `mode='a'`
-      (`logging.py:377`); the degrade path returns the same canonical name → appends (R3).
-- [ ] Tests (`tests/test_logging.py`, `@mark.unit`): add the autouse `_slot_locks` cleanup
-      fixture. Patch `hypershell.core.logging.fcntl.flock` to raise `OSError(errno.ENOSYS)` and
-      `OSError(errno.ENOLCK)` → assert `claim_file_slot` returns the **canonical** path (degrade,
-      R5); raise `OSError(errno.EAGAIN)` → assert it returns `client-…-2.log` (conflict
-      fallthrough, R7); `monkeypatch.setattr('hypershell.core.logging._LOCKING', False)` → assert
-      canonical (R8). Add a repro/documentation test asserting the *old* behavior does not recur
-      (many generations under injected `ENOSYS` yield **one** canonical file, not a PID pile) — this
-      is the empirical half of R1 (and confirms local working-flock still reclaims via the existing
-      `test_slot_reclaimed_after_owner_dies`).
-- **Verify:** `uv run pytest -v tests/test_logging.py -k "slot or lock or degrade or unsupported"`
+- [ ] Rework `_try_lock` (`logging.py:669-694`): open the sidecar **non-truncating** (not
+      `mode='w'`); classify failure — `EAGAIN`/`EWOULDBLOCK` (`BlockingIOError`) → CONFLICT
+      (return `None` = advance); `EINTR` → retry; any other `OSError` → UNSUPPORTED (signal the
+      caller). Keep the `msvcrt` branch (conflict-only) and the `_LOCKING=False` guard.
+- [ ] On a won lock, write the owner record `{"v":1,"pid","create_time","host","instance"}` as a
+      single fixed-shape line + `flush()` (never `close()`). Add a reader `read_lock_record(path)`
+      opening `'r'`, tolerant of empty/legacy/torn (→ `None` = "no live holder"), with a
+      retry-once on parse failure.
+- [ ] Add a liveness helper `_owner_alive(record)` using `psutil.pid_exists` +
+      `psutil.Process(pid).create_time()` within a ~2s tolerance; treat `AccessDenied` as alive
+      (never steal); host-guard on `HOSTNAME_SHORT`. `psutil` is already a dep (`core/resource.py`).
+- [ ] `claim_file_slot` (`logging.py:701-713`): advance only on CONFLICT; on first UNSUPPORTED or
+      `_LOCKING is False`, return the **canonical** path (append) — remove the `<root>-<pid>`
+      returns at `:713` (keep PID-suffix only for genuine all-`EAGAIN` exhaustion). Fix the false
+      comment `:660-666`.
+- [ ] Tests (`@mark.unit`): autouse `_slot_locks` cleanup; patch `fcntl.flock` to inject
+      `ENOSYS`/`ENOLCK` (→ canonical) vs `EAGAIN` (→ `-2`); `_LOCKING=False` → canonical; record
+      round-trips and reads back; legacy 0-byte sidecar parses as no-holder.
+- **Verify:** `uv run pytest -v tests/test_logging.py -k "slot or lock or errno or degrade or record"`
 - **Touches:** `src/hypershell/core/logging.py`, `tests/test_logging.py`.
 
-## Phase P2 — Opportunistic orphan-slot reap
-**Satisfies:** R6, R4 · **Depends on:** P1
-**Goal:** the process that wins the canonical slot removes stale `-N.log` files whose owning
-process is gone, so the artifacts already accumulated on Gautschi get reclaimed — without racing
-live siblings or the rotation/compression machinery.
+## Phase P2 — Ephemeral sidecar lifecycle
+**Satisfies:** R3, R4, R5 · **Depends on:** P1
+**Goal:** sidecars are created while a client runs and removed when it stops — best-effort at
+clean shutdown, swept for crashes at startup — **never** touching `-N.log` data.
 
-- [ ] Add a helper `reap_orphan_slots(canonical_path)` that runs **only** when the caller won the
-      canonical (n=1) lock (one reaper per host). Enumerate `os.listdir(dirname)`, match the
-      **exact** slot shape via a compiled regex on the `basename_without_ext`-scoped prefix:
-      `^{re.escape(root_basename)}-([0-9]+){re.escape(ext)}$` (i.e. `client-<host>-<int>.log`),
-      mirroring `recover_interrupted_compression`'s prefix-scoping discipline (`logging.py:513-533`).
-- [ ] For each matched slot: `_try_lock(slot + '.lock')` — if it returns a handle (LOCKED →
-      orphan), `os.remove` the `-N.log` **data file** and release the probe handle; on CONFLICT
-      (live sibling) or UNSUPPORTED, skip. **Never** remove: the `.lock` sidecars (POSIX
-      inode-reuse race — see PLAN §5), the dot-separated rotation namespace
-      (`client-<host>.<N>` / `.YYYYMMDD` / `.YYYYMMDD-HHMMSS`), the freshly-claimed file, or
-      anything for the `main` role. Wrap `os.remove` to tolerate `FileNotFoundError`/`OSError`
-      (a racing reaper or a live writer).
-- [ ] Call the reaper from `initialize_logging` right where `recover_interrupted_compression`
-      runs (`logging.py:837`), guarded to fire only when the canonical slot was claimed. Keep it
-      before the compression thread does real work (invariant §5 — do not race `FILE_LOCK`).
-- [ ] Tests (`@mark.unit`): seed unlocked orphan `client-h-2.log`/`-3.log`, a *locked*
-      `client-h-4.log` (hold its sidecar flock in-test), rotated `client-h.1` /
-      `client-h.20260723`, and `main.log`; after a canonical claim assert only the unlocked
-      orphans are removed and everything else is retained.
-- **Verify:** `uv run pytest -v tests/test_logging.py -k "reap or orphan"`
+- [ ] **Shutdown drop (R3):** register a finalizer (an `atexit` hook when a slot is claimed and/or
+      an explicit `finalize_logging()` in the app stop path) that stops file logging (the
+      `QueueListener`) so no further writes, then for each `_slot_locks` handle: `unlink` the
+      sidecar **while holding the lock**, then `close`. Wrap best-effort (`try/except OSError`).
+- [ ] **Startup prune (R4):** only the process that wins the **canonical** slot scans sibling
+      sidecars matching the exact dash shape `^{re.escape(root)}-([0-9]+){re.escape(ext)}\.lock$`
+      (prefix-scoped like `recover_interrupted_compression`, `:513-533`). For each:
+      `flock(LOCK_EX|LOCK_NB)` — acquired ⇒ stale ⇒ `unlink` the **sidecar only** while holding
+      it, then release; blocked ⇒ live ⇒ skip. Use `read_lock_record`/`_owner_alive` for
+      diagnostics/logging, but the `flock`-acquire is the safety gate. Invoke beside
+      `recover_interrupted_compression` (`:837`), before the compression thread does real work (§5).
+- [ ] **R5 guard:** never `unlink`/rewrite `-N.log`, rotated (`client-h.<N>`/`.YYYYMMDD…`),
+      `.partial`, or `main`-role files. Add an assertion/test that data files survive a prune.
+- [ ] Tests (`@mark.unit`/`integration`): clean-exit path removes own sidecar; stale sibling
+      (dead PID, unlocked) removed; *held* sibling retained; `-N.log` + rotated + `main.log` all
+      survive; inode-reuse guard (never unlink an unlockable sidecar).
+- **Verify:** `uv run pytest -v tests/test_logging.py -k "sidecar or prune or ephemeral or shutdown"`
 - **Touches:** `src/hypershell/core/logging.py`, `tests/test_logging.py`.
 
-## Phase P3 — End-to-end bounded-count verification (CLI-driven)
-**Satisfies:** R4, R8 · **Depends on:** P1, P2
-**Goal:** prove, by driving the real CLI, that repeated client generations on one host converge
-to a bounded set of log files (no proliferation), and that cross-host / `main`-role behavior is
-unregressed.
+## Phase P3 — server/cluster fork fd-leak hardening
+**Satisfies:** R6 · **Depends on:** P1
+**Goal:** a forked queue-manager child no longer holds the parent's log-slot lock alive, so a
+killed `server`/`cluster` parent never ghost-locks its slot.
 
-- [ ] Add an `@mark.integration` test that, in an isolated `temp_site` with file logging enabled
-      (`HYPERSHELL_LOGGING_FILE=enabled`), runs several serial `hsx`/`hs cluster` generations and
-      asserts the count of `client-*.log` files stays bounded (does not grow with the generation
-      count). Reuse the `temp_site` fixture and the `main`/`main_lines` helpers.
-- [ ] Manually drive the flow once to confirm (record the command in the commit body):
-      `.agents/factory/bin/temp_site.sh sh -c "for i in 1 2 3; do seq 20 | uv run hsx -t 'echo {}' -N2 >/dev/null; done; find \"$HYPERSHELL_SITE\" -name 'client-*.log' | wc -l"`
-      — the count must not scale with the loop iterations.
-- [ ] Confirm no regression: full `uv run pytest -v tests/test_logging.py` stays green
-      (role mapping, host-scoping, `resolve_log_path` client decoration, crash-reclaim), and the
-      `main` role remains un-host-scoped and un-reaped.
+- [ ] In `core/queue.py`, close the inherited `_slot_locks` handles in the forked manager child
+      via the existing post-fork initializer seam (`_tls_bootstrap` path, ~`:243-281`) or
+      `os.register_at_fork(after_in_child=…)`. Import the logging handles list without creating an
+      import cycle (a small `hypershell.core.logging.close_inherited_slot_locks()` helper is
+      cleanest). No-op where there is no fork / on Windows. **Do not** touch RPC framing, TLS
+      context, authkey, or the handshake/fingerprint (high-blast-radius §16).
+- [ ] Note: `os.set_inheritable(False)` is useless here (exec-only; this is fork-without-exec).
+- [ ] Tests (`@mark.unit`, POSIX-only `skipif` Windows): a raw `os.fork()` after a claim — assert
+      the parent's `flock` is released once the parent closes iff the child closed its inherited
+      copy (the child-close is what P3 adds). Keep it `os.fork`, not `multiprocessing`, to isolate
+      the mechanism.
+- **Verify:** `uv run pytest -v tests/test_logging.py -k "fork or leak or inherit or manager"`
+- **Touches:** `src/hypershell/core/queue.py`, `src/hypershell/core/logging.py`, `tests/test_logging.py`.
+
+## Phase P4 — End-to-end bound + regression + docs note
+**Satisfies:** R1, R8, R9 · **Depends on:** P1, P2, P3
+**Goal:** prove the whole thing holds under real CLI drive, codify the behaviors that already
+work, and document the legitimate concurrency/rotation cases.
+
+- [ ] `@mark.integration` test in a `temp_site` (`HYPERSHELL_LOGGING_FILE=enabled`): repeated
+      serial `hsx` generations reclaim the canonical file and leave a bounded set of sidecars;
+      simulate concurrency and assert distinct `-N.log` files are created and their data is never
+      removed.
+- [ ] Regression (R1/R8): existing role/host-scope/`resolve_log_path`/reclaim tests stay green;
+      `main` un-host-scoped and un-pruned; cross-host isolation intact; no-lock/msvcrt fallbacks.
+- [ ] Manual CLI drive (record in commit body):
+      `.agents/factory/bin/temp_site.sh sh -c "HYPERSHELL_LOGGING_FILE=enabled; for i in 1 2 3; do seq 20 | uv run hsx -t 'echo {}' -N2 >/dev/null; done; find \"$HYPERSHELL_SITE\" -name '*.log.lock' | wc -l"`.
+- [ ] **Docs (R9):** in the file-based-logging docs, note (a) per-host `-N.log` under legitimate
+      same-host concurrency, (b) ephemeral, owner-stamped sidecars, (c) legitimate dangling
+      rotated leaves when revisiting a host at lower concurrency.
 - **Verify:** `uv run pytest -v -m integration tests/test_logging.py`
-- **Touches:** `tests/test_logging.py`.
+- **Touches:** `tests/test_logging.py`, `docs/…` (file-logging section).
 
 ---
 
 ## How `hs-build` drives this
 
-1. `next_phase.py` prints the next actionable phase (statuses are authoritative).
+1. `next_phase.py` prints the next actionable phase (statuses authoritative).
 2. Pre-flight: clean tree, on `fix/logging-file-slot-reclaim`, `develop` reachable.
-3. Execute every `[ ]` in the phase (consult `PLAN.md` / `research/` for detail).
-4. Run the phase's `verify:` command — never advance on a checkbox alone.
-5. Amend this file if reality diverges (regenerate frontmatter with `set_phase.py`); STOP and
-   escalate only on a `GOAL.md` contradiction (e.g. discovering a config knob is unavoidable).
-6. Mark the phase `done`, advance `current_phase`, `--touch`; one `[fix]` commit; stop and report.
+3. Execute every `[ ]` (consult `PLAN.md`/`research/09` for detail).
+4. Run the phase `verify:` — never advance on a checkbox alone.
+5. Amend this file if reality diverges (`set_phase.py`); STOP only on a `GOAL.md` contradiction.
+6. Mark phase `done`, advance `current_phase`, `--touch`; one `[fix]` commit; stop and report.
+   P3 touches high-blast-radius `core/queue.py` → expect a human review gate.

--- a/spec/logging-file-slot-reclaim/TECH.md
+++ b/spec/logging-file-slot-reclaim/TECH.md
@@ -6,7 +6,7 @@ appetite: small
 status: in_progress
 branch: fix/logging-file-slot-reclaim
 base: develop
-current_phase: P3
+current_phase: P4
 last_updated: '2026-07-23'
 phases:
 - id: P1
@@ -38,7 +38,7 @@ phases:
     or shutdown"
 - id: P3
   name: server/cluster fork fd-leak hardening (core/queue.py)
-  status: pending
+  status: done
   satisfies:
   - R6
   depends_on:
@@ -151,14 +151,14 @@ clean shutdown, swept for crashes at startup — **never** touching `-N.log` dat
 **Goal:** a forked queue-manager child no longer holds the parent's log-slot lock alive, so a
 killed `server`/`cluster` parent never ghost-locks its slot.
 
-- [ ] In `core/queue.py`, close the inherited `_slot_locks` handles in the forked manager child
+- [x] In `core/queue.py`, close the inherited `_slot_locks` handles in the forked manager child
       via the existing post-fork initializer seam (`_tls_bootstrap` path, ~`:243-281`) or
       `os.register_at_fork(after_in_child=…)`. Import the logging handles list without creating an
       import cycle (a small `hypershell.core.logging.close_inherited_slot_locks()` helper is
       cleanest). No-op where there is no fork / on Windows. **Do not** touch RPC framing, TLS
       context, authkey, or the handshake/fingerprint (high-blast-radius §16).
-- [ ] Note: `os.set_inheritable(False)` is useless here (exec-only; this is fork-without-exec).
-- [ ] Tests (`@mark.unit`, POSIX-only `skipif` Windows): a raw `os.fork()` after a claim — assert
+- [x] Note: `os.set_inheritable(False)` is useless here (exec-only; this is fork-without-exec).
+- [x] Tests (`@mark.unit`, POSIX-only `skipif` Windows): a raw `os.fork()` after a claim — assert
       the parent's `flock` is released once the parent closes iff the child closed its inherited
       copy (the child-close is what P3 adds). Keep it `os.fork`, not `multiprocessing`, to isolate
       the mechanism.

--- a/spec/logging-file-slot-reclaim/TECH.md
+++ b/spec/logging-file-slot-reclaim/TECH.md
@@ -63,10 +63,10 @@ phases:
   hill: uphill
   verify: uv run pytest -v -m integration tests/test_logging.py
 review:
-  last_reviewed_commit: ''
-  verdict: none
+  last_reviewed_commit: e9079df
+  verdict: approved
   blocked_reason: ''
-  cycle: 0
+  cycle: 1
 ---
 # TECH.md — Ephemeral log-lock sidecars + fd-leak/errno hardening
 

--- a/spec/logging-file-slot-reclaim/TECH.md
+++ b/spec/logging-file-slot-reclaim/TECH.md
@@ -3,10 +3,10 @@ slug: logging-file-slot-reclaim
 title: Ephemeral log-lock sidecars + fd-leak/errno hardening
 kind: fix
 appetite: small
-status: in_progress
+status: in_review
 branch: fix/logging-file-slot-reclaim
 base: develop
-current_phase: P4
+current_phase: done
 last_updated: '2026-07-23'
 phases:
 - id: P1
@@ -49,7 +49,7 @@ phases:
   verify: uv run pytest -v tests/test_logging.py -k "fork or leak or inherit or manager"
 - id: P4
   name: End-to-end bound + regression + docs note
-  status: pending
+  status: done
   satisfies:
   - R1
   - R8
@@ -170,15 +170,15 @@ killed `server`/`cluster` parent never ghost-locks its slot.
 **Goal:** prove the whole thing holds under real CLI drive, codify the behaviors that already
 work, and document the legitimate concurrency/rotation cases.
 
-- [ ] `@mark.integration` test in a `temp_site` (`HYPERSHELL_LOGGING_FILE=enabled`): repeated
+- [x] `@mark.integration` test in a `temp_site` (`HYPERSHELL_LOGGING_FILE=enabled`): repeated
       serial `hsx` generations reclaim the canonical file and leave a bounded set of sidecars;
       simulate concurrency and assert distinct `-N.log` files are created and their data is never
       removed.
-- [ ] Regression (R1/R8): existing role/host-scope/`resolve_log_path`/reclaim tests stay green;
+- [x] Regression (R1/R8): existing role/host-scope/`resolve_log_path`/reclaim tests stay green;
       `main` un-host-scoped and un-pruned; cross-host isolation intact; no-lock/msvcrt fallbacks.
-- [ ] Manual CLI drive (record in commit body):
+- [x] Manual CLI drive (record in commit body):
       `.agents/factory/bin/temp_site.sh sh -c "HYPERSHELL_LOGGING_FILE=enabled; for i in 1 2 3; do seq 20 | uv run hsx -t 'echo {}' -N2 >/dev/null; done; find \"$HYPERSHELL_SITE\" -name '*.log.lock' | wc -l"`.
-- [ ] **Docs (R9):** in the file-based-logging docs, note (a) per-host `-N.log` under legitimate
+- [x] **Docs (R9):** in the file-based-logging docs, note (a) per-host `-N.log` under legitimate
       same-host concurrency, (b) ephemeral, owner-stamped sidecars, (c) legitimate dangling
       rotated leaves when revisiting a host at lower concurrency.
 - **Verify:** `uv run pytest -v -m integration tests/test_logging.py`

--- a/spec/logging-file-slot-reclaim/TECH.md
+++ b/spec/logging-file-slot-reclaim/TECH.md
@@ -1,57 +1,73 @@
 ---
 slug: logging-file-slot-reclaim
-title: "Ephemeral log-lock sidecars + fd-leak/errno hardening"
+title: Ephemeral log-lock sidecars + fd-leak/errno hardening
 kind: fix
 appetite: small
 status: in_progress
 branch: fix/logging-file-slot-reclaim
 base: develop
-current_phase: P1
-last_updated: "2026-07-23"
+current_phase: P2
+last_updated: '2026-07-23'
 phases:
-  - id: P1
-    name: "Self-describing sidecar record + errno discrimination + degrade-to-canonical"
-    status: pending
-    satisfies: [R2, R7, R8]
-    depends_on: []
-    parallel: false
-    hammerable: false
-    hill: uphill
-    verify: "uv run pytest -v tests/test_logging.py -k \"slot or lock or errno or degrade or record\""
-  - id: P2
-    name: "Ephemeral sidecar lifecycle (shutdown drop + flock-guarded startup prune)"
-    status: pending
-    satisfies: [R3, R4, R5]
-    depends_on: [P1]
-    parallel: false
-    hammerable: false
-    hill: uphill
-    verify: "uv run pytest -v tests/test_logging.py -k \"sidecar or prune or ephemeral or shutdown\""
-  - id: P3
-    name: "server/cluster fork fd-leak hardening (core/queue.py)"
-    status: pending
-    satisfies: [R6]
-    depends_on: [P1]
-    parallel: false
-    hammerable: false
-    hill: uphill
-    verify: "uv run pytest -v tests/test_logging.py -k \"fork or leak or inherit or manager\""
-  - id: P4
-    name: "End-to-end bound + regression + docs note"
-    status: pending
-    satisfies: [R1, R8, R9]
-    depends_on: [P1, P2, P3]
-    parallel: false
-    hammerable: false
-    hill: uphill
-    verify: "uv run pytest -v -m integration tests/test_logging.py"
+- id: P1
+  name: Self-describing sidecar record + errno discrimination + degrade-to-canonical
+  status: done
+  satisfies:
+  - R2
+  - R7
+  - R8
+  depends_on: []
+  parallel: false
+  hammerable: false
+  hill: uphill
+  verify: uv run pytest -v tests/test_logging.py -k "slot or lock or errno or degrade
+    or record"
+- id: P2
+  name: Ephemeral sidecar lifecycle (shutdown drop + flock-guarded startup prune)
+  status: pending
+  satisfies:
+  - R3
+  - R4
+  - R5
+  depends_on:
+  - P1
+  parallel: false
+  hammerable: false
+  hill: uphill
+  verify: uv run pytest -v tests/test_logging.py -k "sidecar or prune or ephemeral
+    or shutdown"
+- id: P3
+  name: server/cluster fork fd-leak hardening (core/queue.py)
+  status: pending
+  satisfies:
+  - R6
+  depends_on:
+  - P1
+  parallel: false
+  hammerable: false
+  hill: uphill
+  verify: uv run pytest -v tests/test_logging.py -k "fork or leak or inherit or manager"
+- id: P4
+  name: End-to-end bound + regression + docs note
+  status: pending
+  satisfies:
+  - R1
+  - R8
+  - R9
+  depends_on:
+  - P1
+  - P2
+  - P3
+  parallel: false
+  hammerable: false
+  hill: uphill
+  verify: uv run pytest -v -m integration tests/test_logging.py
 review:
-  last_reviewed_commit: ""
+  last_reviewed_commit: ''
   verdict: none
-  blocked_reason: ""
+  blocked_reason: ''
   cycle: 0
 ---
-
 # TECH.md — Ephemeral log-lock sidecars + fd-leak/errno hardening
 
 Resume ground-truth is the YAML frontmatter (read with
@@ -85,22 +101,22 @@ Resume ground-truth is the YAML frontmatter (read with
 **Goal:** the sidecar carries its owner's identity, and lock failures are classified so a lockless
 FS degrades to canonical-append instead of a per-PID file — foundational for P2/P3.
 
-- [ ] Rework `_try_lock` (`logging.py:669-694`): open the sidecar **non-truncating** (not
+- [x] Rework `_try_lock` (`logging.py:669-694`): open the sidecar **non-truncating** (not
       `mode='w'`); classify failure — `EAGAIN`/`EWOULDBLOCK` (`BlockingIOError`) → CONFLICT
       (return `None` = advance); `EINTR` → retry; any other `OSError` → UNSUPPORTED (signal the
       caller). Keep the `msvcrt` branch (conflict-only) and the `_LOCKING=False` guard.
-- [ ] On a won lock, write the owner record `{"v":1,"pid","create_time","host","instance"}` as a
+- [x] On a won lock, write the owner record `{"v":1,"pid","create_time","host","instance"}` as a
       single fixed-shape line + `flush()` (never `close()`). Add a reader `read_lock_record(path)`
       opening `'r'`, tolerant of empty/legacy/torn (→ `None` = "no live holder"), with a
       retry-once on parse failure.
-- [ ] Add a liveness helper `_owner_alive(record)` using `psutil.pid_exists` +
+- [x] Add a liveness helper `_owner_alive(record)` using `psutil.pid_exists` +
       `psutil.Process(pid).create_time()` within a ~2s tolerance; treat `AccessDenied` as alive
       (never steal); host-guard on `HOSTNAME_SHORT`. `psutil` is already a dep (`core/resource.py`).
-- [ ] `claim_file_slot` (`logging.py:701-713`): advance only on CONFLICT; on first UNSUPPORTED or
+- [x] `claim_file_slot` (`logging.py:701-713`): advance only on CONFLICT; on first UNSUPPORTED or
       `_LOCKING is False`, return the **canonical** path (append) — remove the `<root>-<pid>`
       returns at `:713` (keep PID-suffix only for genuine all-`EAGAIN` exhaustion). Fix the false
       comment `:660-666`.
-- [ ] Tests (`@mark.unit`): autouse `_slot_locks` cleanup; patch `fcntl.flock` to inject
+- [x] Tests (`@mark.unit`): autouse `_slot_locks` cleanup; patch `fcntl.flock` to inject
       `ENOSYS`/`ENOLCK` (→ canonical) vs `EAGAIN` (→ `-2`); `_LOCKING=False` → canonical; record
       round-trips and reads back; legacy 0-byte sidecar parses as no-holder.
 - **Verify:** `uv run pytest -v tests/test_logging.py -k "slot or lock or errno or degrade or record"`

--- a/spec/logging-file-slot-reclaim/TECH.md
+++ b/spec/logging-file-slot-reclaim/TECH.md
@@ -1,0 +1,168 @@
+---
+slug: logging-file-slot-reclaim
+title: "Reclaim per-host log-file slots on shared HPC filesystems"
+kind: fix
+appetite: small
+status: in_progress
+branch: fix/logging-file-slot-reclaim
+base: develop
+current_phase: P1
+last_updated: "2026-07-23"
+phases:
+  - id: P1
+    name: "errno discrimination + degrade-to-canonical (core fix)"
+    status: pending
+    satisfies: [R1, R2, R3, R5, R7, R8]
+    depends_on: []
+    parallel: false
+    hammerable: false
+    hill: uphill
+    verify: "uv run pytest -v tests/test_logging.py -k \"slot or lock or degrade or unsupported\""
+  - id: P2
+    name: "Opportunistic orphan-slot reap"
+    status: pending
+    satisfies: [R6, R4]
+    depends_on: [P1]
+    parallel: false
+    hammerable: false
+    hill: uphill
+    verify: "uv run pytest -v tests/test_logging.py -k \"reap or orphan\""
+  - id: P3
+    name: "End-to-end bounded-count verification (CLI-driven)"
+    status: pending
+    satisfies: [R4, R8]
+    depends_on: [P1, P2]
+    parallel: false
+    hammerable: false
+    hill: uphill
+    verify: "uv run pytest -v -m integration tests/test_logging.py"
+review:
+  last_reviewed_commit: ""
+  verdict: none
+  blocked_reason: ""
+  cycle: 0
+---
+
+# TECH.md — Reclaim per-host log-file slots on shared HPC filesystems
+
+The **context engine and finite-state machine** for building this fix. The YAML frontmatter
+is the resume ground-truth (read it with
+`uv run python .agents/factory/bin/next_phase.py spec/logging-file-slot-reclaim/TECH.md`); the
+per-phase checklists below are the work.
+
+- **Vision / requirements (locked):** [`GOAL.md`](GOAL.md) — R-IDs are the contract.
+- **Authoritative design:** [`PLAN.md`](PLAN.md).
+- **Backing research:** [`research/00-digest.md`](research/00-digest.md) + briefs 01–03.
+
+## Conventions (apply to every phase)
+
+- Invariants and house style come from [`AGENTS.md`](../../AGENTS.md) /
+  [`invariants.md`](../../.agents/factory/invariants.md). The whole fix is contained to
+  `src/hypershell/core/logging.py` + `tests/test_logging.py`.
+- One phase per `hs-build` invocation; one atomic commit with **both** code and the `TECH.md`
+  state change. Subjects: `[fix] Build logging-file-slot-reclaim P<n>: …`. **No `Co-Authored-By`.**
+- **No new CLI flag or config key** (internal-only) ⇒ **no** `docs/_include` / `share/` edits
+  (invariant §12). If a phase discovers a knob is truly needed, STOP and escalate — it would
+  change scope and force companion doc/completion edits.
+- Use symbolic `errno.*` constants, never integer literals (numbers differ macOS↔Linux).
+- Add an **autouse fixture** in `tests/test_logging.py` (P1) that closes and clears the module
+  global `_slot_locks` after each test — otherwise held handles leak across tests and cause flakes.
+
+---
+
+## Phase P1 — errno discrimination + degrade-to-canonical (core fix)
+**Satisfies:** R1, R2, R3, R5, R7, R8 · **Depends on:** —
+**Goal:** teach the slot machinery to tell a genuine lock *conflict* from *unavailable* locking,
+and on unavailable locking reuse-and-append the canonical per-host path instead of manufacturing
+a new file — curing the primary proliferation bug end to end.
+
+- [ ] In `_try_lock` (`logging.py:669-677`), replace the bare `except OSError` with errno
+      classification: success → return handle; `errno ∈ {errno.EAGAIN, errno.EWOULDBLOCK}`
+      (i.e. `BlockingIOError`) → **CONFLICT** (return `None`, meaning "advance a slot");
+      `errno == errno.EINTR` → retry the same candidate; **any other** `OSError` → **UNSUPPORTED**
+      (signal the caller to stop walking — e.g. raise a small module-internal `_LockUnavailable`
+      or return a distinct sentinel). Use `getattr(errno, 'ENOTSUP', None)`-style guards only if
+      you enumerate names; the "everything else = unsupported" default avoids that.
+- [ ] Keep the `msvcrt` branch behavior as conflict-only (its `OSError` still means contended);
+      keep the `_LOCKING = False` guard.
+- [ ] In `claim_file_slot` (`logging.py:701-713`): on CONFLICT advance to the next `-N` slot
+      (unchanged); on the **first** UNSUPPORTED, or when `_LOCKING is False`, stop and return the
+      **canonical** (n=1) per-host path, emitting exactly one `warn(...)` that advisory locking is
+      unavailable so files are shared per host. Leave the genuine-exhaustion (all-100-CONFLICT)
+      branch returning the PID suffix — that is real 100-way concurrency where a distinct file is
+      correct. Remove the `_LOCKING=False` PID-suffix return in favor of the canonical degrade.
+- [ ] Update the false comment at `logging.py:660-666` to state the real contract (fall through
+      only on genuine contention; degrade to the shared canonical path when locking is
+      unavailable). Declarative statement of the invariant, no spec ids.
+- [ ] Confirm reclaim+append needs no code change: the handler already opens `mode='a'`
+      (`logging.py:377`); the degrade path returns the same canonical name → appends (R3).
+- [ ] Tests (`tests/test_logging.py`, `@mark.unit`): add the autouse `_slot_locks` cleanup
+      fixture. Patch `hypershell.core.logging.fcntl.flock` to raise `OSError(errno.ENOSYS)` and
+      `OSError(errno.ENOLCK)` → assert `claim_file_slot` returns the **canonical** path (degrade,
+      R5); raise `OSError(errno.EAGAIN)` → assert it returns `client-…-2.log` (conflict
+      fallthrough, R7); `monkeypatch.setattr('hypershell.core.logging._LOCKING', False)` → assert
+      canonical (R8). Add a repro/documentation test asserting the *old* behavior does not recur
+      (many generations under injected `ENOSYS` yield **one** canonical file, not a PID pile) — this
+      is the empirical half of R1 (and confirms local working-flock still reclaims via the existing
+      `test_slot_reclaimed_after_owner_dies`).
+- **Verify:** `uv run pytest -v tests/test_logging.py -k "slot or lock or degrade or unsupported"`
+- **Touches:** `src/hypershell/core/logging.py`, `tests/test_logging.py`.
+
+## Phase P2 — Opportunistic orphan-slot reap
+**Satisfies:** R6, R4 · **Depends on:** P1
+**Goal:** the process that wins the canonical slot removes stale `-N.log` files whose owning
+process is gone, so the artifacts already accumulated on Gautschi get reclaimed — without racing
+live siblings or the rotation/compression machinery.
+
+- [ ] Add a helper `reap_orphan_slots(canonical_path)` that runs **only** when the caller won the
+      canonical (n=1) lock (one reaper per host). Enumerate `os.listdir(dirname)`, match the
+      **exact** slot shape via a compiled regex on the `basename_without_ext`-scoped prefix:
+      `^{re.escape(root_basename)}-([0-9]+){re.escape(ext)}$` (i.e. `client-<host>-<int>.log`),
+      mirroring `recover_interrupted_compression`'s prefix-scoping discipline (`logging.py:513-533`).
+- [ ] For each matched slot: `_try_lock(slot + '.lock')` — if it returns a handle (LOCKED →
+      orphan), `os.remove` the `-N.log` **data file** and release the probe handle; on CONFLICT
+      (live sibling) or UNSUPPORTED, skip. **Never** remove: the `.lock` sidecars (POSIX
+      inode-reuse race — see PLAN §5), the dot-separated rotation namespace
+      (`client-<host>.<N>` / `.YYYYMMDD` / `.YYYYMMDD-HHMMSS`), the freshly-claimed file, or
+      anything for the `main` role. Wrap `os.remove` to tolerate `FileNotFoundError`/`OSError`
+      (a racing reaper or a live writer).
+- [ ] Call the reaper from `initialize_logging` right where `recover_interrupted_compression`
+      runs (`logging.py:837`), guarded to fire only when the canonical slot was claimed. Keep it
+      before the compression thread does real work (invariant §5 — do not race `FILE_LOCK`).
+- [ ] Tests (`@mark.unit`): seed unlocked orphan `client-h-2.log`/`-3.log`, a *locked*
+      `client-h-4.log` (hold its sidecar flock in-test), rotated `client-h.1` /
+      `client-h.20260723`, and `main.log`; after a canonical claim assert only the unlocked
+      orphans are removed and everything else is retained.
+- **Verify:** `uv run pytest -v tests/test_logging.py -k "reap or orphan"`
+- **Touches:** `src/hypershell/core/logging.py`, `tests/test_logging.py`.
+
+## Phase P3 — End-to-end bounded-count verification (CLI-driven)
+**Satisfies:** R4, R8 · **Depends on:** P1, P2
+**Goal:** prove, by driving the real CLI, that repeated client generations on one host converge
+to a bounded set of log files (no proliferation), and that cross-host / `main`-role behavior is
+unregressed.
+
+- [ ] Add an `@mark.integration` test that, in an isolated `temp_site` with file logging enabled
+      (`HYPERSHELL_LOGGING_FILE=enabled`), runs several serial `hsx`/`hs cluster` generations and
+      asserts the count of `client-*.log` files stays bounded (does not grow with the generation
+      count). Reuse the `temp_site` fixture and the `main`/`main_lines` helpers.
+- [ ] Manually drive the flow once to confirm (record the command in the commit body):
+      `.agents/factory/bin/temp_site.sh sh -c "for i in 1 2 3; do seq 20 | uv run hsx -t 'echo {}' -N2 >/dev/null; done; find \"$HYPERSHELL_SITE\" -name 'client-*.log' | wc -l"`
+      — the count must not scale with the loop iterations.
+- [ ] Confirm no regression: full `uv run pytest -v tests/test_logging.py` stays green
+      (role mapping, host-scoping, `resolve_log_path` client decoration, crash-reclaim), and the
+      `main` role remains un-host-scoped and un-reaped.
+- **Verify:** `uv run pytest -v -m integration tests/test_logging.py`
+- **Touches:** `tests/test_logging.py`.
+
+---
+
+## How `hs-build` drives this
+
+1. `next_phase.py` prints the next actionable phase (statuses are authoritative).
+2. Pre-flight: clean tree, on `fix/logging-file-slot-reclaim`, `develop` reachable.
+3. Execute every `[ ]` in the phase (consult `PLAN.md` / `research/` for detail).
+4. Run the phase's `verify:` command — never advance on a checkbox alone.
+5. Amend this file if reality diverges (regenerate frontmatter with `set_phase.py`); STOP and
+   escalate only on a `GOAL.md` contradiction (e.g. discovering a config knob is unavoidable).
+6. Mark the phase `done`, advance `current_phase`, `--touch`; one `[fix]` commit; stop and report.

--- a/spec/logging-file-slot-reclaim/TECH.md
+++ b/spec/logging-file-slot-reclaim/TECH.md
@@ -6,7 +6,7 @@ appetite: small
 status: in_progress
 branch: fix/logging-file-slot-reclaim
 base: develop
-current_phase: P2
+current_phase: P3
 last_updated: '2026-07-23'
 phases:
 - id: P1
@@ -24,7 +24,7 @@ phases:
     or record"
 - id: P2
   name: Ephemeral sidecar lifecycle (shutdown drop + flock-guarded startup prune)
-  status: pending
+  status: done
   satisfies:
   - R3
   - R4
@@ -127,20 +127,20 @@ FS degrades to canonical-append instead of a per-PID file — foundational for P
 **Goal:** sidecars are created while a client runs and removed when it stops — best-effort at
 clean shutdown, swept for crashes at startup — **never** touching `-N.log` data.
 
-- [ ] **Shutdown drop (R3):** register a finalizer (an `atexit` hook when a slot is claimed and/or
+- [x] **Shutdown drop (R3):** register a finalizer (an `atexit` hook when a slot is claimed and/or
       an explicit `finalize_logging()` in the app stop path) that stops file logging (the
       `QueueListener`) so no further writes, then for each `_slot_locks` handle: `unlink` the
       sidecar **while holding the lock**, then `close`. Wrap best-effort (`try/except OSError`).
-- [ ] **Startup prune (R4):** only the process that wins the **canonical** slot scans sibling
+- [x] **Startup prune (R4):** only the process that wins the **canonical** slot scans sibling
       sidecars matching the exact dash shape `^{re.escape(root)}-([0-9]+){re.escape(ext)}\.lock$`
       (prefix-scoped like `recover_interrupted_compression`, `:513-533`). For each:
       `flock(LOCK_EX|LOCK_NB)` — acquired ⇒ stale ⇒ `unlink` the **sidecar only** while holding
       it, then release; blocked ⇒ live ⇒ skip. Use `read_lock_record`/`_owner_alive` for
       diagnostics/logging, but the `flock`-acquire is the safety gate. Invoke beside
       `recover_interrupted_compression` (`:837`), before the compression thread does real work (§5).
-- [ ] **R5 guard:** never `unlink`/rewrite `-N.log`, rotated (`client-h.<N>`/`.YYYYMMDD…`),
+- [x] **R5 guard:** never `unlink`/rewrite `-N.log`, rotated (`client-h.<N>`/`.YYYYMMDD…`),
       `.partial`, or `main`-role files. Add an assertion/test that data files survive a prune.
-- [ ] Tests (`@mark.unit`/`integration`): clean-exit path removes own sidecar; stale sibling
+- [x] Tests (`@mark.unit`/`integration`): clean-exit path removes own sidecar; stale sibling
       (dead PID, unlocked) removed; *held* sibling retained; `-N.log` + rotated + `main.log` all
       survive; inode-reuse guard (never unlink an unlockable sidecar).
 - **Verify:** `uv run pytest -v tests/test_logging.py -k "sidecar or prune or ephemeral or shutdown"`

--- a/spec/logging-file-slot-reclaim/TECH.md
+++ b/spec/logging-file-slot-reclaim/TECH.md
@@ -3,7 +3,7 @@ slug: logging-file-slot-reclaim
 title: Ephemeral log-lock sidecars + fd-leak/errno hardening
 kind: fix
 appetite: small
-status: in_review
+status: done
 branch: fix/logging-file-slot-reclaim
 base: develop
 current_phase: done

--- a/spec/logging-file-slot-reclaim/research/00-digest.md
+++ b/spec/logging-file-slot-reclaim/research/00-digest.md
@@ -1,0 +1,117 @@
+# Research digest — logging-file-slot-reclaim
+
+Consolidated decisions from briefs [01](01-fs-lock-semantics.md) (FS lock semantics),
+[02](02-code-trace-signatures.md) (code trace + failure signatures),
+[03](03-fix-surface-and-tests.md) (fix surface + tests). Where briefs disagreed, the single
+recommendation is stated here.
+
+## Root cause (R1) — confirmed
+
+`_try_lock` (`core/logging.py:669-677`) catches a **bare `OSError`** from
+`fcntl.flock(LOCK_EX|LOCK_NB)` and returns `None`, which `claim_file_slot` treats as "slot
+contended → advance to the next `-N` slot." This **conflates two orthogonal outcomes**: a
+genuine lock *conflict* (a live sibling holds it) vs. locking being *unavailable/broken* on the
+filesystem. For a non-blocking flock, **only `EWOULDBLOCK`/`EAGAIN` means "a live sibling holds
+it"** (surfaced by Python as `BlockingIOError`, an `OSError` subclass). Every other errno means
+"no usable lock here."
+
+On the two Gautschi filesystems the non-contention errno is the *normal* case:
+- **Lustre `/scratch`** default mount is `noflock`; the Lustre manual states flock(2) then
+  returns **`ENOSYS`** on *every* call. → every generation, every candidate errors.
+- **NFS-exported ZFS `/home`** (default `local_lock=none`) emulates flock as a server-coordinated
+  POSIX byte-range lock; a disabled/flaky NLM (rpc.statd/lockd) returns **`ENOLCK`** ("a remote
+  locking protocol failed (e.g., locking over NFS)"). Even where NLM works, release-visibility
+  staleness can make a just-freed slot briefly appear held.
+
+Both are swallowed as "contended," so the canonical `client-<host>.log` is never reclaimed and
+files pile up. The in-source comment at `logging.py:663` — *"same-host advisory locks are
+reliable even on shared network filesystems"* — is the load-bearing false premise.
+
+**Does it reproduce locally?** No. On a working-flock FS (ext4/xfs/APFS/local ZFS) the OS
+releases the held flock on process exit, and the existing loop already reclaims the canonical
+slot and appends (`mode='a'`) — proven by `tests/test_logging.py::test_slot_reclaimed_after_owner_dies`.
+**The defect only surfaces where flock errors or goes stale**, which is why it shows up on the
+cluster and not on the maintainer's laptop.
+
+## Failure signature (to confirm against the real `ls` on Gautschi)
+
+Same defect, two distinguishable signatures (brief 02):
+- **Unsupported (Lustre `ENOSYS`, NFS `ENOLCK` every call):** all 100 candidates error →
+  loop exhausts → PID-suffix branch. On disk: a growing pile of non-sequential
+  `client-<host>-<pid>.log`, a **fixed 100** `.lock` sidecars, and an *"Exhausted 100 log-file
+  slots"* warning on **every** launch.
+- **Stale/spurious-conflict:** gen K lands on slot K → growing **sequential** `client-<host>-2.log`,
+  `-3.log`, … plus growing numbered `.lock` files, canonical present but never reused.
+
+Both are cured by the same fix. (A quick `ls "$log_dir"` on Gautschi will tell us which — useful
+confirmation, not a blocker.)
+
+## Second proliferation source (R5/R8)
+
+Both the `_LOCKING = False` branch and the "exhausted `max_slots`" branch currently return
+`f'{root}-{os.getpid()}{ext}'` — **one file per PID**. The no-locking fallback is itself a
+proliferation bug. Fix: the `_LOCKING = False` and *unsupported-errno* paths degrade to the
+**canonical** per-host path (reuse + append), not a PID suffix. (The genuine-exhaustion case —
+100 *real* concurrent live siblings — legitimately keeps the PID suffix; with errno
+discrimination, an unsupported FS degrades at n=1 and never reaches exhaustion, so that branch
+is now only ever hit by true 100-way concurrency, where a distinct file is the correct
+single-writer choice. This refines brief 03's "replace both PID-suffix returns".)
+
+## The fix (hybrid — resolves GOAL Q2 / R5) — all in `core/logging.py`, no new config knob
+
+1. **Discriminate errno in `_try_lock`** → three outcomes: LOCKED (return handle) / CONFLICT
+   (`errno ∈ {EAGAIN, EWOULDBLOCK}`, i.e. catch `BlockingIOError`) → advance the slot loop,
+   preserving strict single-writer (**R7**) / UNSUPPORTED (any other `OSError`) → stop walking.
+   Compare **symbolic `errno.*`** constants (numbers differ macOS↔Linux). `EINTR` → retry same
+   candidate. Keep the `msvcrt` branch (conflict-only discrimination) and the `_LOCKING=False`
+   guard.
+2. **Degrade to canonical on UNSUPPORTED / `_LOCKING=False`** — return the n=1 per-host path
+   (append), emit **one** warning that advisory locking is unavailable. Bounded to one file per
+   host; accepts possible interleave — exactly the GOAL's resolved R5 (**R5**, **R8**).
+3. **Reclaim canonical (R2/R3)** — the existing loop is already correct on working flock; the
+   degrade extends the same reuse-and-append behavior to lockless filesystems. No new mechanism.
+4. **Opportunistic orphan reap (R6)** — performed **only by the process that just won the
+   canonical (n=1) lock** (natural one-reaper-per-host serialization). Scan siblings matching the
+   **exact `-N` slot shape** (`client-<host>-<int>.log`); for each, `_try_lock` its sidecar — if
+   LOCKED it is an orphan → `os.remove` the orphaned `-N.log` data file; if CONFLICT/UNSUPPORTED,
+   skip. Mirror `recover_interrupted_compression`'s prefix-scoping discipline; **never** touch
+   rotated forms (`client-<host>.<N>` / `.YYYYMMDD`, dot-separated), the `.lock` sidecars, or the
+   `main` role.
+
+### The one real footgun (brief 03) — carried into design, not hand-waved
+
+Unlinking a `.lock` sidecar is a **POSIX inode-reuse race**: process A can hold `flock` on the
+old inode while B does `open(mode='w')` and gets a *new* inode + a *new*, independent lock →
+two writers to one log. **Decision:** reap only the `-N.log` **data** file (the real disk cost);
+**leave the 0-byte `.lock` sidecars** — their count is bounded once `-N` proliferation stops.
+(Reaping an orphan slot's *own* rotated children, e.g. `client-<host>-2.3`, and GC of stale
+sidecars are explicitly deferred — see GOAL Non-goals / this plan's Risks.)
+
+## Test technique (brief 03)
+
+- **Unit:** `monkeypatch.setattr('hypershell.core.logging.fcntl.flock', …)` (or patch `_try_lock`)
+  to raise `OSError(errno.EOPNOTSUPP)` / `OSError(errno.ENOSYS)` vs `OSError(errno.EAGAIN)`, and
+  assert the claim **degrades to canonical** vs **falls through to `-2`**. Toggle the no-lock
+  path via `monkeypatch.setattr('hypershell.core.logging._LOCKING', False)` (patch the **module
+  attribute**, not a test-module `from … import` copy).
+- **`_slot_locks` leaks:** it is a never-cleared module global; add an **autouse fixture** in
+  `test_logging.py` that closes handles and clears it after each test (existing tests only dodge
+  this via unique `tmp_path`).
+- **Reap:** seed orphan `-2.log`/`-3.log` (no live locker) → assert removed after a canonical
+  claim; seed a *locked* `-2.log` → assert retained; assert rotated (`client-host.1`,
+  `client-host.20260723`) and `main.log` untouched.
+- **Bound (R4) / integration:** N serial subprocess generations (or the CLI in `temp_site` with
+  `HYPERSHELL_LOGGING_FILE=enabled`) → `glob('client-*.log')` count stays bounded (==1 on the
+  degrade/reclaim path). Markers `@mark.unit` / `@mark.integration`.
+
+## Invariants (brief 02/03)
+
+- **§11** — no client-argv change: the log path is **not** forwarded to launched clients (all
+  three argv builders omit it; each client derives `client-<own-host>.log`). The whole fix lives
+  in `core/logging.py`; the per-mode argv builders are untouched.
+- **§5** — reap runs at claim time (in `initialize_logging`, beside `recover_interrupted_compression`);
+  it must touch only exact `-N.log`, never the rotation namespace managed under `FILE_LOCK` by the
+  compression thread, nor the freshly-claimed file.
+- **§12** — internal-only fix ⇒ **no** new config knob ⇒ no `docs/_include` / `share/` churn.
+- **R8** — keep `msvcrt`; `main` role stays un-host-scoped and un-reaped; degrade path is still
+  host-scoped, preserving cross-host safety.

--- a/spec/logging-file-slot-reclaim/research/00-digest.md
+++ b/spec/logging-file-slot-reclaim/research/00-digest.md
@@ -1,5 +1,12 @@
 # Research digest — logging-file-slot-reclaim
 
+> **⚠️ SUPERSEDED (2026-07-23).** This digest's root-cause theory (errno conflation / Lustre
+> `noflock`→`ENOSYS`→slot exhaustion) was **refuted by ground-truth evidence** from Gautschi:
+> `flock` acquire and reclaim+append work on both Lustre and ZFS, and the `-N.log` files were
+> **legitimate concurrent clients**, not a reclaim failure. See
+> [`09-revised-design.md`](09-revised-design.md) for the corrected diagnosis and the re-scoped
+> plan. Retained only as an audit trail of the initial (wrong) hypothesis.
+
 Consolidated decisions from briefs [01](01-fs-lock-semantics.md) (FS lock semantics),
 [02](02-code-trace-signatures.md) (code trace + failure signatures),
 [03](03-fix-surface-and-tests.md) (fix surface + tests). Where briefs disagreed, the single

--- a/spec/logging-file-slot-reclaim/research/01-fs-lock-semantics.md
+++ b/spec/logging-file-slot-reclaim/research/01-fs-lock-semantics.md
@@ -1,0 +1,131 @@
+# Filesystem advisory-lock semantics and log-slot proliferation
+
+## Summary
+
+The slot-claim code in `src/hypershell/core/logging.py` (`_try_lock` → `claim_file_slot`)
+catches a **bare `OSError`** from `fcntl.flock(LOCK_EX|LOCK_NB)` and collapses every failure
+into one meaning: "contended, try the next slot." That is wrong. For `LOCK_NB`, **only
+`EWOULDBLOCK`/`EAGAIN` means "a live sibling holds the lock."** Every other `OSError`
+(`ENOSYS`, `ENOLCK`, `EOPNOTSUPP`/`ENOTSUP`, `EINVAL`) means "locking is unavailable or
+failed on this filesystem" — a condition under which falling through to a new slot is exactly
+the wrong response. On Lustre and NFS-backed filesystems these non-contention errnos are the
+normal case, which is why the canonical `client-<host>.log` is never reclaimed and `.lock` /
+`-N.log` files grow without bound.
+
+The in-source comment (logging.py:663) — *"same-host advisory locks are reliable even on
+shared network filesystems"* — is the load-bearing false assumption. It is false on **both**
+of Gautschi's filesystems, for two *different* reasons.
+
+## How Python surfaces each errno
+
+`fcntl.flock()` raises `OSError` on any failure
+(https://docs.python.org/3/library/fcntl.html). The concrete subclass is chosen by errno:
+`OSError`'s constructor "often actually returns a subclass … depend[ing] on the final errno"
+and **`BlockingIOError` corresponds to `EAGAIN`, `EALREADY`, `EWOULDBLOCK`, `EINPROGRESS`**
+(https://docs.python.org/3/library/exceptions.html). So genuine contention arrives as a
+`BlockingIOError` (itself an `OSError`); unsupported/failed-locking arrives as a plain
+`OSError` with a different `.errno`. Empirically confirmed on this macOS host: a contended
+`flock(LOCK_EX|LOCK_NB)` raises `BlockingIOError`, `errno == EAGAIN (35)`, and here
+`EWOULDBLOCK == EAGAIN`. **errno *numbers* differ across OSes** (macOS `ENOSYS`=78, `ENOLCK`=77,
+`EOPNOTSUPP`=102, `ENOTSUP`=45; Linux `ENOSYS`=38, `ENOLCK`=37, `EOPNOTSUPP`=95, `EAGAIN`=`EWOULDBLOCK`=11)
+— so any fix MUST compare symbolic `errno.*` constants, never integer literals.
+
+## Filesystem × flock behavior × errno
+
+| Filesystem / mount | flock(LOCK_EX\|LOCK_NB) behavior | errno on failure | Reclaim safe? |
+|---|---|---|---|
+| Local (ext4/xfs/APFS, ZFS-on-Linux local) | Works; genuine advisory lock | `EWOULDBLOCK`/`EAGAIN` only when truly held | Yes — fall-through = real contention |
+| **Lustre, default (`noflock`)** | **Disabled entirely; call is rejected** | **`ENOSYS`** (every call, always) | **No** — never contention |
+| Lustre `-o localflock` | Node-local kernel locks; reliable same-host | `EWOULDBLOCK`/`EAGAIN` | Yes |
+| Lustre `-o flock` | Cluster-coherent across clients (NLM-like overhead) | `EWOULDBLOCK`/`EAGAIN` | Yes |
+| NFS, default (`local_lock=none`) | flock **emulated as whole-file fcntl byte-range lock**, coordinated to the server via NLM/NFSv4 — NOT node-local | `EWOULDBLOCK`/`EAGAIN` if held; **`ENOLCK` if the remote lock protocol fails** | Only if NLM healthy |
+| NFS `local_lock=flock` / `=all` | flock handled node-locally | `EWOULDBLOCK`/`EAGAIN` | Yes |
+| NFS < 2.6.11 | flock was local-scope only (historical) | — | n/a on modern kernels |
+| Windows (`msvcrt.locking`) | byte-range lock | `OSError` (`EACCES`/`EDEADLOCK`) on contention | separate taxonomy needed |
+
+**Lustre (authoritative, Lustre Operations Manual §40.4 / mount.lustre, https://doc.lustre.org/lustre_manual.xhtml):**
+- `flock` — "Enables advisory file locking support … using the flock(2) system call. This
+  causes file locking to be coherent across all client nodes also using this mount option …
+  imposes communications overhead."
+- `localflock` — "Enables client-local flock(2) support, using only client-local advisory
+  file locking. This is faster … for applications that … run only on a single node. It has
+  minimal overhead using only the Linux kernel's locks."
+- `noflock` — **"Disables flock(2) support entirely, and is the default option. Applications
+  calling flock(2) get an ENOSYS error."**
+
+**NFS (nfs(5), https://man7.org/linux/man-pages/man5/nfs.5.html; flock(2),
+https://man7.org/linux/man-pages/man2/flock.2.html):**
+- Since Linux 2.6.12, "NFS clients support flock() locks by emulating them as fcntl(2)
+  byte-range locks on the entire file" (flock.2).
+- `local_lock` = `none` (the default): "the client assumes that the locks are not local" —
+  i.e. flock is coordinated to the server, **not** node-local (nfs.5). It can be forced
+  node-local with `local_lock=flock`/`all`.
+- **`ENOLCK` = "Too many segment locks open, lock table is full, or a remote locking protocol
+  failed (e.g., locking over NFS)"** (fcntl(2),
+  https://manpages.ubuntu.com/manpages/jammy/man2/fcntl.2.html). This is the errno a flaky/
+  disabled NLM (rpc.statd/lockd) or a lock-averse export produces.
+- NFSv4 lock-staleness footgun: pre-3.12 an NFSv4 client that lost contact "might lose and
+  regain a lock without ever being aware"; ≥3.12 subsequent I/O fails until reopen
+  (`nfs.recover_lost_locks`) — relevant to same-node release *visibility* delays (fcntl(2) NOTES).
+
+**flock vs POSIX (fcntl/lockf F_SETLK) on network FS (Q5):** flock is tied to the *open file
+description* (survives `fork`, released on last close); POSIX `F_SETLK` locks are per-process
+and are **released when the process closes *any* fd referring to the file**, and are not
+inherited across `fork` (fcntl.2). Over NFS the "native" coordinated lock is the POSIX one
+(flock is merely emulated on top of it), so `fcntl`/`lockf` is marginally more portable on
+NFS — but on Lustre-default **both are governed by the same `flock` mount option and both fail
+with `ENOSYS`**, so switching lock APIs does not rescue Lustre. ZFS-on-Linux is an in-kernel
+POSIX filesystem and supports flock/fcntl locally via the standard VFS lock layer; when a ZFS
+dataset is the backing store for an NFS-exported HPC `/home`, **the client sees NFS lock
+semantics, not ZFS's** — so the NFS row above governs `/home`.
+
+## errno-classification recommendation
+
+Replace the bare `except OSError` with errno inspection:
+
+- **"Genuinely held by a live sibling → advance to the next slot":** `errno` in
+  `{EWOULDBLOCK, EAGAIN}` — equivalently, catch `BlockingIOError`. This is the *only* class
+  that should ever trigger fall-through to `-N.log`.
+- **"Advisory locking unavailable/unreliable on this FS → do NOT walk slots":**
+  `errno` in `{ENOSYS, ENOLCK, EOPNOTSUPP, ENOTSUP, EINVAL, EPERM, EACCES}`. On the *first*
+  such result, stop iterating and return the **canonical** path (n==1) directly (best-effort
+  single-writer, accepting the lock is a no-op), rather than manufacturing 100 `.lock` files
+  and a PID-suffixed log. Optionally emit one `warn` that locking is unsupported.
+- **Transient:** `EINTR` → retry the same candidate.
+- **Portability:** compare `e.errno` against `errno.*` symbolic names (numbers differ
+  macOS↔Linux); guard `ENOTSUP`/`EOPNOTSUPP` with `getattr(errno, 'ENOTSUP', None)` since
+  they are not universally distinct. Windows (`msvcrt`) needs its own contention-vs-error
+  discrimination.
+
+## Why this explains proliferation on BOTH ZFS and Lustre
+
+The bug is a **one-way collapse of two orthogonal outcomes into one branch.** `claim_file_slot`
+walks `client-<host>.log`, `-2.log`, …, taking the "first lockable slot," and treats *any*
+`OSError` as "this slot is taken."
+
+- **Lustre `/scratch` (default `noflock`):** *every* `flock` call returns **`ENOSYS`**, on
+  *every* candidate, for *every* process generation. The loop therefore rejects all 100 slots
+  and falls to the `-<pid>.log` branch — so no process ever "holds" the canonical slot, the
+  canonical name is never reclaimed, and each process spawns fresh `.lock` + PID-suffixed
+  files. Unbounded growth, exactly as observed.
+- **ZFS `/home` (NFS-exported):** with the default `local_lock=none`, flock is emulated as a
+  server-coordinated POSIX byte-range lock; when NLM (rpc.statd/lockd) is disabled, unhealthy,
+  or the export is lock-averse, the call returns **`ENOLCK`** ("a remote locking protocol
+  failed (e.g., locking over NFS)"). `_try_lock` again reads this as "contended," walks and
+  fails all slots, and PID-suffixes — same unbounded growth, different errno. (Even where NLM
+  works, cross-node/same-node release-visibility staleness can make a just-freed canonical
+  slot briefly appear held, pushing new processes onto `-N.log` and defeating reclaim.)
+
+Both filesystems break the same invariant — that a failed `LOCK_NB` means "a live sibling has
+it" — but via `ENOSYS` (unsupported) and `ENOLCK` (protocol failure), neither of which is
+contention. Because the code cannot tell "no lock service here" from "lock is held," it
+manufactures a new file on every launch. Distinguishing the errno classes (fall through only
+on `EWOULDBLOCK`/`EAGAIN`; otherwise reuse the canonical path) is the fix.
+
+### Sources
+- flock(2): https://man7.org/linux/man-pages/man2/flock.2.html
+- fcntl(2) (ENOLCK, NFS notes): https://manpages.ubuntu.com/manpages/jammy/man2/fcntl.2.html · https://man7.org/linux/man-pages/man2/fcntl.2.html
+- nfs(5) (local_lock): https://man7.org/linux/man-pages/man5/nfs.5.html
+- Lustre Operations Manual (flock/localflock/noflock, default=noflock→ENOSYS): https://doc.lustre.org/lustre_manual.xhtml
+- Python `fcntl`: https://docs.python.org/3/library/fcntl.html
+- Python exceptions (BlockingIOError↔EAGAIN/EWOULDBLOCK; OSError errno→subclass): https://docs.python.org/3/library/exceptions.html

--- a/spec/logging-file-slot-reclaim/research/02-code-trace-signatures.md
+++ b/spec/logging-file-slot-reclaim/research/02-code-trace-signatures.md
@@ -1,0 +1,122 @@
+# Code Trace & Failure Signatures — per-host log-slot reclaim
+
+All line refs are `src/hypershell/core/logging.py` unless noted.
+
+## 1. Full call trace (process start → resolved log path)
+
+Role is declared by the entry point, never sniffed from argv:
+
+- `main(argv)` (`__init__.py:136`) →
+  `initialize_logging(role=role_from_command(argv[0] if argv else None))` (`__init__.py:139`).
+  `main_x` prepends `cluster`, so `hsx` → role `cluster`.
+- `role_from_command(cmd)` (`:649`): returns `cmd` if it is in
+  `DISTRIBUTED_ROLES = {server, cluster, client, submit}` (`:646`), else `DEFAULT_ROLE='main'` (`:645`).
+- `initialize_logging(role)` (`:730`, guarded once by `_INIT`) computes
+  `default_file = default_file_for(role)` (`:744`).
+- `default_file_for(role)` (`:654`): `main` → `main.log`; any distributed role →
+  `<role>-<HOSTNAME_SHORT>.log` under `default_path.log`
+  (platform Logs dir, `core/platform.py:54-99`). So a launched client → `client-<host>.log`.
+- If file logging is enabled, `resolve_log_path(path, role, is_default)` (`:716`, called `:757`/`:771`).
+  For `role=='client'` **and** a non-default explicit path it host-decorates:
+  `…-client-<host>.log` (`:718-722`); the default is already host-scoped. Then →
+  `claim_file_slot(path)` (`:701`).
+- `claim_file_slot` (`:701`): `os.makedirs(dir)`, then for `n` in `1..max_slots(100)`:
+  candidate = `path` (n==1) else `<root>-<n><ext>`; call `_try_lock(candidate + '.lock')` (`:708`).
+  First non-None handle → append to `_slot_locks` (held for process life) and return candidate.
+  Loop exhausted → `warn("Exhausted 100 log-file slots … using PID suffix")` (`:712`) and return
+  `<root>-<pid><ext>` (`:713`).
+- `_try_lock(path)` (`:669` fcntl branch): `handle = open(path, mode='w')` (**truncates the sidecar**),
+  then `fcntl.flock(fileno, LOCK_EX|LOCK_NB)`; on success return handle, on **any** `OSError`
+  `handle.close(); return None` (`:675-677`). msvcrt branch is analogous; if neither imports,
+  `_LOCKING=False` and `claim_file_slot` skips locking entirely, always returning `<root>-<pid><ext>`.
+
+The returned path becomes `TimedRotatingFileHandler`/`SizeRotatingFileHandler.filename`; the actual
+`.log` file is created lazily (`delay=True`, `:377`) only for the **returned** path — probed-but-not-won
+slots never get a `.log`, only a `.lock`.
+
+**Root flaw:** `except OSError:` (`:675`) cannot distinguish a genuine lock **conflict**
+(`EAGAIN`/`EWOULDBLOCK`) from lock being **unsupported/broken** (`ENOSYS`/`EOPNOTSUPP`/`ENOLCK`/`EINVAL`,
+common on Lustre without `-o flock`, some ZFS/NFS setups). Both map to "slot taken."
+
+## 2. Failure-signature table (N serial generations, one host)
+
+### Theory A — flock raises OSError on EVERY candidate (unsupported FS)
+Every candidate 1..100 errors identically → loop always exhausts → PID fallback.
+- Per process: creates **100 `.lock` sidecars** (`client-host.lock`, `-2.lock`…`-100.lock`), emits the
+  **"Exhausted 100 log-file slots … using PID suffix" WARNING** (to stderr; file handler not yet attached),
+  writes exactly one real log `client-host-<pid>.log`.
+- Canonical `client-host.log` is **never created**; no sequential `-N.log` files are created (numbered
+  slots only get `.lock`, never `.log`).
+- Across N gens: `.lock` count stays **fixed at 100** (deterministic names, re-`open('w')`-truncated each
+  time); `client-host-<pid>.log` grows by 1 per generation.
+- **Signature: dominated by non-sequential `-<pid>.log` files + a constant 100 `.lock` files + a warning
+  on every launch.** Real (unbounded) proliferation, but of PID-suffixed logs, not `-2/-3` logs.
+
+### Theory B — flock succeeds, but a released lock is not seen as released (stale / spurious EAGAIN)
+Gen K sees slots `1..K-1` as still "held" (stale) and acquires slot K.
+- Gen 1 → `client-host.log`; Gen 2 → `client-host-2.log`; … Gen K → `client-host-<K>.log`.
+- Across N gens: `.lock` files `client-host.lock`…`client-host-<N>.lock` (**N, growing**) + real logs
+  `client-host.log`, `-2.log`…`-N.log` (**N, growing**). Canonical is created by gen 1 and **never reclaimed**.
+  Once N>100, the warning + PID suffix also kick in.
+- **Signature: dominated by SEQUENTIAL `-N.log` files + growing numbered `.lock` files, canonical present.**
+  This matches the reported symptom ("canonical never reclaimed; `.lock` and `-N.log` accumulate") most literally.
+
+### Theory C — flock is a working node-local lock that always succeeds/releases (e.g. Lustre `localflock`)
+Acquire and **release** both work on the local node. Serial gens on one host: gen1 holds `client-host.log`,
+exits → OS releases → gen2 reclaims `client-host.log`.
+- Only ever `client-host.log` + `client-host.lock` (both reused). **No proliferation — does NOT reproduce
+  the bug.** (localflock's only hazard is cross-node contention on the *same* filename, which the host-scoped
+  default filename already precludes.)
+
+**Assessment:** the user's literal wording matches **Theory B**. Theory A also yields unbounded proliferation
+but is distinguishable: PID-valued (not sequential) suffixes, a fixed 100 `.lock` files, and a per-launch
+"Exhausted…" warning. Both A and B are the *same* code defect (`except OSError` conflating error with
+conflict); the discriminator to confirm with the user's real `ls` is: sequential `-2/-3.log` + growing lock
+count (B) vs. big-number `-<pid>.log` + exactly 100 locks + warning spam (A).
+
+## 3. Reclaim analysis (working FS — apfs/ext4/xfs)
+On a filesystem where flock is correct, reclaim works and there is **no bug**. Reasoning from code: the held
+handle lives only in `_slot_locks` (`:698`, `:710`) for the life of the process; on exit (clean or crash) the
+OS drops the flock. A later same-host generation restarts the loop at n=1, `_try_lock('client-host.lock')`
+succeeds (the sidecar file persists but is unlocked), and the canonical slot is returned again. This is
+asserted by `tests/test_logging.py::test_slot_reclaimed_after_owner_dies` (`:91-106`): while an owner lives a
+peer is pushed to `client-2.log`; after the owner dies, a new claim returns `client.log`. So locally the
+canonical slot **is** reclaimed — the defect only surfaces where flock errors or goes stale.
+
+## 4. Cleanup gap
+Nothing in the module ever deletes `.lock` sidecars or reclaims/removes orphaned `-N.log`/`-<pid>.log` slot
+files. The only deletion path is `compress_file` → `files_eligible_for_deletion` (`:334`, `:488-491`), which
+(a) only runs when compression is enabled (`COMPRESSION_MODE is not None`) and (b) only matches **rotation**
+artifacts via `search_files` (`:309`) whose regex is `re_pattern_count` = `prefix\.([0-9]+)ext` (`:230`) — i.e.
+`client-host.<N>` with a **dot** (rotation counter), never `client-host-<N>.log` with a **dash** (slot suffix).
+Slot files and `.lock` files are therefore invisible to pruning. `recover_interrupted_compression` (`:513`)
+only touches `.partial` files. **No `.lock` is ever unlinked.**
+
+`open(path, mode='w')` truncating the sidecar each attempt (`:671`) is **harmless for data** (the `.lock`
+file has no contents — it is a pure flock target), but it is the mechanism that **creates** an orphan `.lock`
+for every probed slot (the file springs into existence as a side effect of the failed probe). Using
+`O_CREAT` without truncate would not change accumulation; the real fix must both (a) not treat unsupported
+flock as a conflict and (b) clean up / not leave sidecars for slots never won.
+
+## 5. Process lifecycle facts (feeds invariant §11: no shared client-argv builder)
+- **Many client generations per host under autoscaling.** `AutoScaler.scale()`
+  (`cluster/remote.py:531-536`) runs `Popen(self.launcher)` — a full
+  `<launcher(srun/mpirun/…)> … hyper-shell client …` (built once at `remote.py:832-836`) — every time
+  pressure/INIT demands growth, over the whole run. Clients self-exit on idle (the autoscaler never kills
+  them; `clean()` at `:542` only `poll()`s and reaps PIDs). Scale-to-zero then scale-up means the **same
+  physical hosts host many serial client generations** → the exact serial-reclaim path that Theories A/B break.
+- **Clean exit → OS releases flock.** Client shutdown is FSM-driven: schedulers/executors/collector/heartbeat
+  each `machine.halt()` in `stop()` (`client.py:286,425,955,1060`) and the process exits normally, so on a
+  working FS the flock is released and the slot reclaimable (§3). On a broken FS the *lock* mechanism is what
+  fails, not the exit.
+- **No log path is forwarded to launched clients.** All three argv builders omit any `--log-*`/path:
+  - `RemoteCluster` (`remote.py:303-306`) and `AutoScalingCluster` (`remote.py:832-836`):
+    `… client -H <HOSTNAME> -p <port> -N -b -w -t <template> -k <auth> -d -S [<client_args>]`.
+  - `SSHCluster` (`ssh.py:296-306`): per-host `… <remote_exe> client -H <HOSTNAME> …`.
+  - `LocalCluster` embeds threads in-process (no client argv).
+  `client_args` only ever carries `--no-confirm/--capture/--monitor/-C/-M/-T/-W/-R/--no-tls` — never a log
+  path. So **every launched client independently derives `client-<its-own-host>.log`** via
+  `role_from_command('client')`. Cross-host names differ (host in filename); the proliferation is purely the
+  **same-host serial-generation reclaim failure**. A fix that adds/forward a logging flag must be replicated
+  across `local.py`/`remote.py` (×2)/`ssh.py` (§11: no shared client-argv builder), but the cleaner fix keeps
+  path derivation client-side and repairs `_try_lock`/reclaim/cleanup in `core/logging.py` alone.

--- a/spec/logging-file-slot-reclaim/research/03-fix-surface-and-tests.md
+++ b/spec/logging-file-slot-reclaim/research/03-fix-surface-and-tests.md
@@ -1,0 +1,55 @@
+# Research 03 — Fix surface, reap/reclaim algorithm, and test approach
+
+Scope: `src/hypershell/core/logging.py` slot machinery + `tests/test_logging.py`. Read-only survey for `/hs-plan`.
+
+## 1. The fix surface (exact mechanics)
+
+Names, as the code actually builds them (path = `client-a123.log`, `root='client-a123'`, `ext='.log'`):
+
+- **Canonical slot (n=1):** `client-a123.log`; lock sidecar `client-a123.log.lock`.
+- **Fallthrough slots (n≥2):** `client-a123-2.log`, … ; sidecar `client-a123-2.log.lock` (`.lock` appended to the *full* name incl. `.log`).
+- **Rotated files** strip the last ext (`basename_without_ext`) → `client-a123.1` / `.20260723` / `.20260723-140000` (+ compression ext). Each slot has its **own** rotation namespace (`client-a123-2.1`).
+
+**`claim_file_slot` (L701-713)** loops n=1..max_slots, calls `_try_lock(candidate + '.lock')` (L671/684: `open(mode='w')` on the *sidecar* — never touches the `.log`; keeps the handle in module-global `_slot_locks` for process life so the OS releases on crash). First lockable candidate wins.
+
+**Key finding — R2/R3 already work on POSIX.** The FileHandler opens `mode='a', delay=True` (L377). When a previous owner dies the OS drops its `flock`, so the next process's `_try_lock('client-a123.log.lock')` succeeds → returns the canonical path → appended to. The existing integration test `test_slot_reclaimed_after_owner_dies` proves this. So R2/R3 need **no new mechanism on filesystems where `flock` works** — the bug is elsewhere.
+
+**Root cause (R1).** `_try_lock` catches **all** `OSError` and returns `None` — it conflates a *conflict* (live owner) with an *unsupported/errored* lock (Lustre mounted without `-o flock`, which raises `EOPNOTSUPP`/`ENOSYS`/`EINVAL`). Every generation then errors on n=1, falls through to a fresh `-N` slot → unbounded proliferation, plus a matching pile of `.lock` sidecars. Note: Lustre `-o localflock` (node-local locks) is actually *sufficient* for us — hostname is baked in, so we only ever need same-host locks. The failure is the *no-flock* case.
+
+**Second proliferation source (R5/R8).** Both the `_LOCKING = False` branch (L694→713) and the "exhausted max_slots" branch (L712-713) return `f'{root}-{os.getpid()}{ext}'` — **one file per PID**. The no-locking fallback is itself a proliferation bug the fix must close.
+
+**Collision check (safe):** `client-a123.log.lock` is never numeric/date, so it cannot match `re_pattern_count/date/datetime` — `search_files(canonical)` ignores it. Slot `client-a123-2.log` (`-2.log`) also never matches `client-a123\.([0-9]+)` (needs a literal `.` then digits), so canonical rotation never sees sibling slots. Reap logic must therefore key off the distinct **`-N` slot** shape, not the rotation regex.
+
+## 2. Recommended reap/reclaim algorithm shape
+
+1. **Discriminate errno in `_try_lock`** — return three outcomes: LOCKED (handle) / CONFLICT / UNSUPPORTED. Treat `{EAGAIN, EWOULDBLOCK}` (and EACCES) as CONFLICT (live owner → keep the fallthrough → **R7**); everything else (`EOPNOTSUPP, ENOTSUP, ENOSYS, EINVAL, ENOLCK, EROFS`) as UNSUPPORTED. `msvcrt` branch: keep as conflict-only.
+2. **On UNSUPPORTED (or `_LOCKING=False`): degrade to the canonical per-host path** (reuse + append). Bounded to one file/host; accepts possible interleave — exactly the GOAL's resolved R5 choice. Replaces both PID-suffix returns.
+3. **Reclaim canonical (R2/R3):** unchanged loop — already correct on working `flock`; degrade extends it to Lustre.
+4. **Opportunistic reap (R6), performed only by the process that just acquired the *canonical* lock** (natural single-reaper-per-host serialization). For each sibling matching the exact `-N` slot shape: `_try_lock(slot + '.lock')` → if LOCKED (orphan) remove the orphaned `-N.log`; if CONFLICT/UNSUPPORTED, skip. **Never** touch rotated forms (`prefix.N`/`prefix.YYYYMMDD`) or the `main` role — mirror `recover_interrupted_compression`'s `prefix = basename_without_ext + '.'` prefix-scoping discipline (L513-533).
+
+**Race to flag for the plan author (do not hand-wave):** unlinking a `.lock` sidecar is a POSIX inode-reuse footgun — process A can hold `flock` on the old inode while B does `open(mode='w')` and gets a *new* inode + a *new* independent lock → two writers. Safest: **reap the `-N.log` data file (the real disk cost) and leave/limit the 0-byte `.lock` sidecars** (their count is bounded once `-N` proliferation stops), or unlink `.lock` only while holding its `flock` and accept the residual small window. Also a scope gap: an orphan `-N.log`'s *own* rotated children (`client-a123-2.3`) are also orphaned; reaping just the bare slot is the minimum for `appetite=small`.
+
+## 3. R5 mechanism recommendation
+
+**Recommend option (iii) hybrid = errno-discrimination + degrade-to-canonical, with (ii) opportunistic reap layered on.** Rationale: (i) alone (degrade) fixes the ongoing Lustre bleed with minimal code and honors R7 where locking works; (ii) alone can't help when locking is genuinely broken (can't prove orphan-vs-live). The hybrid keeps distinct files + strict single-writer where `flock` works, and collapses to one reused file where it doesn't. Decision is the plan author's + human's per GOAL Q2. Flag: no new config knob is *needed* — the whole fix is internal (errno + degrade + reap), so it avoids the §12 docs/_include + `share/` completions burden. A knob (`logging.file.lock = auto|off`) is optional and would force those companion edits in-commit; recommend against for a small fix.
+
+## 4. Test approach
+
+**Existing coverage (`tests/test_logging.py`):** role mapping, host-scoping, `resolve_log_path` client decoration, `claim_file_slot` within-process disambiguation (unit, skip if `not _LOCKING`), and the crash-reclaim integration test (`_HOLDER` subprocess via `Popen`, reads claimed path on stdout, asserts contention→slot-2 then reclaim after `terminate()`). Tests **call `claim_file_slot` directly** already.
+
+**Simulating a lockless/erroring FS (the key technique):**
+- Unit: `monkeypatch.setattr('hypershell.core.logging._try_lock', fake)` — model an in-memory `name→owner` dict so no real fds leak; assert claim degrades to canonical vs. falls through per outcome.
+- To test the *discrimination* itself: patch `fcntl.flock` to `raise OSError(errno.EOPNOTSUPP, ...)` vs `OSError(errno.EAGAIN, ...)` and assert claim returns canonical (degrade) vs `-2` (conflict fallthrough).
+- No-locking branch: `monkeypatch.setattr('hypershell.core.logging._LOCKING', False)` — note the test module's top-level `from ... import _LOCKING` is a *separate binding*; patch the **module attribute**, not the imported copy; skip/guards read the copy.
+
+**File-count assertions after N generations:** cleanest is N sequential subprocess spawns (lock auto-released at exit) asserting only `client.log` survives (POSIX reclaim). For the Lustre degrade path, either inject the errno via an env var the fake `_try_lock` reads in the child, or assert in-process with the monkeypatched fake and `glob('client-*.log')` count == 1.
+
+**`_slot_locks` global leak — cleanup required.** `_slot_locks` (L698) accumulates handles and is **never cleared**; in-process "owner-died-then-reclaim" tests must release (close handles + clear the list) in teardown. Recommend an autouse fixture in `test_logging.py` that snapshots and closes `_slot_locks` after each test. Existing tests dodge this only because each uses a unique `tmp_path`.
+
+**Markers:** `@mark.unit` for monkeypatched errno/degrade/reap logic; `@mark.integration` for subprocess crash-reclaim and real-CLI emission (`temp_site` + `HYPERSHELL_LOGGING_FILE=enabled`, glob for the file).
+
+## 5. Invariants / risks
+
+- **§5 (compression thread + `FILE_LOCK`):** reap runs at claim time (in `initialize_logging`, alongside `recover_interrupted_compression` at L837). Reap must touch only exact `-N.log`/`-N.log.lock`, never `prefix.N`/`prefix.YYYYMMDD` rotated files (managed under `FILE_LOCK` by the compression thread), and never the process's own newly-claimed files.
+- **§12:** internal-only fix ⇒ no docs/completions churn. Confirm before adding any knob.
+- **R8:** keep the `msvcrt` branch; `main` role stays un-host-scoped and un-reaped; degrade path is still host-scoped (`path` is already `client-<host>.log`), preserving cross-host safety.

--- a/spec/logging-file-slot-reclaim/research/04-evidence-forensics.md
+++ b/spec/logging-file-slot-reclaim/research/04-evidence-forensics.md
@@ -1,0 +1,214 @@
+# Research 04 — Evidence forensics & hypothesis disambiguation
+
+Scope: reconcile the committed (now-**refuted**) ENOSYS/exhaustion diagnosis with the
+maintainer's real on-disk evidence from Gautschi, decide which hypotheses the evidence
+*excludes* vs *permits*, and hand the maintainer a short list of decisive, low-effort
+diagnostics. All line refs are `src/hypershell/core/logging.py` unless noted. **The source is
+read-only; this brief changes no behavior.** Do **not** resurrect the ENOSYS theory — the disk
+evidence refutes it (§2).
+
+## 0. The evidence (verbatim on-disk signature)
+
+After a short (~few minute) autoscaling run, on **both** `/scratch` (Lustre) and `/home`
+("POSIX-ish" ZFS, `~/.hypershell/log`):
+
+```
+client-a261.log      client-a261.log.lock
+client-a306.log      client-a306.log.lock
+client-a306-2.log    client-a306-2.log.lock
+cluster-login01.log  cluster-login01.log.lock
+main.log             main.log.lock
+submit-a068.log      submit-a068.log.lock
+```
+
+Maintainer's five facts: (i) **no** PID-suffixed files; (ii) **no** ~100-`.lock` pile;
+(iii) **no** "Exhausted … slots" warning; (iv) a **sequential** `-2` slot on a306; (v) the
+process that got `client-a306.log` **won slot-1's flock** (clean canonical name, no PID);
+(vi) behavior is **identical** on Lustre and ZFS. Plus a longitudinal claim: over *longer*
+runs the `-N.log`/`.lock` set "proliferates" and slot 1 is "never reclaimed."
+
+## 1. What each artifact *proves* (decode against the code)
+
+The claim loop (`claim_file_slot`, `:701-713`) starts every process at `n=1`, calls
+`_try_lock(candidate + '.lock')` (`:708`), and returns the **first candidate whose flock
+succeeds**. The `.log` itself is opened lazily (`delay=True`, `:377`) **only for the returned
+(won) path** — a probed-but-lost slot ever only gets a `.lock`, never a `.log` (`research/02 §1`).
+
+Therefore, mechanically:
+
+- **`client-a306.log` exists with a clean (no-PID) name** ⇒ some process's
+  `_try_lock('client-a306.log.lock')` **returned a handle** ⇒ `fcntl.flock(LOCK_EX|LOCK_NB)`
+  **succeeded** on this filesystem. flock **acquire works** on both Lustre and ZFS. (Fact v.)
+- **`client-a306-2.log` exists as a real `.log` (not just a `.lock`)** ⇒ slot 2 was **won and
+  written**, which only happens after `_try_lock` on slot 1 returned `None` (a real CONFLICT →
+  `BlockingIOError`/`EAGAIN`, `:675`) *and then* slot 2's flock **succeeded**. So the code both
+  **detects contention** and **acquires the next slot** correctly here.
+- **No `client-a306-<pid>.log`** ⇒ the PID-suffix branch (`:712-713`) was **never taken** ⇒
+  neither genuine 100-way exhaustion nor the `_LOCKING=False` path fired.
+- **No 100-`.lock` pile** (`client-a306-2.log.lock … -100.log.lock`) ⇒ the loop **never walked
+  past a couple of slots**. Every failed probe would `open(path,'w')` and thereby *create* a
+  sidecar (`:671`, `research/02 §4`), so a full 1..100 walk would leave exactly 100 sidecars.
+  We see 2. The loop stopped at 2 because slot 2 was **won**, not errored.
+- **No "Exhausted … slots" warning** (`:712`) ⇒ the loop terminated by *winning* a slot, never
+  by falling off the end.
+
+These five deductions are mutually reinforcing and all point one way: **flock ACQUIRE and
+CONFLICT-detection are functioning on both filesystems.** That single conclusion is what
+demolishes the committed diagnosis.
+
+## 2. Hypothesis matrix — consistent vs excluded
+
+| Hypothesis | Verdict vs the `ls` | Why (what it would leave on disk) |
+|---|---|---|
+| **refuted-ENOSYS** (every flock errors → exhaust 100 → PID suffix) | **EXCLUDED** | Predicts PID-suffixed logs, a fixed **100** `.lock` sidecars, an "Exhausted" warning **per launch**, and **no** clean canonical `.log` (the canonical name is never *returned*, so its `delay=True` `.log` is never created). The disk shows the exact opposite on all four counts (facts i–iii, v). Contradicted, not merely unsupported. |
+| **H-conc** (≥2 genuinely concurrent client processes on a306) | **CONSISTENT — leading** | Working flock + a live slot-1 holder ⇒ a concurrent peer gets `EAGAIN` on slot 1 and correctly wins `-2` (**R7 behaving as designed**). Produces precisely {clean canonical + one sequential `-2`, no PID, no 100-pile, no warning}. FS-independent (needs only acquire+conflict, which fact v confirms work). a261 = 1 rank, a306 = 2 ranks explains the asymmetry directly. |
+| **H-leak** (an inherited flock fd outlives its owner) | **CONSISTENT on disk, but code-grounded UNLIKELY on the client** | Same disk signature as H-conc (a stale fd looks like a live sibling → next gen pushed to `-2`, slot 1 "never reclaimed"), and FS-independent. **But** the client's own code has *no fork-without-exec vector* (§3): a remote `hyper-shell client` only **connects** to the queue (`client.py:1219`; `QueueClient.connect`→`BaseManager.connect`, `core/queue.py:421-427`) — it never `.start()`s a manager, and every child it spawns **execs** (`Popen(shell=True)`, `client.py:772`, default `close_fds=True`) so the CLOEXEC sidecar fd is dropped. Kept live because a site launcher/wrapper or a not-yet-found `multiprocessing.Process` could still inherit it; diagnostic (d) settles it. |
+| **H-stale** (network-FS lock release not *seen* as released) | **CONSISTENT on Lustre only; EXCLUDED as the *common* cause** | Would give the same sequential-`-N` picture, but it is intrinsically **FS-semantic** (NFS/NLM release-visibility lag; NFSv4 lock recovery — `research/01`). Fact (vi): identical behavior on a **local-POSIX ZFS**, where a dead process's flock is dropped *immediately and coherently*, means staleness cannot be the mechanism on the ZFS half. A single cause that fits both halves cannot be release-staleness. (Caveat below.) |
+| **H-bug** (some other reclaim bug in our code) | **CONSISTENT (weak) — catch-all** | The reclaim loop restarts at `n=1` and returns the first lockable slot, so with working flock + a dead prior owner it *does* reclaim (proven by `test_slot_reclaimed_after_owner_dies`, `tests/test_logging.py:91-106`). No obvious defect; retained only as the residue if (a)–(e) exonerate conc/leak/stale. |
+
+### The FS-independence argument (made explicit)
+
+refuted-ENOSYS and H-stale are the only **filesystem-semantic** hypotheses: each depends on a
+*specific* FS's flock implementation (Lustre `noflock`→ENOSYS; NFS→ENOLCK/NLM staleness). The
+maintainer reports an **identical** signature on two filesystems with **different** flock
+implementations — a network Lustre and a "POSIX-ish" ZFS. A common cause therefore cannot be a
+property of either one's flock quirk; it must live *above* the FS layer, in the
+**process/lock lifecycle** — i.e. H-conc or H-leak (or H-bug), all of which need only that
+flock *acquire* + *conflict-detect* work, which fact (v) independently confirms they do.
+
+**Caveat that gates this deduction (→ diagnostic e).** The argument assumes `/home` ZFS has
+*working, local* flock. If `/home` turns out to be **NFS-exported** ZFS (as `research/01`
+speculated), then it too is a network FS and H-stale re-enters for *both* halves. Confirming
+the ZFS mount (local dataset vs NFS export, and its `flock`/`local_lock` options) is a
+**prerequisite** for trusting FS-independence. The maintainer's own framing ("POSIX-ish ZFS"
+vs "network Lustre") suggests local, but this must be verified, not assumed.
+
+### The one datum that splits the surviving field
+
+The snapshot alone **cannot** separate H-conc, H-leak, and H-stale — all three yield
+{clean canonical + sequential `-2`, no PID, no pile, no warning}. The decisive question is
+**longitudinal**: do `-N` files stay **bounded by peak concurrency** (⇒ H-conc + a cleanup
+gap: working-as-designed, files merely never consolidated/reaped) or do they **grow past** any
+plausible concurrency on a node that runs few clients at once (⇒ a genuine **reclaim failure** =
+H-leak or H-stale)? Diagnostics (a)–(d) answer exactly this.
+
+## 3. Why H-leak is code-grounded *unlikely on the client* (but not dismissed)
+
+- `initialize_logging` (`:730`) runs from `main()` at `__init__.py:139`, opening the flock'd
+  sidecar fd **before** any thread/subprocess exists — the necessary precondition for an
+  inheritance leak.
+- **BUT** the fd is non-inheritable: `open(path,'w')` (`:671`) sets `O_CLOEXEC` by default
+  (PEP 446), and there is **no** `os.set_inheritable`/`close_fds`/CLOEXEC override anywhere in
+  `src/hypershell/` (grep: none). So any child that **execs** loses it: task subprocesses
+  (`Popen(shell=True)`, default `close_fds=True`, `client.py:772`) and the site launcher
+  (`srun`/`mpirun`, exec'd) all drop it.
+- The only fork-**without**-exec in the package is `QueueServer.start()` →
+  `BaseManager.start()` (`core/queue.py:373-385`), which spawns a manager process (on Linux,
+  `fork` start-method inherits fds *despite* CLOEXEC, since no exec occurs). **That is the
+  server/cluster side** and would inherit the *server/cluster* role's fd — not a client slot.
+  A remote client (`client.py:1219`) only **connects** and drives daemon **threads**
+  (`.start()` at `client.py:1263-1267` are `Thread`s, not `Process`es) — **no client-side
+  fork**. Hence no obvious mechanism to leak `client-a306.log.lock` into a surviving process.
+
+Conclusion: H-leak fits the disk and the FS-independence, but the client code as written does
+not supply the fd-inheritance path, so it drops below H-conc in priority. Diagnostic (d)
+(`lsof`/`fuser` on the sidecar of a *dead* client) is a direct yes/no test and cheap — run it
+regardless, because it is the *only* hypothesis whose confirmation would change the fix
+(reclaim can't work while a zombie fd pins the lock).
+
+## 4. Decisive, low-effort diagnostics (ordered)
+
+Run in this order; each is a few minutes and most are one-liners. For each: what result
+confirms/denies which hypothesis.
+
+**(a) Timestamp overlap between `client-a306.log` and `client-a306-2.log`** *(most decisive)*.
+Compare the **first and last** log-record timestamps inside each file (the `%(asctime)s` field;
+`head -1` / `tail -1`, or `sort` the datetime column).
+  - **OVERLAPPING** time ranges (both files have records in the same wall-clock window) ⇒ two
+    clients were **alive simultaneously** ⇒ **H-conc / working-as-designed**; the only bug is
+    non-consolidation + non-reap.
+  - **DISJOINT / strictly sequential** (a306-2 begins only after a306's last record — or worse,
+    a306 stops early and every later generation writes to a306-2) ⇒ **reclaim failure**
+    (H-leak or H-stale), because a *serial* successor should have re-won slot 1, not slot 2.
+
+**(b) Peak client concurrency per node the autoscaler actually launches.** Inspect the launcher
+argv / autoscaler config: `srun`'s `--ntasks-per-node` / `mpirun -n` mapping, and
+`AutoScalingCluster` growth (`cluster/remote.py:533` `Popen(self.launcher)`; launcher built at
+`remote.py:832-836`). Cross-check against the **max `-N`** seen for any host.
+  - max `-N` **==** peak concurrent ranks/generations on that node ⇒ **H-conc** (bounded,
+    correct-by-design).
+  - max `-N` **≫** any plausible concurrency (e.g. `-7` on a node that runs ≤2 at once) ⇒
+    **reclaim failure** (H-leak/H-stale/H-bug).
+
+**(c) Two-serial-process flock reclaim probe, on BOTH Lustre and ZFS.** A ~10-line script:
+proc-1 `flock`s `probe.lock` (`LOCK_EX|LOCK_NB`), prints "held", **exits**; then proc-2
+`flock`s the *same* path and prints whether it acquired. Run once under `/scratch`, once under
+`/home`.
+  - gen-2 **acquires** (reclaims) on both ⇒ raw flock reclaim is healthy ⇒ the failure is
+    **above** the FS (H-conc or a leak/bug *in our process model*), not the FS itself.
+  - gen-2 **fails/blocks** on Lustre but **succeeds** on ZFS ⇒ **H-stale** on the Lustre half,
+    and the ZFS half needs a *different* explanation (H-conc/H-leak) — i.e. two causes.
+  - gen-2 fails on **both** ⇒ re-open the FS-semantic angle for both (and re-check mount, (e)).
+
+**(d) After a client exits, is its `.lock` still flock-held by a *live* pid?** On the compute
+node, once a client that owned `client-a306.log` has exited, run
+`lsof client-a306.log.lock` (or `fuser client-a306.log.lock`).
+  - **A live pid still holds it** (especially a pid ≠ the dead client — a parent shepherd, a
+    forked helper, a lingering task) ⇒ **H-leak confirmed** (an inherited OFD pins the flock;
+    the kernel releases only when *all* fds to that OFD close). This directly answers the
+    user's Q1 (today we track no PIDs — flock is the only signal; `lsof` is how you'd learn who
+    holds it) and would justify tracking/verifying the holder in the fix.
+  - **No process holds it, yet a fresh client still lands on `-2`** ⇒ **not** a leak → H-stale
+    (network visibility) or H-bug.
+
+**(e) Mount / flock options for both filesystems** *(prerequisite for the FS-independence
+claim)*. `/scratch`: `mount | grep lustre` and `lctl get_param llite.*...` (look for
+`flock`/`localflock`/`noflock`). `/home`: `mount | grep home`; if NFS, `nfsstat -m` (inspect
+`local_lock=`), and whether it is a **local ZFS dataset** or an **NFS export**.
+  - Lustre shows `flock`/`localflock` (not `noflock`) ⇒ consistent with fact (v) (acquire
+    works) and definitively buries refuted-ENOSYS.
+  - `/home` is a **local** ZFS mount ⇒ FS-independence (§2) holds ⇒ H-stale excluded as common
+    cause. `/home` is **NFS-exported** ⇒ FS-independence weakens; keep H-stale live for both.
+
+## 5. Local test-suite reproducibility
+
+`tests/test_logging.py` (read in full):
+
+- **CAN reproduce today.** `test_slot_reclaimed_after_owner_dies` (`:91-106`) Popens a
+  `_HOLDER` (`:30-35`) that only `claim_file_slot`s and sleeps; it proves, on the dev FS
+  (APFS/local), that flock **acquire + conflict (`-2`) + release-on-death + canonical reclaim**
+  all work. `test_claim_file_slot_disambiguates_within_process` (`:80-87`) proves in-process
+  conflict fallthrough. The committed PLAN P1 also plans **errno injection** — patch
+  `fcntl.flock` to raise `OSError(errno.ENOSYS/ENOLCK/EAGAIN)` — which deterministically
+  exercises the code's *response* to each errno class.
+- **CANNOT reproduce.** (1) **Real** Lustre `noflock`/ENOSYS or NFS ENOLCK/NLM **staleness** —
+  no such FS in CI; errno injection tests our *reaction*, not the FS's true behavior, so
+  H-stale is not falsifiable locally. (2) **H-leak** is *not* covered: `_HOLDER` neither forks
+  nor starts multiprocessing, so no fd is inherited; the existing test structurally cannot
+  surface an inheritance leak. It *is* locally constructible with a **new** probe — a parent
+  that claims a slot then `multiprocessing.get_context('fork').Process(...)` spawns a child that
+  inherits the fd and outlives the parent; assert the slot is **not** reclaimed. (Force `fork`
+  explicitly: macOS defaults to `spawn`, and Python 3.14 moves Linux toward `forkserver` — both
+  re-exec and would *not* inherit, masking the very bug.) (3) The **autoscaler multi-rank-per-
+  node** launch (H-conc's premise) isn't exercised; PLAN P3's serial-generation CLI count test
+  approximates the *serial* half but not true same-node concurrency.
+
+## 6. Summary (~200 words)
+
+The committed ENOSYS/exhaustion diagnosis is **refuted by construction**: a clean, no-PID
+`client-a306.log` can only exist if `flock(LOCK_EX|LOCK_NB)` on its sidecar **succeeded**, and a
+real `client-a306-2.log` requires a genuine CONFLICT on slot 1 followed by a successful acquire
+on slot 2. The disk shows no PID files, no 100-`.lock` pile, and no "Exhausted" warning — the
+exact opposite of what an unsupported-flock FS would leave. flock **acquire and conflict-detect
+work on both filesystems**. Because the *identical* signature appears on a network Lustre and a
+"POSIX-ish" ZFS, the cause is **filesystem-independent** — it lives in the process/lock
+lifecycle, not FS flock quirks — which excludes H-stale as the *common* cause (Lustre-only at
+most) and leaves **H-conc (leading: `-2` = a legitimate concurrent rank, working-as-designed)**
+and **H-leak (an inherited flock fd outliving its owner — disk-consistent but code-grounded
+unlikely, since the client only *connects* and all its children *exec* a CLOEXEC fd)**. The
+snapshot can't split them; the **longitudinal** question does. Run, in order: (a) timestamp
+overlap between a306 and a306-2, (b) peak ranks/generations per node vs max `-N`, (c) a
+two-serial-process flock reclaim probe on both FSes, (d) `lsof`/`fuser` on a dead client's
+`.lock`, (e) confirm mount/`flock` options (and whether `/home` is local ZFS or NFS —
+prerequisite for the FS-independence claim). Overlap + bounded `-N` ⇒ H-conc + cleanup gap;
+disjoint + a live fd-holder ⇒ H-leak.

--- a/spec/logging-file-slot-reclaim/research/05-process-model-audit.md
+++ b/spec/logging-file-slot-reclaim/research/05-process-model-audit.md
@@ -1,0 +1,110 @@
+# Research 05 — Process-model / FD-inheritance lock-leak audit (H-leak)
+
+## SUMMARY (verdict up front)
+
+**H-leak does NOT explain the observed `client-<host>` proliferation, but it is a real *latent*
+bug for the `server`/`cluster` roles.**
+
+`initialize_logging()` runs in `main()` (`__init__.py:139`) — *before* any subcommand dispatch —
+so the flock'd slot fd from `_try_lock`'s `open(path,'w')` (`logging.py:671`) is open before any
+process creation. `open()` fds carry `O_CLOEXEC` (PEP 446), which closes on **exec** but **not on
+fork**.
+
+There is exactly **one fork-without-exec** in the codebase: `QueueServer.start()`
+(`queue.py:385`) → `SecureManager.start` → `BaseManager.start()`, which spawns the manager
+subprocess via multiprocessing's default context. No `set_start_method` exists anywhere (grep), so
+on the Linux HPC target the method is **`fork`** (default through 3.13; 3.14 flips to `forkserver`).
+The forked manager child runs a pure-Python loop (no exec) and therefore **inherits and shares the
+role's log-slot OFD**, so that flock is released only when *both* parent and manager child close it.
+This fires only in roles that run a `QueueServer`: `server`, `cluster`, and in-process
+`RemoteCluster`/`AutoScalingCluster` (`remote.py:312` → `server.py:845 with self.queue:`).
+
+**The client never forks a manager** — it uses `QueueClient.connect()` (`client.py:1219`, no fork);
+its executors/collector/heartbeat are threads; its only child processes are task subprocesses
+(`client.py:772 Popen(shell=True)`, default `close_fds=True` + exec) which drop the fd. So a
+standalone/launched `hs client` holds its `client-<host>.log.lock` OFD solely in itself; on exit the
+kernel drops the flock. FD inheritance therefore **cannot** cause non-reclaim of client slots — that
+symptom points at H-conc (≥2 concurrent clients/host) and/or H-stale. The manager-child leak only
+threatens `server`/`cluster` slots, and only when that child is orphaned (parent SIGKILL/OOM). The
+evidence (clean `cluster-login01.log`, no `-2`) shows clean shutdowns normally release it.
+
+---
+
+## 1. WHEN `initialize_logging()` runs vs. process creation
+
+- `main()` calls `initialize_logging(role=role_from_command(argv[0]...))` at
+  **`__init__.py:139`**, *then* `register_handlers()` (`:140`), *then* `HyperShellApp.main(argv)`
+  (`:141`). `main_x`/`hsx` (`__init__.py:146`) prepends `cluster` and routes through `main`.
+- Consequence: the slot fd is acquired **before** any subcommand runs, hence **before** every
+  `Popen`/fork below. Any fork that happens during a subcommand inherits an already-open slot fd.
+- The lock fd is created by `_try_lock`: `handle = open(path, mode='w')` (**`logging.py:671`**),
+  `fcntl.flock(handle.fileno(), LOCK_EX|LOCK_NB)` (`:673`). The handle is appended to the
+  module-global `_slot_locks` (`logging.py:698`, `:710`) and **held for the life of the process** —
+  never closed. There is only one live-ness signal: the flock on that OFD.
+
+## 2. Python defaults that matter here
+
+- **PEP 446:** fds from `open()` are non-inheritable (kernel `O_CLOEXEC` / `FD_CLOEXEC` set).
+  `O_CLOEXEC` acts on **exec only**; a plain **fork** leaves the fd open in the child, and the child
+  **shares the same OFD**. A flock is a property of the OFD and is released only when **all** fds
+  referring to it are closed. So a fork-without-exec descendant keeps the flock alive after the
+  logical owner exits.
+- **`subprocess.Popen` defaults `close_fds=True`** → in the child, fds ≥3 (except stdio/`pass_fds`)
+  are closed before exec; combined with `O_CLOEXEC` this guarantees the slot fd is gone in any
+  exec'd child.
+- **multiprocessing default start method** (no override in this repo): Linux `fork` through 3.13
+  (3.14 → `forkserver`); macOS/Windows `spawn`. `fork` is the leak-relevant case and is the Gautschi
+  (Linux) default.
+
+## 3. Fork/exec inventory after logging init
+
+| Site | Mechanism | Execs? | Inherits slot fd past owner? |
+|------|-----------|--------|------------------------------|
+| `queue.py:385` `BaseManager.start()` (via `QueueServer.start`) | multiprocessing `fork` (Linux) | **No** (Python loop) | **YES — shares the role's slot OFD** |
+| `client.py:772` task `Popen(shell=True)` | fork+exec, `close_fds=True` | Yes | No (closed at exec) |
+| `remote.py:314` `Popen(client_argv)` (RemoteCluster) | fork+exec, default `close_fds` | Yes | No |
+| `remote.py:533` `Popen(launcher)` (AutoScaler.scale) | fork+exec, default `close_fds` | Yes | No |
+| `ssh.py:311` `Popen(ssh argv)` (SSHCluster) | fork+exec, default `close_fds` | Yes | No |
+| `config.py:91`, `template.py:201` | fork+exec | Yes | No |
+
+Only the multiprocessing `BaseManager` child fork-without-exec retains the fd.
+
+## 4. Role-by-role
+
+- **`server`:** `initialize_logging('server')` claims `server-<host>.log.lock`; `ServerThread`
+  runs `with self.queue:` (`server.py:845`) → `QueueServer.start()` (`queue.py:385`) forks the
+  manager child, which **inherits `server-<host>.log.lock`'s OFD**. Released on clean shutdown when
+  BaseManager terminates the child; leaked if the child is orphaned (parent SIGKILL/OOM).
+- **`cluster` (Local):** single process, role `cluster`. Server runs in-process, so the same
+  BaseManager fork inherits `cluster-<host>.log.lock`. Clients here are **threads**, so there is
+  **no** `client-<host>.log` from `LocalCluster` at all.
+- **`cluster` (Remote/AutoScaling):** cluster process runs `ServerThread` in-process (same manager
+  fork, inherits `cluster-<host>.log.lock`) and then `Popen(launcher/client_argv)` — those exec, so
+  launched `hs client` processes get **clean fd tables** (no cluster-slot fd).
+- **`client`:** `QueueClient.connect()` (`client.py:1219`) — **no fork**. Threads only
+  (`client.py:1263-1267`). Task subprocesses (`client.py:772`) exec with `close_fds=True`. The
+  `client-<host>.log.lock` OFD lives **only** in this process → released on its death.
+- **`submit`:** no fork; `submit.py` only imports `AuthenticationError`.
+
+## 5. VERDICT and minimal fix
+
+**No fork/lingering-parent/shared-OFD path exists that would prevent release of a *client* slot
+lock.** Client processes never fork a manager and their only children exec with `close_fds=True`.
+This refutes H-leak as the cause of the reported `client-<host>` non-reclaim/proliferation and
+shifts weight to **H-conc** (genuinely ≥2 concurrent clients per host → correct `-2`, never
+consolidated/reaped) and **H-stale**.
+
+**However, a genuine FD-inheritance leak exists for `server`/`cluster` slots:** the fork-without-exec
+`BaseManager` manager child (`queue.py:385`) shares the role's `*.log.lock` OFD. If that child is
+orphaned (parent OOM/SIGKILL before BaseManager's `Finalize` terminates it), the flock is **not**
+released though the owner is gone → next generation falls to `server-<host>-2.log`. The evidence
+(clean `cluster-login01.log`, no `-2`) is consistent with clean shutdowns normally releasing it, so
+this is latent rather than the observed symptom.
+
+**Minimal hardening (recommended, not the root-cause fix):** close the inherited `_slot_locks`
+handles inside the manager child. `SecureManager.start` already injects the `_tls_bootstrap`
+initializer that runs *in the child after fork* (`queue.py:243-247, 278`); extend that initializer
+(and add one for the non-TLS branch) to `for h in _slot_locks: h.close()`. Since the child runs it
+post-fork, only the parent then holds the flock, so the lock releases exactly when the logical owner
+exits. **`os.set_inheritable(False)` is useless here** — it only acts on exec, and the manager child
+is fork-without-exec; the fd must be actively closed in the child (or the OFD kept single-holder).

--- a/spec/logging-file-slot-reclaim/research/06-liveness-design.md
+++ b/spec/logging-file-slot-reclaim/research/06-liveness-design.md
@@ -1,0 +1,191 @@
+# Research 06 — Liveness-signal design (flock-independent slot reclaim)
+
+Scope: design a slot-liveness signal that does **not** depend on flock's release *visibility*,
+so a canonical per-host slot is reclaimed exactly when its intended owner is dead — even when
+flock disagrees (H-leak) or goes stale (H-stale). Grounded in `core/logging.py` as it stands;
+the refuted ENOSYS/exhaustion theory is not relied on anywhere below.
+
+## The enabling invariant — same-host guarantee
+
+`default_file_for` bakes `HOSTNAME_SHORT` into every distributed slot name
+(`logging.py:654-657`, `stem = f'{role}-{HOSTNAME_SHORT}'`). Therefore **every process that ever
+competes for `client-a306.log` runs on a306.** A pid written into that slot's sidecar is a
+*local* pid: it can be checked with `os.kill(pid, 0)` / `psutil.pid_exists(pid)` on the
+claiming host, with no cross-host RPC. This is what makes a pid-record a usable liveness
+signal, and it is the property the current 0-byte sidecar throws away (nothing is written into
+it — `_try_lock` at `logging.py:669-677` only opens+flocks; no pid is recorded).
+
+## Dependency finding (settles the "psutil vs stdlib" question)
+
+**`psutil>=7.0.0` is already a hard, non-optional dependency** (`pyproject.toml:37`) and is
+already imported in `core/resource.py:17` (`from psutil import Process, NoSuchProcess, …`). The
+EPEL/RHEL low-floor concern does **not** apply — the floor is already committed and the project
+already ships psutil on every platform. So the cross-platform liveness problem (Linux has
+`/proc`, macOS has neither `/proc` nor `os.kill(pid,0)` semantics we want to hand-roll, Windows
+has no `os.kill` at all) is solved uniformly by:
+
+- `psutil.pid_exists(pid)` — cross-platform existence.
+- `psutil.Process(pid).create_time()` — **wall-clock epoch** process-start timestamp; the
+  pid-reuse defense. (Prefer this over `/proc/<pid>/stat` field-22 jiffies, which are
+  since-boot and need a boot-id to interpret — with psutil's epoch value **no boot-id is
+  needed**; it is already reboot-safe.)
+- `NoSuchProcess` → dead; `AccessDenied` → a live process owned by another user (conservatively
+  treat as **alive**, never steal — same-user is the HPC norm but this is the safe default).
+
+We keep a raw-stdlib `os.kill(pid, 0)` path only as an in-extremis fallback if `psutil.Process`
+raises unexpectedly; it is not the primary mechanism.
+
+## The sidecar record
+
+Replace the 0-byte sidecar with one atomically-written JSON line, e.g.
+
+```json
+{"pid": 12345, "host": "a306", "create_time": 1690000000.12, "instance": "<uuid>", "v": 1}
+```
+
+- `pid` — local liveness target (same-host guarantee).
+- `create_time` — from `psutil.Process(pid).create_time()`; pid-reuse defense (compare with a
+  small tolerance; a mismatch means a *different* process now holds that pid → original is dead).
+- `host` — `HOSTNAME_SHORT`; defense-in-depth for the `resolve_log_path` explicit-path case
+  (`logging.py:716-723`) where a user's non-default path could be shared across hosts. If
+  `record.host != HOSTNAME_SHORT`, we are not entitled to judge it → treat as live/advance.
+- `instance` — the existing per-process `INSTANCE` uuid (`logging.py:57`). Used as the
+  race tie-breaker token (write-then-reread-verify): after we claim, the record carrying *our*
+  `instance` proves we own the slot.
+- `v` — schema version, so a future field add is not a flag day.
+
+## Composition with `_try_lock` / `claim_file_slot` (concrete)
+
+Two code-level hazards must be handled or the record is silently corrupted:
+
+1. **`_try_lock` opens `mode='w'` (TRUNCATE) — `logging.py:671`.** A *losing* probe truncates
+   the sidecar to 0 bytes *before* it gets `EAGAIN` and closes, blanking the winner's record
+   while the winner still holds the flock. Fix: probe with a **non-truncating** open
+   (`open(p, 'a+')` or `os.open(p, O_RDWR|O_CREAT)`), flock, and only the **winner**
+   `seek(0)+truncate()+write(record)+flush()` — never `close()` (closing drops the flock; the
+   handle stays in `_slot_locks`, `logging.py:698`).
+2. **Reader path must never truncate.** Liveness checks read the sidecar `mode='r'`; parse
+   failure / empty / `v` unknown ⇒ "no live holder."
+
+## Options
+
+### (A) pid-record PRIMARY (record decides; flock optional/absent)
+
+On claim: read the record; empty/legacy/stale/dead ⇒ reclaim canonical (rewrite record, append
+to `client-a306.log`); live ⇒ advance to `-2`.
+
+- **H-leak:** ✅ **fixes it.** The record stamps the *original* owner's `pid`+`create_time`. If a
+  fork inherited the flock'd OFD but the original owner exited, `pid_exists(orig)` is False (or
+  `create_time` mismatches) ⇒ record says **dead** ⇒ reclaim. This *deliberately disagrees with
+  flock*, which still shows the slot held by the ghost OFD — exactly the intended behavior.
+- **H-stale:** ✅ liveness never consults flock-release visibility, so a network-FS stale lock is
+  irrelevant; the local pid check is authoritative.
+- **Legit concurrency:** correct outcome (record alive ⇒ advance) **but** the *acquire* is not
+  atomic — see race below.
+- **pid-reuse:** ✅ `create_time` comparison.
+- **Two-starters race:** ✗ weakest point. Two cold starts both read a stale/empty record, both
+  decide "free," both write and open ⇒ two writers. A rename-based CAS
+  (write-temp→`os.rename`→reread; back off unless the record still carries *my* `instance`)
+  narrows it but cannot fully close it without an atomic acquire primitive: the reread is not
+  ordered after all competitors' writes.
+- **Crash safety:** ✅ stale record ⇒ next starter reclaims; nothing to leak.
+- **Cross-platform:** ✅ psutil only; no flock needed.
+- **Backward-compat:** ✅ legacy 0-byte sidecar ⇒ parse fail ⇒ "no live holder" ⇒ reclaim
+  (aligns with R6 — those are the orphans we want to reclaim).
+
+### (B) flock PRIMARY, pid-record as fallback (**recommended**)
+
+1. Attempt `flock(LOCK_EX|LOCK_NB)` (non-truncating open).
+2. **Acquired** ⇒ strict single-writer (R7). Write our record into the locked sidecar. Done.
+3. **CONFLICT** (`EAGAIN`/`EWOULDBLOCK` ⇒ `BlockingIOError`) ⇒ flock says held. **Now consult the
+   record:**
+   - record **alive** (pid up, `create_time` matches) ⇒ genuine live sibling ⇒ advance to `-2`
+     (R7 preserved by the kernel).
+   - record **dead/stale/empty/legacy** ⇒ **ghost flock** (H-leak inherited OFD, or H-stale
+     network lock) ⇒ **override**: use the canonical path and append; rewrite the record with our
+     `instance`. We cannot seize the held OFD's flock, but the record proves no real owner
+     exists, so appending is safe.
+4. **UNSUPPORTED** (any other `OSError`) or `_LOCKING is False` ⇒ fall back to Option-A pure
+   record mode on the canonical path (this is the R5 "bounded, accept possible interleave"
+   regime).
+
+- **H-leak:** ✅ fixed via step 3 (record override) — flock alone would loop to `-2` forever;
+  the record is what breaks the ghost. **This is how B fixes the actually-observed bug** (clean
+  canonical + sequential `-2`, identical on ZFS and Lustre ⇒ FS-independent ⇒ ghost-lock, not FS
+  semantics).
+- **H-stale:** ✅ same step-3 override.
+- **Legit concurrency:** ✅ **best of the options** — in the healthy case flock is an *atomic*
+  acquire, so exactly one of two simultaneous starters wins slot 1 and the other gets `EAGAIN`,
+  reads the (alive) record, and advances. Strict single-writer, no interleave (R7, R8).
+- **pid-reuse:** ✅ `create_time`.
+- **Two-starters race:** ✅ **closed by the kernel** in the healthy case. Only in the degenerate
+  flock-broken regime does it fall to A's weaker CAS — and *that regime is exactly where GOAL R5
+  already accepts bounded interleave*, so the unavoidable race is confined where it is already
+  permitted.
+- **Crash safety:** ✅ doubled — kernel releases flock on crash *and* the record goes stale.
+- **Cross-platform:** ✅ keeps the `fcntl`/`msvcrt`/`_LOCKING=False` structure (R8); psutil for
+  the record check on all three.
+- **Backward-compat:** ✅ healthy flock still works on a legacy 0-byte sidecar; on winning we
+  upgrade it in place to carry a record. On CONFLICT with a legacy sidecar (holder on old code,
+  no record) we cannot judge liveness ⇒ defer to flock's verdict (advance). Mixed-version fleets
+  are transient.
+
+### (C) pure pid-record, drop flock — **reject**
+
+FS-independent and simple, but throws away the atomic acquire, so the two-starter race is
+present *even on a healthy filesystem* — regressing R7's "where locking works," the one property
+that works today (`tests/test_logging.py::test_slot_reclaimed_after_owner_dies`). Also forfeits
+free kernel crash-release. Not worth it given GOAL keeps the scheme.
+
+### (D) mtime / heartbeat staleness — **reject as primary**
+
+Needs a background thread touching the sidecar on an interval; the staleness threshold is a
+guess (too long ⇒ slow reclaim; too short ⇒ false-reap a GC-paused live writer ⇒ two writers);
+and mtime coherence/clock-skew is worst on the very network FS we distrust. A pid-record is an
+*instantaneous, authoritative* signal with no timer — strictly better. Not used.
+
+## Recommendation — (B) flock-primary + pid-record fallback
+
+B is the only option that (i) keeps strict single-writer where flock works — honoring R7/R8 and
+not regressing `test_slot_reclaimed_after_owner_dies`; (ii) **fixes the observed FS-independent
+bug** by letting the local pid-record override a ghost flock; and (iii) degrades to A's
+record-only mode precisely in the lockless regime GOAL R5 already scopes. It reuses machinery
+already in the tree (`psutil`, `INSTANCE`, `HOSTNAME_SHORT`) and needs no new dependency and no
+new config knob.
+
+**How B fixes H-leak (if real):** the inherited-OFD ghost keeps the flock after the true owner
+dies, so flock-only never reclaims. B reads the record, sees the *stamped* owner's pid gone (or
+`create_time` mismatched), and reclaims the canonical path anyway — the pid check *correctly
+disagrees* with flock. Two complementary, plan-level structural mitigations (defense-in-depth,
+not substitutes for the record): open the sidecar fd `O_CLOEXEC` (Python fds are already
+non-inheritable across **exec**, so `Popen`/spawn children never inherit it) — but note this
+does **not** help `os.fork()` without exec (multiprocessing 'fork' start method on Linux shares
+the OFD regardless of CLOEXEC), which is exactly why the record, not an fd flag, is the real
+fix. B's record also repairs the **reaper** (P2): the current plan treats a `_try_lock`
+handle-grant as "orphan," but under a ghost flock the probe gets `EAGAIN` and would **skip a
+genuine orphan** — reaping on `record.pid is dead` instead makes R6 correct too.
+
+---
+
+## ~250-word summary
+
+The same-host guarantee — `default_file_for` bakes `HOSTNAME_SHORT` into every distributed slot
+(`logging.py:654-657`) — means every competitor for a slot runs locally, so a pid written into
+the sidecar can be checked with a local `psutil.pid_exists` + `Process.create_time()`. Crucially,
+**`psutil>=7.0.0` is already a core dependency** (`pyproject.toml:37`, used in
+`core/resource.py:17`), so the EPEL/stdlib worry is moot and cross-platform liveness (Linux/macOS
+no-`/proc`, Windows no-`os.kill`) is uniform; `create_time()` is a wall-clock epoch that defeats
+pid reuse with **no boot-id needed**. Recommend **Option B: flock-primary with a pid-record
+fallback.** Where flock works it stays the atomic acquire — strict single-writer (R7/R8), and the
+two-starter race is closed by the kernel. On CONFLICT we consult the record: a live sibling ⇒
+advance to `-2`; a dead/stale/empty/legacy record ⇒ **override the flock** and reclaim the
+canonical path (append via the handler's existing `mode='a'`, `logging.py:377`). On UNSUPPORTED /
+`_LOCKING=False` it degrades to record-only mode — exactly GOAL R5's bounded-interleave regime.
+This **fixes H-leak**: an inherited-OFD ghost keeps the flock after the true owner dies, so
+flock-only never reclaims; the record stamps the *original* pid, which reads as dead, so B
+reclaims anyway — the pid check deliberately disagrees with flock. Composition caveats: switch
+`_try_lock`'s truncating `mode='w'` (`logging.py:671`) to a non-truncating probe so a losing
+probe can't blank the winner's record; reader path opens `'r'`; legacy 0-byte sidecars parse as
+"no live holder." B also repairs the P2 reaper (reap on `record.pid` dead, not on a `_try_lock`
+grant that a ghost flock would deny). Reject C (regresses R7 on healthy FS) and D (timer-based,
+false-reap risk).

--- a/spec/logging-file-slot-reclaim/research/07-reap-and-tension.md
+++ b/spec/logging-file-slot-reclaim/research/07-reap-and-tension.md
@@ -1,0 +1,176 @@
+# Research 07 — Reap semantics & the reframed design tension
+
+Scope: read-only. Builds on the **corrected ground-truth evidence** (flock *acquire* is honored
+on both Lustre `/scratch` and ZFS `/home`; canonical `client-a306.log` was won cleanly at slot 1;
+a sequential `client-a306-2.log` appeared; **no** PID files, **no** ~100 `.lock` pile, **no**
+"Exhausted slots" warning; behavior **identical** on both filesystems). That evidence **refutes**
+the committed ENOSYS/exhaustion diagnosis in `00`–`03`/`PLAN.md`/`TECH.md` — do not resurrect it.
+The live root-cause hypotheses (H-conc legitimate concurrency; H-leak fd-inheritance flock leak;
+H-stale network release; H-bug) and the **robust pid-based liveness signal** are owned by brief 06;
+this brief consumes that signal and does **not** re-derive the cause.
+
+All line refs are `src/hypershell/core/logging.py` unless noted.
+
+---
+
+## PART 1 — Reap semantics for orphaned `-N.log` slot files
+
+### 1.0 The load-bearing correction: the reap oracle must be pid-liveness, NOT flock
+
+The committed plan reaps by **probing the flock**: "if `_try_lock(slot + '.lock')` returns LOCKED
+→ owner is gone → `os.remove` the `-N.log`" (`PLAN.md` §2(d); `TECH.md` P2). **The corrected
+evidence disqualifies this probe.** flock cannot serve as the liveness oracle for reaping, for the
+same reason it cannot serve for reclaim:
+
+- **If H-leak holds** (a fork after `initialize_logging` opened the sidecar fd — e.g.
+  `BaseManager.start()`'s child at `core/queue.py:385`, reached after `main()` calls
+  `initialize_logging` at `__init__.py:139`; note the task-executor `Popen(shell=True)` at
+  `client.py:772` uses POSIX default `close_fds=True` — nothing sets `close_fds` anywhere — so it
+  does **not** inherit, which is why H-leak is weaker for the pure `client` role than for
+  cluster/server): the leaked open-file-description keeps the flock **held after the owner exits**.
+  A flock probe then reports the *dead* owner's slot as LOCKED (live) and **refuses to reap a
+  genuine orphan** — proliferation persists forever. This is exactly the observed symptom
+  ("slot 1 never reclaimed").
+- **If H-stale holds**: network release-visibility lets a just-freed slot flap between
+  held/free, so a flock probe reaps non-deterministically (sometimes deletes a slot whose owner
+  is transiently invisible-but-alive → data loss; sometimes misses a real orphan).
+- **If H-conc holds**: flock is honest *while contended*, but the `-2` orphan left behind after a
+  concurrency peak subsides is only reapable once its (now-dead) owner's flock is released — which
+  is precisely the case H-leak/H-stale corrupt.
+
+Since the FS-independent evidence points away from flock semantics entirely, the reap decision
+**must** use brief 06's robust signal: a **pid recorded in the sidecar** + `os.kill(pid, 0)`
+(`ESRCH` ⇒ dead ⇒ orphan; success/`EPERM` ⇒ alive), gated by a host check (the pid is only
+meaningful on the host baked into the filename — already guaranteed same-host by `default_file_for`,
+`:654-657`, but re-assert it so a recycled pid on a different host can never trigger a delete).
+This is FS-independent, matching the identical-on-both-filesystems evidence. **Reap on liveness,
+never on flock.**
+
+### 1.1 Options for the orphan's *data*
+
+| Option | History | Convergence to 1/host | Complexity | Verdict |
+|---|---|---|---|---|
+| **(a) delete orphan** | loses that generation's log | yes | trivial, idempotent | acceptable *iff* owner proven dead |
+| **(b) concat → canonical, then delete** | preserves (R3 spirit) | yes | high (see 1.2–1.4) | over-appetite for a `small` fix |
+| **(c) leave data, stop creating new** | preserves | no (pile persists) | trivial | fails R6 ("removable") |
+| **(d) hybrid** | tunable | yes | medium | **recommended** |
+
+**Recommended (d):** *delete the orphan `-N.log` only after the robust dead-owner check
+(1.0) passes.* This is the smallest change that satisfies R6 and R4 and is **fully idempotent**
+(`os.remove` wrapped to swallow `FileNotFoundError`/`OSError` — a racing reaper or live writer is
+harmless). It does lose a **crashed** client's own tail — but only *that* generation's lines in a
+*distinct* file; the canonical host history is untouched. If the maintainer deems crashed-slot
+diagnostics load-bearing, upgrade the same helper to **(b)** *for the bare `-N.log` only* (see
+1.2 for why "only"); the liveness gate and call site are identical, so (a)→(b) is a localized
+swap, not a redesign. Default to (a); offer (b) as the history-preserving dial.
+
+### 1.2 Interaction with the rotation namespace and `.partial` — the hidden proliferation
+
+An orphan slot is **not one file**. `client-a306-2.log` owns an entire private rotation lineage:
+`client-a306-2.1` / `client-a306-2.20260723` / `client-a306-2.20260723-140000` (+ a compression
+ext), because rotation strips the last extension via `basename_without_ext` (`:304-306`) and keys
+on a **dot**-separated counter/date (`re_pattern_count` = `prefix\.([0-9]+)ext`, `:230-232`;
+`:260-277`), plus possible `<name>.gz.partial` mid-compression files (`compress_file`, `:473-491`).
+
+Two hard consequences:
+1. **Reap must key on the exact `-N` *slot* shape** `^{re.escape(root)}-([0-9]+){re.escape(ext)}$`
+   (dash), and **never** touch the dot-separated rotation namespace (managed under `FILE_LOCK` by
+   the compression thread, §5) nor `.partial` nor the `.lock` sidecars nor the `main` role —
+   mirroring `recover_interrupted_compression`'s prefix-scoping discipline (`:513-533`).
+2. **Deleting/folding only the bare `-N.log` silently abandons its rotated/compressed children**,
+   which are themselves unbounded under long autoscaling runs. So *whichever* data option is
+   chosen, the orphan's rotation lineage is a second proliferation source. Folding that lineage
+   into the canonical file (option b, done "properly") would require **decompressing** children
+   and **time-order-merging two independent rotation lineages** — decisively beyond `appetite:
+   small`. This is the strongest argument that **(b) is not small-appetite** and that (a)
+   delete-the-whole-lineage (bare slot **and** its `client-a306-2.*` children, all gated on the
+   dead-owner check) is both smaller *and* more complete than a bare-`-N.log`-only concat.
+
+### 1.3 Out-of-time-order lines (concat only)
+
+Concat appends the orphan's records to the *tail* of the canonical file, so the merged file is
+**not monotonic in time**: an orphan created at T0 and reaped at T2 lands after canonical records
+written up to T2. Downstream `grep`/`sort -k<time>` breaks. Acceptable only if consumers key on
+the embedded timestamp field, not file order — an assumption to surface, not to make silently.
+
+### 1.4 Must concat hold a lock? Crash-mid-concat idempotency
+
+Yes — concat (option b) **must** hold the flock on the orphan sidecar for the whole copy (to
+exclude a mis-classified live writer or a racing reaper), *in addition to* the canonical lock the
+reaper already holds by virtue of being the n=1 winner. Worse, concat is **not idempotent**: a
+crash *after* appending the orphan's bytes to canonical but *before* `unlink`ing the orphan causes
+the next run to **re-append the same bytes → duplicated log lines**. The usual atomic-rename trick
+does not apply (this is an append into a live file, not a whole-file replace). A `.reaping` rename
+marker narrows but does not close the window (the append itself is not all-or-nothing under
+`O_APPEND`, especially on Lustre). By contrast **(a) delete is perfectly idempotent** (unlink is
+naturally so). This is the second decisive strike against (b) at `small` appetite.
+
+### 1.5 Definitive answer to the user's Q2 (quotable)
+
+> Reclaim does **not** require unlinking the `.lock` sidecar. "Reclaim" means re-acquiring the
+> advisory lock on the *persistent* sidecar — opening the same `client-<host>.log.lock` inode and
+> flocking it — so the sidecar is a reusable rendezvous point that *should* live for the whole
+> host's logging, not a per-generation artifact to delete. Deleting sidecars is in fact harmful:
+> `open(mode='w')` on a path another process still holds via flock yields a **new inode with a
+> new, independent lock** (POSIX inode-reuse race) → two live writers to one log. Bounded file
+> counts therefore come from *reusing* the fixed set of sidecars, never from unlinking them; only
+> the `-N.log` **data** (and its dead owner) is the reap target.
+
+---
+
+## PART 2 — The reframed design tension
+
+The corrected evidence — flock works yet files still pile up, identically on both filesystems, and
+the maintainer's own framing ("we never reclaim … just proliferate") — suggests the **slot
+abstraction itself may be the mismatch**: the maintainer appears to expect *one appending file per
+host*, and the `-N` slots are unwanted machinery whose entire lifecycle (reclaim + reap +
+pid-tracking) is pure cost if genuine same-host concurrency is rare. Two architectures:
+
+### Architecture I — KEEP slots; fix reclaim + reap
+
+Distinct files while genuinely concurrent, converging to one when serial. Reclaim and reap both
+switch from the (refuted) flock oracle to brief 06's **pid-liveness** signal: at claim time, if the
+canonical sidecar's recorded pid is dead, **steal** the canonical slot (append) regardless of a
+leaked/stale flock; reap dead-owner `-N.log` lineages (Part 1).
+
+- **Pros:** honors **R7 as written** (real single-writer where it matters — no interleave); keeps
+  per-generation isolation; smallest *conceptual* departure from today's model.
+- **Cons:** correctness now hinges on the pid signal being right across H-leak/H-stale/pid-reuse;
+  retains the orphan data-vs-history question (Part 1); more moving parts (pid record, `os.kill`,
+  host guard, reap helper, `_slot_locks` hygiene); the fleet still *transiently* shows many files.
+- **GOAL:** satisfies **R2, R3, R4, R6, R7, R8** (and R5 via pid-based bounding even if flock is a
+  no-op). Nothing violated.
+
+### Architecture II — ABANDON slots; one shared per-host file
+
+Every same-host client opens and **appends** to the single canonical `client-<host>.log`; a failed
+or unavailable lock **never** walks to `-N` — it just appends (best-effort single-writer). Exactly
+one data file per host by construction. The flock/sidecar may survive as an *advisory* hint only.
+
+- **Pros:** **dramatically smaller** — deletes the slot loop, reclaim, reap, pid-tracking, and the
+  entire orphan lifecycle; **exactly** 1/host by construction (strongest R4/R5, FS-independent, no
+  reliance on flock working); directly matches the maintainer's evident mental model and GOAL Q1
+  (append). Interleave is *line-atomic on most filesystems*: the stdlib emits each record in a
+  single `write(msg + terminator)`, and `O_APPEND` makes that atomic up to a per-FS size limit.
+- **Cons:** **contradicts R7** — concurrent same-host writers interleave, and `O_APPEND` write
+  atomicity is *not* guaranteed on Lustre for records exceeding a stripe/`PIPE_BUF`-class bound
+  (possible torn lines). Requires the **maintainer to explicitly relax R7**. Loses per-generation
+  isolation. R6 becomes largely moot **except** the one-time reap of the *legacy* pile already on
+  Gautschi (still needed via the Part-1 liveness sweep).
+- **GOAL:** satisfies **R2** (always canonical), **R3** (append), **R4/R5** (1/host, lockless-safe),
+  **R8** (host-scoped; `main` untouched). **Violates R7.** R6 reduces to a one-shot legacy sweep.
+
+### Which is smaller, and the decision to put to the maintainer
+
+**II is decisively smaller** and eliminates the flock/liveness/reap surface that the corrected
+evidence just proved fragile — at the cost of a GOAL amendment (relax R7). **I is larger** and its
+correctness rests entirely on the pid signal from brief 06.
+
+**Explicit decision for the maintainer:** *Are concurrent same-host clients a real workload?* One
+`ClientThread` per process is the documented model, and autoscaling typically scales a host to zero
+before relaunching (serial generations) — so R7's protection may be buying little while the slot
+lifecycle costs a lot. **If same-host concurrency is rare/absent → Architecture II** (relax R7 to
+"best-effort single-writer," one appending file per host, keep flock only as an advisory hint, plus
+a one-time legacy reap). **If it is a genuine workload → Architecture I** with brief 06's pid
+liveness driving both reclaim and reap. Either way, **the flock-probe reap in the committed
+`PLAN`/`TECH` must be replaced** — flock is no longer a trustworthy liveness oracle.

--- a/spec/logging-file-slot-reclaim/research/08-scope-invariants.md
+++ b/spec/logging-file-slot-reclaim/research/08-scope-invariants.md
@@ -1,0 +1,161 @@
+# Research 08 — Re-scope, invariant gate, cross-platform & testability
+
+Read-only survey for `/hs-plan`, reflecting the **post-refutation** evidence (identical behavior
+on ZFS `/home` and Lustre `/scratch`; clean canonical name won, one `-2` slot, **no** PID pile,
+**no** 100-lock pile, **no** "Exhausted" warning). That evidence kills the committed ENOSYS/
+exhaustion diagnosis (PLAN §1, TECH P1) and points at an **FS-independent** cause — a lock/reclaim
+leak — not errno conflation. This brief re-scopes the two architectures brief 07 frames
+(**KEEP-slots** with pid-stamped liveness vs **SINGLE-file** per host), gates them against
+`invariants.md`, and pins the compat + test surface.
+
+## 0. The three questions, answered (they anchor both architectures)
+
+- **Q1 — how do we know the canonical `.lock` is held by a *live* process?** Today: we do **not**
+  track pids at all — the flock is the only signal, and the sidecar is written `open(mode='w')`
+  and left 0-byte (`logging.py:671`, never written into). Proposal: keep **flock as the primary
+  and authoritative signal** (it self-releases on death, works cross-generation), and *add* a
+  **pid line written into the sidecar** as a **secondary/fallback** liveness signal used only
+  where flock is unavailable/unreliable or to make reap trustworthy. Liveness check = a single
+  injectable seam `_pid_alive(pid)` (POSIX: `os.kill(pid, 0)` → `ProcessLookupError` ⇒ dead,
+  `PermissionError` ⇒ alive; optionally `/proc/<pid>` on Linux). Flock must stay primary so a
+  new pid-stamping process and an old non-stamping one interoperate during a rolling upgrade.
+- **Q2 — if we can't unlink `.lock` files, how do we ever reclaim?** Reclaim ≠ unlink. Reclaim =
+  **re-acquiring the flock on the persistent sidecar** (and overwriting the pid stamp). This
+  already works on a healthy FS: the sidecar file persists, the OS drops the flock on owner death,
+  and the next `_try_lock('client-host.log.lock')` succeeds → canonical returned + appended
+  (`mode='a'`, `logging.py:377`; proven by `test_slot_reclaimed_after_owner_dies`). Unlinking a
+  sidecar is a **POSIX inode-reuse race** (A holds flock on the old inode while B `open('w')`s a
+  new inode → two independent locks → two writers); brief 03 §2 already banned it. So the sidecar
+  is never unlinked; only its lock is re-acquired.
+- **Q3 — when we reap a `-N.log`, do we append its contents onto the canonical file?** Per the
+  locked clarification *"reclaim ⇒ APPEND (preserve history)"* (GOAL Q1/R3), reaping must **concat
+  the orphan `-N.log` onto the canonical file, then remove the `-N.log`** — a bare `os.remove`
+  (as PLAN (d)/TECH P2 currently specify) *discards* that generation's history and contradicts
+  R3's intent. This upgrades reap from *delete* to *concat-then-delete*, which is the §5 crux
+  (below).
+
+## 1. Revised phase breakdown (vertical slices per architecture)
+
+### Architecture A — KEEP-slots + pid-stamped liveness + trustworthy reap
+
+Keeps the `-N` scheme and R7 (distinct files for genuinely-concurrent same-host writers). No
+GOAL change.
+
+- **P1 — Close the fd-inheritance lock leak (likely root cause; ship-alone-able).**
+  `SecureManager(BaseManager).start()` (`core/queue.py:273`, `:385`) forks a manager process
+  **after** `initialize_logging` (`__init__.py:139`); on Linux's default **`fork`** start method
+  the child inherits a **dup of the slot-lock OFD**, so the flock is *not* released when the
+  original owner exits (a flock releases only when **all** fds on that OFD close) — FS-independent,
+  and it explains "canonical never reclaimed" + `-2` persisting. This also explains **no local
+  repro**: macOS multiprocessing defaults to **`spawn`** (exec ⇒ `O_CLOEXEC` closes the fd ⇒ no
+  leak), Linux to **`fork`** (leak). Fix: `os.register_at_fork(after_in_child=…)` to close/clear
+  the `_slot_locks` handles in forked children (and audit `LocalCluster`, resource/semaphore
+  trackers). `Popen` sites (`remote.py:314,533`, `ssh.py:311`, `client.py:772`) exec → CLOEXEC,
+  already safe. **Vertical slice: P1 alone may fully restore reclaim.** Appetite: **small**.
+- **P2 — pid-stamped liveness sidecar (R5 lockless fallback + reap trust).** Write `pid` into the
+  sidecar on claim; add `_pid_alive` seam. Used only where flock is unavailable/unreliable
+  (`_LOCKING=False`, or a probe that can't distinguish stale-release) to arbitrate reclaim. Small.
+- **P3 — trustworthy reap + concat-on-reclaim (R6/R3).** Canonical-lock winner scans exact
+  `client-<host>-<int>.log` slots (regex on `basename_without_ext` prefix, mirroring
+  `recover_interrupted_compression`, `logging.py:513-533`); an orphan = flock-probe LOCKED **or**
+  pid-dead → **concat its bytes onto canonical, then remove** the `-N.log`. Never touch sidecars,
+  the rotation namespace, the fresh file, or `main`. Medium.
+- **P4 — end-to-end bounded-count + regression (R4/R8).** Integration: serial + *overlapping*
+  generations on one host; assert bounded count and cross-host/`main` unregressed. Small.
+
+**Total 4 phases; appetite starts small (P1), grows to small-medium.** Under the circuit-breaker.
+
+### Architecture B — SINGLE-file per host (all same-host writers share one file)
+
+Collapses `-N` entirely: one canonical `client-<host>.log`/host, append-only. R2/R3/R4/R5 hold
+*by construction*; reap reduces to a one-time legacy consolidation.
+
+- **P1 — Collapse slot walk → single canonical path (append; one warn if lockless).** Small.
+- **P2 — Cross-process rotation-owner election.** *New hazard:* multiple live processes now share
+  one file, each with its own `RotatingFileHandler` calling `os.rename`/compress under a
+  **process-local** `FILE_LOCK` (`logging.py:355,400`) — which does **not** serialize across
+  processes. Rotation must be gated by the **cross-process flock** (only the flock holder rotates;
+  others append without rotating). This is genuinely hard. Medium-large.
+- **P3 — Legacy `-N.log` one-time concat/migrate + reap.** Medium.
+- **P4 — e2e bounded-count + rotation-under-concurrency integration test.** Medium.
+
+**Appetite: big.** Two blockers: (i) it **violates R7 as written** ("distinct files for
+genuinely-concurrent same-host writers where locking works") → a **GOAL amendment / human gate**;
+(ii) it introduces a cross-process rotation race the slot scheme never had (single-writer
+guaranteed a single rotator). Simpler for *counting*, costlier for *correctness*.
+
+**Recommendation:** pursue **Architecture A**. It preserves R7, needs no GOAL change, and its P1
+is a credible complete fix for the observed symptom. Keep SINGLE-file as an explicit *opt-in* only
+if the maintainer accepts interleave — and note that making it opt-in means a config knob (§12).
+Circuit-breaker: A is ≤4 phases; B trending toward the ~8 reconsider line once R7/rotation are
+paid for.
+
+## 2. Invariant gate (`.agents/factory/invariants.md`)
+
+- **§5 (compression thread + `FILE_LOCK`).** The **concat-on-reap** (Q3) and reclaim-append are
+  the real §5 exposure. `FILE_LOCK` is **process-local**, so it does *not* protect a concat that
+  races another process's `rotate()`; and `recover_interrupted_compression` + the compression
+  thread start at `logging.py:818-820,837`. Mitigation: perform reap/concat **before**
+  `queue_listener.start()`/`compression_thread.start()`, or hold `FILE_LOCK` **and** the canonical
+  flock during concat, and only touch `-N.log` we have flock-probed/pid-confirmed as orphaned —
+  never the dot-separated rotation namespace (`client-host.1`/`.YYYYMMDD`). No new thread; no new
+  shared mutable state beyond `_slot_locks`. Architecture B's cross-process rotation is a **harder
+  §5 violation** requiring flock-gated rotation.
+- **§11 (no shared client-argv builder).** **Verified by grep:** the log path is **not** forwarded
+  to launched clients. `client_args` in `RemoteCluster` (`remote.py:281-306`), `AutoScalingCluster`
+  (`remote.py:813-835`), and `SSHCluster` (`ssh.py:275-300`) carry only
+  `--no-confirm/--capture/--monitor/-C/-M/-T/-W/-R/--no-tls`; `LocalCluster` embeds threads (no
+  argv). Every client derives `client-<own-host>.log` client-side. **Neither architecture touches
+  any argv builder** — pid-stamping and single-file are both purely client-side. ✔
+- **§12 (same-commit docs/completions).** A **pid-stamp is behavior-only** (sidecar contents change
+  0-byte → `"<pid>\n"`; no new CLI flag, no new config key) ⇒ **no** `docs/_include/*.rst` or
+  `share/` edits required (matches the existing TECH §12 note). **A lock-mode knob**
+  (`logging.file.lock = auto|flock|pid|off|shared`) — or making SINGLE-file opt-in via config —
+  **is a new config key** and would force, in the same commit: `docs/_include/config_param_ref.rst`
+  (the `[file]` block, lines 48-74), regeneration of `share/man/man1/{hs,hsx,hyper-shell}.1` (hsx.1
+  is a copy of hs.1), and the bash+zsh completions under `share/`. **Recommendation: stay
+  knob-free** (auto behavior: flock-primary → pid-fallback → canonical-append degrade) to avoid the
+  §12 burden and keep appetite small. A non-gated behavioral note in `docs/logging.rst` is good
+  practice but not the §12 same-commit trigger.
+
+## 3. Cross-platform & backward-compat
+
+- **Windows (`msvcrt`, no `/proc`).** `msvcrt.locking` gives a mandatory byte-range lock released
+  on close/exit — keep it **authoritative**. `os.kill(pid, 0)` is unreliable on Windows (signal 0
+  unsupported); the `_pid_alive` seam must degrade to "trust flock only" (or best-effort
+  `OpenProcess`) and **never crash**. Windows lacks `fork`, so the P1 leak/`register_at_fork` fix
+  is a POSIX-only concern and must be guarded.
+- **`_LOCKING = False` path** (neither `fcntl` nor `msvcrt`). Today returns a PID suffix
+  (`logging.py:713`) — itself a proliferation bug. With **no flock at all**, the pid-stamp is the
+  **only** liveness signal, but `os.kill`/`signal` may also be absent on such a platform. Safest
+  R5/R8-compliant behavior: **degrade to the canonical per-host path (append)**, bounded to one
+  file/host; pid-liveness arbitration is opportunistic on top.
+- **Legacy 0-byte sidecars (millions on disk).** A pid scheme **must** treat an **empty /
+  non-integer / legacy** sidecar as **`unknown → reclaimable-if-flock-free`**: read defensively,
+  never raise on unparseable contents, and fall back to the flock probe. Reap (R6) of pre-existing
+  buggy-version `-N.log` files must likewise work off the flock probe when no pid stamp exists.
+  **Forward/rolling-upgrade interop:** an old (non-stamping) process only flocks; a new process
+  must therefore keep flock **primary** and treat the pid stamp as advisory, so mixed fleets never
+  double-write.
+
+## 4. Testability
+
+- **pid-liveness (deterministic).** Introduce a single seam `_pid_alive(pid) -> bool` and
+  `monkeypatch.setattr('hypershell.core.logging._pid_alive', fake)` (or patch
+  `hypershell.core.logging.os.kill` to raise `ProcessLookupError` for "dead" / return for
+  "alive"). Seed sidecars with a known-dead sentinel pid; assert reclaim vs skip. Avoids real
+  `/proc` and is cross-platform. `@mark.unit`.
+- **fd-leak regression (the crux, pins P1).** In-process claim canonical (handle in `_slot_locks`);
+  `os.fork()` a child that sleeps holding the inherited fd; parent closes/clears `_slot_locks`;
+  from a **fresh subprocess** (no shared globals) assert a claim returns the **canonical** path
+  (leak ⇒ pushed to `-2` → red before fix; green after `register_at_fork`). Use raw `os.fork()`
+  (not `multiprocessing`, whose start method differs macOS↔Linux); `skipif` Windows.
+  `@mark.integration`.
+- **`_slot_locks` (+ any new module globals) cleanup.** Autouse fixture in `tests/test_logging.py`
+  that, after each test, closes every handle in `hypershell.core.logging._slot_locks` and clears
+  the list (existing tests only dodge leakage via unique `tmp_path`; without the fixture a held
+  slot-1 pushes later claims to `-2` → flakes). Reset the pid-stamp seam/state too.
+- **concat-on-reap (Q3/§5).** Seed unlocked orphan `client-h-2.log`/`-3.log` with known bytes, a
+  *locked* `client-h-4.log`, rotated `client-h.1`/`client-h.20260723`, and `main.log`; after a
+  canonical claim assert the orphans' bytes are **appended to canonical** then removed, and
+  everything else retained. `@mark.unit`.

--- a/spec/logging-file-slot-reclaim/research/09-revised-design.md
+++ b/spec/logging-file-slot-reclaim/research/09-revised-design.md
@@ -1,0 +1,285 @@
+# Research 09 — Revised design synthesis
+
+Consolidates briefs [04](04-evidence-forensics.md) (evidence forensics), [05](05-process-model-audit.md)
+(fd-inheritance audit), [06](06-liveness-design.md) (liveness signal), [07](07-reap-and-tension.md)
+(reap semantics + architecture tension), [08](08-scope-invariants.md) (re-scope + invariant gate)
+against the maintainer's **corrected ground-truth evidence** from Gautschi, and supersedes the
+committed [`PLAN.md`](../PLAN.md) / [`TECH.md`](../TECH.md) diagnosis. All line refs are
+`src/hypershell/core/logging.py` unless noted; source is read-only. **Do not resurrect the
+refuted ENOSYS/exhaustion theory** (§1).
+
+---
+
+## 1. Refined diagnosis
+
+### Where the committed plan was wrong
+
+The committed `PLAN.md §1` / `TECH.md P1` diagnosis — *"`_try_lock` swallows every `flock`
+`OSError` as contention; on Lustre `noflock` every call returns `ENOSYS`, so the loop exhausts
+100 slots → PID suffix + 100 `.lock` files + an Exhausted warning"* — is **refuted by
+construction** (brief 04 §1–2). The on-disk evidence is the *exact opposite* of what that theory
+predicts:
+
+| ENOSYS theory predicts | Disk actually shows | Deduction |
+|---|---|---|
+| PID-suffixed logs (`:713`) | **no** PID files | PID branch never taken |
+| a fixed **100** `.lock` pile | **2** sidecars on a306 | loop stopped at slot 2, by *winning* |
+| an "Exhausted slots" warn/launch (`:712`) | **no** warning | loop never fell off the end |
+| **no** clean canonical `.log` (name never *returned*, so `delay=True` never creates it) | clean `client-a306.log` **won at slot 1** | `flock(LOCK_EX\|LOCK_NB)` **succeeded** |
+
+A clean, no-PID `client-a306.log` can only exist if `_try_lock('client-a306.log.lock')` returned
+a handle → the flock **acquired**. A real `client-a306-2.log` requires a genuine CONFLICT on
+slot 1 (`EAGAIN`) followed by a successful acquire on slot 2. So **flock acquire and
+conflict-detection work on both `/scratch` (Lustre) and `/home` (ZFS).** The errno-conflation
+defect is real *code smell* but is **not** the cause of the observed proliferation.
+
+### The FS-independence lever
+
+The *identical* signature on a network Lustre and a POSIX-ish ZFS — two different flock
+implementations — means the cause cannot be a property of either FS's flock quirk. It lives
+**above** the FS layer, in the process/lock lifecycle. This **excludes both filesystem-semantic
+hypotheses** (refuted-ENOSYS; H-stale as the *common* cause — H-stale is Lustre-only at most),
+and leaves H-conc, H-leak, H-bug (brief 04 §2). *Prerequisite caveat:* the argument assumes
+`/home` is a **local** ZFS mount; if it is NFS-exported ZFS, H-stale re-enters for both halves —
+confirm with diagnostic (e).
+
+### Ranking
+
+1. **H-conc (LEADING) — legitimate concurrency, working-as-designed.** ≥2 client generations
+   overlap on a306, so `-2` is *correct by design* (R7 behaving). Working flock + a live slot-1
+   holder ⇒ a concurrent peer gets `EAGAIN` and correctly wins `-2`. Produces exactly {clean
+   canonical + one sequential `-2`, no PID, no pile, no warning}; FS-independent; a261 = 1 rank,
+   a306 = 2 ranks explains the asymmetry. **If this is the truth, the real complaints are
+   downstream of correctness:** files are never consolidated to one-per-host, never cleaned up,
+   and stale ones are never reaped when concurrency drops — all cleanup/UX gaps, not a lock bug.
+
+2. **H-leak — inherited-OFD flock leak. DISK-CONSISTENT but code-grounded UNLIKELY for the
+   `client` role** (briefs 04 §3, 05). The process-model audit (brief 05) is decisive here:
+   - `initialize_logging` runs in `main()` (`__init__.py:139`) *before* any process creation, so
+     the flock'd sidecar fd (`open(path,'w')`, `:671`; held in `_slot_locks`, `:698`/`:710`,
+     never closed) exists before every fork/`Popen`.
+   - A flock releases only when **all** fds on its OFD close. `O_CLOEXEC` (PEP 446) drops the fd
+     on **exec** but **not on fork-without-exec**.
+   - The **only** fork-without-exec in the tree is `SecureManager/BaseManager.start()`
+     (`core/queue.py:273-281`), which on Linux's default `fork` method spawns a manager child
+     that inherits and shares the role's slot OFD. **But that fires only in `server`/`cluster`
+     roles** (which run a `QueueServer`), inheriting the *server/cluster* slot — not a client
+     slot. The **client only `connect()`s** (`client.py:1219`), drives *threads*, and its task
+     subprocesses `Popen(shell=True)` with default `close_fds=True` + exec → drop the fd.
+   - **Verdict (brief 05): no fork/shared-OFD path prevents release of a *client* slot lock**, so
+     H-leak does **not** explain the observed `client-<host>` proliferation. It *is* a real
+     **latent** bug for `server`/`cluster` slots if the manager child is orphaned (parent
+     OOM/SIGKILL). Clean `cluster-login01.log` (no `-2`) shows normal shutdowns release it.
+
+3. **H-stale — network-FS release lag. EXCLUDED as common cause** (Lustre-only at most), by
+   FS-independence — contingent on the (e) mount check.
+
+4. **H-bug — residual catch-all.** No obvious defect; the reclaim loop restarts at `n=1` and
+   `test_slot_reclaimed_after_owner_dies` (`tests/test_logging.py:91-106`) proves reclaim works on
+   a healthy FS. Retained only if diagnostics exonerate the above.
+
+**Bottom line:** the most-likely truth is **H-conc + a cleanup/consolidation gap** — the slot
+scheme is working as designed, and the maintainer's pain is that it *never converges to one file
+per host and never reaps*. The single decisive diagnostic (§4) settles conc-vs-stale before we
+commit to more machinery than the truth warrants.
+
+---
+
+## 2. Definitive answers to the maintainer's three questions
+
+**Q1 — How do we know the canonical `.lock` is held by a REAL live process? How do we track
+PIDs?**
+> Today we do **not** — and that is the gap. The sidecar is opened `open(mode='w')` and left
+> **0-byte** (`:671`, `:669-677`); no pid, mtime, or heartbeat is ever written. The *only*
+> liveness signal is the advisory flock itself, which the kernel drops when the last fd on the
+> holding open-file-description closes (i.e. on process death). That signal is correct on a
+> healthy local FS but is **blind to two failure modes**: an inherited-OFD ghost (H-leak) keeps
+> the flock held after the true owner dies, and a network FS can lag release visibility
+> (H-stale). To *track* pids we exploit the **same-host guarantee**: `default_file_for` bakes
+> `HOSTNAME_SHORT` into every distributed slot name (`:654-657`), so every competitor for
+> `client-a306.log` runs on a306 and a pid written into the sidecar is a **local** pid, checkable
+> with `psutil.pid_exists(pid)` + `psutil.Process(pid).create_time()` (pid-reuse defense; a
+> wall-clock epoch, so **no boot-id needed**). **`psutil>=7.0.0` is already a hard core
+> dependency** (`pyproject.toml:37`, used in `core/resource.py:17`) — no new dependency, and the
+> EPEL/stdlib-floor worry is moot. The recommended record is one atomically-written JSON line:
+> `{"pid", "create_time", "host", "instance", "v"}` (brief 06), used as a liveness/reap oracle.
+
+**Q2 — If we can't unlink `.lock` files, how do we ever reclaim?**
+> Reclaim is **not** unlinking — it is **re-acquiring the flock on the persistent sidecar**:
+> open the same `client-<host>.log.lock` inode, `flock` it, and the handler appends to
+> `client-<host>.log` (`mode='a'`, `:377`). The sidecar is a *reusable rendezvous point* that
+> should live for the whole host's logging, not a per-generation artifact. **Unlinking sidecars
+> is actively harmful:** `open(mode='w')` on a path another process still holds via flock yields
+> a **new inode with a new, independent lock** (POSIX inode-reuse race) → two live writers to one
+> log. Bounded file counts therefore come from **reusing** the fixed set of sidecars, never from
+> deleting them. On a healthy FS this reclaim *already works*
+> (`test_slot_reclaimed_after_owner_dies`); the fix's job is to make it also fire when flock is
+> blind, by letting the pid-record **override a ghost/stale flock** (brief 06 Option B step 3).
+
+**Q3 — When we reap a `-N.log`, do we append its contents onto the canonical file?**
+> **The maintainer's call, and it is genuinely balanced.** GOAL Q1/R3's *"reclaim ⇒ APPEND,
+> preserve history"* argues for **concat-then-delete**. But concat is (brief 07 §1.2–1.4):
+> (i) **not idempotent** — a crash after appending bytes but before `unlink` re-appends on the
+> next run → **duplicated log lines** (the atomic-rename trick doesn't apply to an append into a
+> live file); (ii) produces **out-of-time-order** lines (orphan's records land after newer
+> canonical records — breaks `sort`/`grep` unless consumers key on the embedded timestamp);
+> (iii) an orphan slot is **not one file** — `client-a306-2.log` owns a whole private rotation
+> lineage (`-2.1`, `-2.20260723`, `.gz`, `.gz.partial`); folding it "properly" means
+> **decompressing and time-merging two rotation lineages** — decisively over `small` appetite.
+> **Recommended default: reap = delete** the dead-owner's *entire* `-N.*` lineage (bare slot +
+> rotated/compressed children), gated on the pid-liveness check, wrapped to swallow
+> `FileNotFoundError`/`OSError` (perfectly idempotent). Offer concat-of-the-bare-`-N.log`-only as
+> a localized (a)→(b) swap *if* the maintainer deems crashed-slot tails load-bearing.
+
+---
+
+## 3. Recommendation
+
+**Liveness signal (from brief 06): Option B — flock-primary + pid-record fallback.**
+1. `flock(LOCK_EX|LOCK_NB)` on a **non-truncating** open (see caveat below). **Acquired** ⇒
+   strict single-writer (R7); write our record into the locked sidecar. Done.
+2. **CONFLICT** (`BlockingIOError`/`EAGAIN`) ⇒ consult the record: **alive** (pid up,
+   `create_time` matches) ⇒ genuine sibling ⇒ advance to `-2` (R7 preserved by the kernel);
+   **dead/stale/empty/legacy** ⇒ **ghost flock** (H-leak/H-stale) ⇒ **override**: use the
+   canonical path and append, rewrite the record with our `instance`.
+3. **UNSUPPORTED** (other `OSError`) or `_LOCKING is False` ⇒ record-only mode on the canonical
+   path — exactly GOAL R5's bounded-interleave regime (replaces today's `:713` PID-suffix, itself
+   a proliferation bug).
+
+B is the only option that (i) keeps the **atomic** single-writer where flock works (R7/R8, no
+regression to `test_slot_reclaimed_after_owner_dies`); (ii) **fixes H-leak/H-stale if real** by
+letting the local pid-record deliberately disagree with a ghost flock; (iii) degrades to
+record-only precisely in the lockless regime R5 already scopes. Reject C (pure record — regresses
+R7 on healthy FS, reintroduces the two-starter race even where flock would close it) and D
+(mtime/heartbeat — timer guesswork, false-reap risk, worst on the network FS we distrust).
+
+**Two composition caveats that are load-bearing** (brief 06 §Composition): `_try_lock` opens
+`mode='w'` (**TRUNCATE**, `:671`) — a *losing* probe would blank the winner's record before it
+gets `EAGAIN`. Switch to a non-truncating probe (`open(p,'a+')` / `os.open(...,O_RDWR|O_CREAT)`);
+only the **winner** `seek(0)+truncate()+write(record)`, never `close()` (closing drops the
+flock). Reader path opens `'r'`; empty/legacy/unparseable ⇒ "no live holder."
+
+**Reap semantics (from brief 07): reap on pid-liveness, NEVER on a flock probe.** The committed
+plan's flock-probe reap (`PLAN §2(d)`, `TECH P2`) is disqualified: under H-leak a ghost flock
+makes a dead owner's slot read as LOCKED, so the probe **refuses to reap a genuine orphan** —
+exactly the reported symptom. Reap on `record.pid` dead (+ host guard), key on the **exact slot
+shape** `^{re.escape(root)}-([0-9]+){re.escape(ext)}$` (dash), and **never** touch the
+dot-separated rotation namespace, `.partial`, `.lock` sidecars, or the `main` role — mirroring
+`recover_interrupted_compression`'s prefix-scoping (`:513-533`).
+
+**Architecture: recommend KEEP-slots (Architecture A / brief 08 A), but flag it as the
+maintainer's call.** A preserves R7 as written, needs **no GOAL amendment**, touches no argv
+builder or config knob (invariant §11/§12 clean), and its liveness fix credibly restores reclaim.
+SINGLE-file (Architecture B) is *conceptually* what the maintainer's mental model wants (one
+appending file/host) and is smaller for *counting* — but it **violates R7**, forfeits
+per-generation isolation, and introduces a **cross-process rotation race** the slot scheme never
+had (multiple live processes each running a `RotatingFileHandler` with a *process-local*
+`FILE_LOCK`, `:355` — rotation would need to be flock-gated). That pushes B to **big** appetite
+and a GOAL amendment. **Both the architecture choice and reap=delete-vs-concat are explicitly the
+maintainer's decisions** — they turn on one empirical fact (§4) plus one policy call (R7).
+
+---
+
+## 4. Explicit decisions the maintainer must make
+
+**D0 (DECISIVE DIAGNOSTIC — run first; from brief 04 §4a). Timestamp-overlap between
+`client-a306.log` and `client-a306-2.log`.** Compare first/last `%(asctime)s` records in each.
+- **OVERLAPPING wall-clock windows ⇒ H-conc / working-as-designed** — the only bug is
+  non-consolidation + non-reap. Favors modest cleanup work; SINGLE-file becomes tempting.
+- **DISJOINT / strictly sequential (a306-2 starts only after a306 ends) ⇒ reclaim failure**
+  (H-leak/H-stale) — a serial successor should have re-won slot 1. Favors the full Option-B
+  liveness override. Corroborate with (04 §4d) `lsof client-a306.log.lock` on a dead client (a
+  live holder ⇒ H-leak confirmed) and (04 §4e) confirm `/home` is local ZFS vs NFS-exported.
+
+**D1 — Architecture.** *Recommended default:* **KEEP-slots (A)** — preserves R7, no GOAL change,
+smaller blast radius. Choose SINGLE-file (B) only if D0 shows same-host concurrency is
+rare/absent *and* you accept relaxing R7 to "best-effort single-writer" (a GOAL amendment + a
+cross-process rotation-election phase → **big** appetite).
+
+**D2 — Reap data policy.** *Recommended default:* **delete the dead-owner's whole `-N.*`
+lineage** (idempotent, complete). Upgrade to concat-of-bare-`-N.log`-only if crashed-slot tails
+are load-bearing (accept non-idempotency + out-of-order lines + abandoned rotated children).
+
+**D3 — Ship the `server`/`cluster` fd-leak hardening now?** (brief 05 §5) *Recommended: yes,
+cheap.* Close inherited `_slot_locks` handles in the forked manager child via the existing
+`_tls_bootstrap` initializer seam (`core/queue.py:243-281`) or `os.register_at_fork`. This is a
+genuine latent leak for server/cluster slots even though it is **not** the observed client
+symptom.
+
+**D4 — Config knob or knob-free?** *Recommended: knob-free* auto behavior (flock-primary →
+pid-fallback → canonical-append). A knob (`logging.file.lock=...`) is a **new config key** → forces
+same-commit `docs/_include/config_param_ref.rst` + man-page + bash/zsh completion edits (invariant
+§12) and enlarges scope.
+
+---
+
+## 5. Revised phase plan (Architecture A) + appetite
+
+The committed 3-phase plan (errno discrimination → flock-probe reap → count) is **built on the
+refuted diagnosis** and must be replaced. Revised, for KEEP-slots:
+
+- **P0 — Confirm the cause (gate).** Maintainer runs D0 (+ corroborators). Decide D1/D2. *This
+  gates whether P2/P3 below are even the right shape.* (Not code; a few minutes.)
+- **P1 — pid-record liveness + non-truncating probe (Option B core).** Replace the 0-byte sidecar
+  with an atomic JSON record; add a `_pid_alive`/`_record_holder_alive` seam
+  (`psutil.pid_exists` + `create_time`, host-guarded, defensive on legacy/empty/`AccessDenied`);
+  switch `_try_lock` to a non-truncating open with winner-only write; implement the CONFLICT→
+  consult-record→override branch; degrade UNSUPPORTED/`_LOCKING=False` to canonical-append
+  (kills the `:713` PID-suffix bug); fix the false comment (`:660-666`). Tests: monkeypatch the
+  liveness seam + inject errnos; **autouse `_slot_locks` cleanup fixture**. **Ship-alone-able** —
+  may fully restore reclaim. Appetite: **small**.
+- **P2 — pid-liveness reap of dead-owner `-N.*` lineages (R6/R4).** Canonical-lock winner scans
+  the exact dash-slot shape, reaps whole lineages whose recorded owner is dead (D2 default:
+  delete), idempotent, prefix-scoped, never touching rotation namespace/sidecars/`main`. Runs
+  beside `recover_interrupted_compression` (`:837`), before the compression thread does real work
+  (invariant §5). Appetite: **small-medium**.
+- **P3 — `server`/`cluster` fork fd-leak hardening (D3, POSIX-only, `skipif` Windows).** Close
+  `_slot_locks` in the manager child (`core/queue.py:243-281` seam / `register_at_fork`). Guarded
+  no-op where there is no fork. Appetite: **small**.
+- **P4 — End-to-end bounded-count + regression (R4/R8).** Integration: serial **and
+  overlapping** same-host generations; assert bounded count; cross-host/`main`/Windows/no-lock
+  fallbacks unregressed. The fd-leak regression test (raw `os.fork()`, not `multiprocessing`) is
+  the crux pinning P3. Appetite: **small**.
+
+**Appetite: stays `small`→`small-medium` for Architecture A** (4 code phases in one module + one
+queue-seam, under the circuit-breaker). **Escalate to `big` only if the maintainer picks
+Architecture B** (adds cross-process rotation election + a GOAL R7 amendment + a config knob for
+opt-in). Honest fork: if D0 shows pure H-conc with a healthy FS, **P1's override branch may be
+unnecessary** and the work collapses toward "reap + one-shot legacy cleanup + fd-leak hardening"
+— smaller still.
+
+---
+
+## ~350-word summary
+
+**Diagnosis.** The committed ENOSYS/exhaustion diagnosis is refuted by construction: a clean
+no-PID `client-a306.log` proves `flock` *acquired* at slot 1, and a real `client-a306-2.log`
+proves genuine CONFLICT + acquire — with no PID files, no 100-`.lock` pile, no "Exhausted"
+warning (brief 04). flock acquire/conflict-detect work on **both** Lustre and ZFS, so the cause
+is **FS-independent** (excludes ENOSYS and H-stale-as-common-cause). Ranking: **H-conc leading**
+(the `-2` is a legitimate concurrent rank — working-as-designed; the real gap is
+non-consolidation + non-reap); **H-leak disk-consistent but code-grounded UNLIKELY for the
+client** — brief 05 finds the client never forks a manager and its children exec with
+`close_fds=True`, so no client-slot OFD leaks (though a real latent leak exists for
+`server`/`cluster` via `BaseManager.start()`); H-stale Lustre-only; H-bug residual.
+
+**Answers.** Q1: today we track no pids — flock is the only signal; add a `psutil`-checked pid+
+`create_time` record in the sidecar (same-host guarantee makes the pid local; `psutil>=7` already
+a dep). Q2: reclaim = re-acquiring the flock on the *persistent* sidecar and appending; never
+unlink sidecars (inode-reuse race). Q3: maintainer's call — recommend **delete** the whole
+dead-owner lineage (idempotent); concat is non-idempotent, reorders lines, and abandons rotated
+children (over `small`).
+
+**Recommendation.** Brief 06 Option **B** (flock-primary + pid-record override) + brief 07
+pid-liveness reap (**never** flock-probe reap) + **KEEP-slots** architecture (preserves R7, no
+GOAL change, no argv/knob churn). SINGLE-file is the maintainer's mental model but violates R7 and
+adds a cross-process rotation race → **big**. Architecture and reap=delete-vs-concat are
+explicitly the maintainer's decisions.
+
+**Decisions-for-user.** D0 run the timestamp-overlap diagnostic (overlap ⇒ H-conc; disjoint ⇒
+reclaim failure) — decisive; D1 architecture (default A); D2 reap policy (default delete); D3 ship
+server/cluster fd-leak hardening (yes, cheap); D4 knob-free (yes, avoids §12).
+
+**Phases.** P0 confirm+decide (gate) · P1 pid-record liveness + non-truncating probe
+(ship-alone) · P2 pid-liveness reap · P3 fork fd-leak hardening · P4 e2e bounded-count +
+regression. Appetite stays **small→small-medium** for A; **big only if B**.

--- a/spec/logging-file-slot-reclaim/research/10-stress-liveness.md
+++ b/spec/logging-file-slot-reclaim/research/10-stress-liveness.md
@@ -1,0 +1,175 @@
+# Research 10 — Adversarial stress-test of the liveness / fd-leak recommendation
+
+Attacks the recommended fix in [09](09-revised-design.md) §3 (= brief [06](06-liveness-design.md)
+Option **B** + brief [05](05-process-model-audit.md) fork hardening + brief 07 pid-liveness reap).
+Goal: break it. All line refs `src/hypershell/core/logging.py` unless noted; source is read-only.
+The refuted ENOSYS theory is **not** relied on anywhere.
+
+**Verdict up front:** the *spine* is sound — `psutil` pid+`create_time` record is the right
+liveness oracle, flock-primary is right, C/D rightly rejected. But the **OVERRIDE branch** (B
+step 3) and the **pid-only reaper** (07/09) as written contain **R7/R8 holes and an internal
+contradiction** that must be amended before build. None is fatal to the approach; several are
+required amendments.
+
+---
+
+## H1 — Torn-record read → OVERRIDE of a *live, still-initializing* sibling (R7 violation on a HEALTHY FS). **REQUIRED AMENDMENT.**
+
+This is the sharpest hole. Brief 06 §Composition mandates the winner write its record **in place**:
+`seek(0)+truncate()+write(record)+flush()`, **never `close()`** (close drops the flock, `:698`/`:710`).
+It cannot use the atomic write-temp→`os.rename` trick the record section calls "atomically-written"
+— renaming onto the sidecar makes a **new inode** and drops the flock. So the record write is
+**genuinely non-atomic**, and the two claims in brief 06 (an "atomically-written JSON line" vs. an
+in-place seek/truncate/write) are **mutually inconsistent**.
+
+Now the race. Winner A must `flock`-win *before* it can know to write, so ordering is forced:
+`open(non-trunc)` → `flock` OK → *(record still empty/stale here)* → write record. Between A's
+flock-win and A's flush there is a window where the sidecar is **empty or half-written**. A
+concurrent starter B probes slot 1, gets `EAGAIN` (A holds the kernel flock — healthy FS!), reads
+the record → **empty/torn → parse-fail → "no live holder" → B takes the OVERRIDE branch (B step 3
+dead/empty case) → B appends to the canonical `.log` while A also writes.** Two live writers on a
+**healthy** filesystem — precisely the R7 property the recommendation claims to preserve and the
+sole reason it rejects Option C. The window is small but is hit exactly under the concurrent-startup
+storm autoscaling produces.
+
+*Mitigation (required):* on `EAGAIN` with an **empty/torn/unparseable** record, **defer to flock →
+advance to `-2`**, never override. Override only on a record that is **present and definitively
+dead** (pid gone / `create_time` mismatch). Also make the write torn-read-resistant: single
+`write()` of a fixed-width, newline-terminated, zero-padded record and have the reader retry-once on
+parse failure. Verdict: **mitigable, but blocking** — ship without it and R7 breaks on ZFS/Lustre both.
+
+## H2 — Internal contradiction: empty/legacy record ⇒ override *or* ⇒ advance? **MUST RESOLVE (toward advance).**
+
+Brief 06 Option B **step 3** lists "dead/stale/**empty/legacy** ⇒ override," but brief 06
+**Backward-compat** says "CONFLICT with a legacy sidecar (no record) ⇒ **defer to flock (advance)**."
+These are opposite verdicts for the identical on-disk state (`EAGAIN` + unparseable sidecar), and
+09 §2-Q2 inherits the ambiguity. H1 forces the resolution: **held-flock + empty/legacy ⇒ advance,
+never override.** Cost: a legacy 0-byte orphan that is *also* a ghost-held flock will not be
+reclaimed by the override path (it still gets reaped later by P2 once its owner reads as dead via a
+*written* record — but legacy holders never wrote one, so those specific orphans persist until the
+fleet finishes rolling to new code). Acceptable — mixed-version fleets are transient — but the plan
+must state it, not paper over it.
+
+## H3 — Concurrent OVERRIDE under a genuine ghost flock: race is NOT "confined to R5". **MITIGABLE; the doc's framing is WRONG.**
+
+09 §3 and 06 §B claim the only residual race is "confined where GOAL R5 already permits bounded
+interleave" (the `_LOCKING=False` / `OSError` regime). False. Consider a **real** ghost flock
+(H-leak/H-stale) on slot 1 with a present-and-dead record. Two starters B1, B2 both probe slot 1 →
+both `EAGAIN` (ghost holds it) → both read the same **dead** record → **both legitimately override →
+both append to canonical.** Neither can take the kernel flock (the ghost owns the OFD), so there is
+**no mutual exclusion among override-ers at all.** This is R7 violation in the regime "flock works
+but a ghost holds it" — which is **not** R5's "locking unavailable." The kernel-closes-the-race
+argument only covers the *acquire* path, never the *override* path.
+
+*Mitigation:* the override path needs its own exclusion. Options: (a) override-ers `flock` a
+**secondary** rendezvous (e.g. `<canonical>.log.reclaim.lock`) — the loser advances; (b) accept it
+and re-label it R5-class interleave (honest, but then say so). Verdict: **mitigable**, but the
+"confined to R5" claim must be struck.
+
+## H4 — pid-only reap races a concurrent claimant → deletes a LIVE generation's files (inode-reuse). **REQUIRED AMENDMENT to the reap design.**
+
+Brief 07/09 insists "reap on pid-liveness, **NEVER** on a flock probe" (because a ghost flock would
+make the probe skip a genuine orphan). But a **pure-pid** reaper is blind to a *concurrent live
+claimant*. Sequence: canonical-winner W scans `client-a306-2.*`, reads its record (owner dead),
+decides delete. Meanwhile the dead owner's kernel flock has released, so a fresh starter N `flock`s
+`-2.lock` (wins), writes its record, and (`delay=True`, `:377`) has not yet created `-2.log`. W now
+`unlink`s `-2.log`/`-2.lock` out from under N. N holds a flock on an **unlinked** inode; a *third*
+starter opening `-2.lock` makes a **new** inode + independent flock → two writers on `-2.log` — the
+exact inode-reuse hazard Q2 warns about, now caused by the reaper deleting a `.lock` sidecar.
+
+*Mitigation (required):* the reaper must **flock-guard each `-N` slot before deleting it** — try to
+acquire that slot's own lock; reap only if acquired (⇒ no live *and* no ghost holder, owner truly
+gone, safe), else skip. This is the *opposite* of "never flock-probe reap," and it is correct:
+missing a ghost-held slot is **safe** (you just don't reclaim it this pass; a bounded miss), whereas
+racing a live claimant is a **regression**. Ghost-held dead slots should be handled at the source by
+P3 (fd-leak fix), not by deleting files under a held lock. Verdict: **mitigable, but the stated reap
+rule must be inverted.**
+
+## H5 — Windows `msvcrt` mandatory locking blocks the reader. **REQUIRED for R8.**
+
+06 says B "keeps the `fcntl`/`msvcrt`/`_LOCKING=False` structure (R8)." But `msvcrt.locking(fd,
+LK_NBLCK, 1)` (`:686`) takes a **mandatory** byte-range lock, and today it locks **byte 0** — where
+the JSON record now lives. A reader (`open('r')`) on Windows can be **denied access to the locked
+region**, so the liveness read fails exactly when a holder is live. `fcntl.flock` is advisory and
+has no such problem; the recommendation's "keeps the msvcrt structure" is not free.
+
+*Mitigation:* on Windows, lock a **high, reserved byte offset** (seek past the max record size, lock
+1 byte there) and keep the record in the low, unlocked bytes so readers can always read it. Verdict:
+**mitigable**, but R8 ("preserve the Windows fallback") is violated as specified.
+
+## H6 — `AccessDenied` (reused pid owned by another user) ⇒ slot never reclaimed. **ACCEPTABLE; document.**
+
+06 correctly treats `AccessDenied` as "alive, never steal." But on a **node-shared** allocation, a
+dead owner's pid can be reused by *another user's* process: `psutil.pid_exists` → True,
+`create_time()` → `AccessDenied` → "alive" → the canonical slot is **never reclaimed** and
+proliferation continues. `host` guard doesn't help (same hostname). This is safe (never steals) but
+defeats the fix on shared nodes. Verdict: **acceptable** on HPC exclusive-node norm (Gautschi jobs
+are typically node-exclusive), but the plan must state the conservative failure mode.
+
+## H7 — pid liveness across PID namespaces / containers. **ACCEPTABLE; document.**
+
+The same-host invariant (`:654-657`) assumes all competitors share a **pid namespace**. Clients in
+separate containers (separate namespaces) sharing a mounted log dir break pid-based liveness: a
+recorded pid is meaningless in another namespace (`pid_exists` may hit an unrelated process).
+`create_time`+`instance` mismatch mostly saves correctness (reads as dead → reclaim, which is at
+worst an over-eager reclaim of a *live* container's slot → possible interleave). HyperShell's
+MPI/Slurm launchers are not per-client-containerized, so out of practical scope. Verdict:
+**acceptable**, note it.
+
+## H8 — `create_time` / boot-id / reboot. **NOT A HOLE (spine is correct).**
+
+The attack brief asked about `/proc/<pid>/stat` field-22 (since-boot jiffies, needs a boot-id).
+Confirmed moot: `psutil>=7.0.0` is a **hard dep** (`pyproject.toml:37`, imported `resource.py:17`),
+and `psutil.create_time()` returns a **wall-clock epoch** (Linux: `btime + starttime/HZ`; macOS
+sysctl; Windows API) — it **folds boot_time in**, so a reboot changes the value and a reused pid
+reads as a mismatch. **No boot-id needed** — 06's claim holds. One caveat: Linux `btime` can jitter
+±1s and psutil precision changed across versions, so the `create_time` comparison **must use a
+tolerance ≥ ~2s** (06 says "small tolerance" — pin it). A pid reused within ~2s with a near-identical
+`create_time` is astronomically unlikely. Verdict: **not a hole**; pin the tolerance.
+
+## H9 — Does the record actually reclaim under a *real* H-leak? **YES — but cost/benefit is misaligned.**
+
+Mechanically the override works: the record stamps the **original owner's** pid (written by the
+parent at claim time), and a lingering fork child that inherited the OFD (`queue.py` BaseManager
+child, brief 05) has a **different** pid — so `pid_exists(original)=False` → dead → override. Good.
+**But** brief 05 is decisive that H-leak affects **server/cluster only, never client**, and the
+observed symptom is `client-<host>` proliferation whose leading cause is **H-conc**. So the OVERRIDE
+branch — the machinery H1/H2/H3 show is the riskiest part — is aimed at a mode that *does not affect
+the reported role*. Under the leading (H-conc) truth, the override branch is **never legitimately
+exercised and is pure added race surface.** Verdict: **gate the override branch behind D0**
+confirming H-leak/H-stale (09 §4 already makes D0 a gate — this reinforces it: if D0 shows H-conc,
+**drop override entirely** and the fix collapses to flock-primary + flock-guarded reap + P3, which is
+smaller and has none of H1/H3).
+
+## Not-a-hole checks
+
+- **P3 fork hardening** (close `_slot_locks` in the manager child via the `_tls_bootstrap` seam,
+  `queue.py:273-281`, + a non-TLS initializer / `os.register_at_fork`): sound and cheap; `close()`
+  in the post-fork child leaves the parent as sole OFD holder → flock releases on true owner exit.
+  `os.set_inheritable(False)` would be useless (exec-only) — 05 is right.
+- **psutil dependency**: no new dep, no EPEL floor issue — confirmed.
+- **`:713` PID-suffix removal**: replacing it with canonical-append (R5 regime) genuinely removes a
+  proliferation bug — correct.
+
+---
+
+## VERDICT
+
+**The recommendation HOLDS in direction** (pid+`create_time` record via already-present psutil;
+flock-primary; reject C/D; KEEP-slots; P3 fork hardening) **but does NOT hold as specified.**
+Required amendments before build:
+
+1. **Override only on a present-and-definitively-dead record.** Empty/torn/legacy under a held flock
+   ⇒ **advance to `-2`**, never override (fixes H1 R7-break on healthy FS; resolves H2 contradiction).
+2. **Make the record write torn-read-safe** (single fixed-width `write()`, reader retry-once);
+   abandon the "atomic rename" language — impossible under a held flock.
+3. **Invert the reap rule: flock-guard each `-N` slot before deleting it** (fixes H4 delete-vs-claim
+   inode-reuse); accept bounded missed ghost-reaps, handle ghosts via P3.
+4. **Windows: lock a reserved high byte offset**, keep the record in unlocked low bytes (fixes H5/R8).
+5. **Gate the OVERRIDE branch behind D0**; if D0 shows H-conc (the leading hypothesis), drop override
+   — it adds H1/H3 risk to fix a mode brief 05 says never hits the client (H9).
+6. **Pin the `create_time` tolerance (~2s)**; document the `AccessDenied`-⇒-never-reclaim (H6) and
+   pid-namespace (H7) conservative failure modes.
+
+With 1–6 applied, Option B is safe and meets R2–R8. Without them, it can **break R7 on a healthy
+filesystem** (H1/H3) and **regress R8 on Windows** (H5) — i.e. it can be *worse* than the status quo.

--- a/spec/logging-file-slot-reclaim/research/11-stress-reap.md
+++ b/spec/logging-file-slot-reclaim/research/11-stress-reap.md
@@ -1,0 +1,169 @@
+# Research 11 — Adversarial stress of the reap / architecture choice
+
+Scope: read-only. This brief **attacks** the recommendations in
+[`09-revised-design.md`](09-revised-design.md) (§3 reap = delete, KEEP-slots) and
+[`07-reap-and-tension.md`](07-reap-and-tension.md) (Part 1 options, Part 2 architectures). It does
+not re-derive the root cause and does **not** resurrect the refuted ENOSYS/exhaustion theory. All
+line refs are `src/hypershell/core/logging.py` unless noted. Verdict is first; the kills follow.
+
+---
+
+## VERDICT (first)
+
+- **Reap = DELETE, never concat.** Concat is *fatal at `small` appetite* (three independent
+  strikes below). DELETE is the safest choice — but only if it (i) deletes the **whole `-N.*`
+  lineage**, and (ii) is interlocked by **acquiring the `-N.lock` flock during the unlink**. Brief
+  07 §1.0's "reap on pid-liveness, **never** on flock" is **too strong and unsafe**: pid-liveness
+  alone races a *relaunched* same-slot writer. The correct oracle is **both** — flock-acquire is
+  the safety interlock against a live/fresh writer; the pid record is only the *ghost-override* for
+  the H-leak case (`pid dead` + flock unacquirable ⇒ inherited-OFD ghost that isn't writing ⇒ safe
+  to delete). Neither signal alone is sufficient.
+- **Architecture = KEEP-slots (A).** SINGLE-file-per-host (B/II) is not merely "big" — with
+  rotation enabled it is **correctness-breaking** (cross-process rename/compress/prune corruption;
+  `FILE_LOCK` is process-local, `:355`) and on Lustre risks **torn lines**. It also silently
+  violates R7. Reject B.
+- **Does KEEP-slots satisfy "one file per host"?** Only in the *serial* regime (where reclaim
+  already delivers it). It cannot give one file during genuine concurrency without violating R7.
+  That is a UX/expectation gap, not a bug — and it is the honest answer to give the maintainer.
+
+---
+
+## PART 1 — Kill the concat-append reap path
+
+### Strike 1 — Non-idempotent; crash mid-concat duplicates or truncates (FATAL)
+Concat is *append into a live file*, so the atomic-rename trick cannot apply (07 §1.4 concedes
+this; I sharpen it). Sequence: reaper appends orphan bytes to `client-a306.log`, then `os.remove`
+the orphan. A crash (SIGKILL / OOM / node eviction — the *normal* autoscaling exit) **between** the
+append and the unlink means the next start finds the orphan still present and **re-appends the same
+bytes → duplicated log lines**, unboundedly across restarts. A `.reaping` marker does not close the
+window: the append itself is not all-or-nothing under `O_APPEND` on Lustre, so a crash *mid-append*
+leaves a **truncated** partial record with no way to know how many bytes already landed. DELETE
+(`os.remove` swallowing `FileNotFoundError`/`OSError`) is idempotent by construction.
+
+### Strike 2 — Concat races the reaper's *own* writer thread and corrupts the byte counter (FATAL, missed by 07)
+The reaping process is the fresh canonical (slot-1) winner. Its file writes go through a
+**QueueListener background thread** (`:818-819`) driving `file_handler`. If concat runs in
+`initialize_logging` (the natural site, beside `recover_interrupted_compression`, `:836-838`) it
+executes on the **main thread** and does a raw `open(canonical,'a')` + `copyfileobj`. That is a
+**second, unsynchronized writer** to the canonical file from the *same process* — `FILE_LOCK`
+(`:355`) guards only rotation, not raw appends, so listener records and concatenated orphan bytes
+interleave/tear. Worse: the concatenated bytes **bypass `update_interval`** (`:460-462`), so
+`SizeRotatingFileHandler.count_bytes` never accounts for them → the size-rotation threshold
+misfires (over-large files, or rotation at the wrong offset). Concat silently breaks the rotation
+accounting the handler depends on. DELETE touches neither the writer thread nor the counter.
+
+### Strike 3 — Mis-detected-dead owner still writing ⇒ corruption (FATAL for concat, guarded for delete)
+`os.kill(pid,0)` / `psutil.pid_exists` is a TOCTOU probe. Under **H-stale** (network
+release-visibility lag) or a transient stop, a live orphan owner can read as dead; concat then
+copies a file *being appended to concurrently on another node* — interleaved/torn merge into the
+permanent canonical history. DELETE gated on **flock-acquire** is immune: a live owner still holds
+the `-N.lock` flock, the reaper fails to acquire, and skips. (This is exactly why "reap on pid,
+never on flock" is wrong — see Part 3.)
+
+### Strike 4 — Out-of-time-order lines break parsers (MITIGABLE, but a silent contract change)
+Concat lands the orphan's T0..T2 records **after** canonical records already written to T2 (07
+§1.3). `grep`/`sort -k<time>`/log-shippers that assume file order break. Only acceptable if every
+consumer keys on the embedded `%(asctime)s` — an assumption the fix would impose silently.
+
+### Strike 5 — An orphan is a *lineage*, not a file: unbounded concat work (FATAL at `small`)
+`client-a306-2.log` owns a private rotation lineage (`-2.1`, `-2.20260723`, `.gz`, `.gz.partial`;
+`:230-277`, `:473-491`). Concatenating "properly" means **decompressing** children and
+**time-merging two independent rotation lineages** — decisively over `small` (07 §1.2). Concat of
+the bare `-2.log` **only** silently abandons the compressed children, which are themselves the
+proliferation the feature exists to stop. DELETE-the-whole-lineage is both smaller and *more
+complete*.
+
+**Concat verdict: reject.** Strikes 1, 2, 3, 5 are individually fatal at the stated appetite. R3
+("reclaim ⇒ append, preserve history") is about the **canonical file's continuity across serial
+generations** — which KEEP-slots reclaim already delivers (re-acquire the persistent sidecar flock,
+handler opens `mode='a'`, `:377`) — **not** about resurrecting a dead concurrent slot's tail.
+Losing a crashed *concurrent* generation's private tail is acceptable; corrupting the permanent
+host history to save it is not.
+
+---
+
+## PART 2 — Kill SINGLE-file-per-host (Architecture B / brief 07 II)
+
+### Strike A — Cross-process rotation is corrupting, not just "racy" (FATAL)
+`FILE_LOCK` is a **process-local** `Lock()` (`:355`) — it cannot serialize N processes. With N live
+appenders on one `client-host.log`: process A hits its size threshold, `rotate()` does
+`close()`+`os.rename(log → log.1)`+queues compression (`:398-405`). Process B still holds an open
+`mode='a'` fd (`:377`, `delay=True`) to the **renamed inode** → B keeps writing into `log.1` while
+A creates a fresh `log` and A's compression thread **compresses `log.1` out from under B**
+(`:483-491`) and prunes it (`files_eligible_for_deletion`, `:334-345`). Result: silent data loss +
+compressing a file under an active writer. Every process also independently runs
+`recover_interrupted_compression` on the shared prefix at startup (`:837`), racing to re-queue the
+same partials (`:513-533`). Making B safe requires a **cross-process rotation election / flock-gated
+rotation** the slot scheme never needed → this is the "big" the briefs name, but the framing
+"smaller" undersells that B is *broken with rotation on by default*.
+
+### Strike B — Torn lines on Lustre (FATAL on the target FS)
+stdlib emits each record as a single `stream.write(msg+terminator)`, and `O_APPEND` makes that
+atomic **only up to a per-FS bound** (~`PIPE_BUF` for pipes; regular-file guarantees are weaker and
+implementation-defined). Multi-node concurrent `O_APPEND` on Lustre is **not** guaranteed atomic
+for records exceeding a stripe/`PIPE_BUF`-class size — the exact deployment (Gautschi `/scratch`)
+where the maintainer runs. Interleaved partial lines corrupt records. 07 §II bills interleave as
+"line-atomic on most filesystems"; on the *actual* filesystem that is not safe.
+
+### Strike C — Silently violates R7 (FATAL vs GOAL as written)
+R7 requires distinct files for genuinely-concurrent same-host writers where locking works. B
+abolishes that by construction. It needs an explicit **GOAL amendment** (relax R7 to "best-effort
+single-writer"), so choosing it silently would ship a spec violation.
+
+**SINGLE-file verdict: reject** unless the maintainer *both* amends R7 *and* accepts a cross-process
+rotation-election phase (big). Its only genuinely-needed piece — a **one-shot legacy sweep** of the
+pile already on Gautschi — is deliverable inside Architecture A anyway.
+
+---
+
+## PART 3 — Correct the reap oracle; confirm DELETE is safest
+
+Brief 07 §1.0 disqualifies flock-probe reap because H-leak's ghost flock makes a dead owner's slot
+read LOCKED. True — but the proposed replacement, **reap on pid-liveness alone**, opens a *new*
+hole: between reading the (dead) pid record and unlinking, a **relaunched** process can legitimately
+claim `-2` (the slot is genuinely free), rewrite the record with its live pid, open `-2.log`
+`mode='a'`, and start writing — the reaper then **deletes a live writer's file**. pid-liveness is
+not a mutual-exclusion primitive; only the flock is.
+
+**Correct interlock (needs BOTH signals):** to reap slot `-N`, attempt `flock(-N.lock, LOCK_EX|
+LOCK_NB)`.
+- **Acquired** ⇒ no live writer holds it (original dead, none relaunched) ⇒ delete the whole `-N.*`
+  lineage **while holding the flock**, then release. (This is safe even though it *uses* flock —
+  the H-leak objection is about flock giving a false *LOCKED*, never a false *FREE*.)
+- **Not acquired** ⇒ consult the pid record: **alive** ⇒ genuine sibling/relaunch ⇒ skip.
+  **dead** ⇒ inherited-OFD **ghost** (H-leak): the flock is held by a live *inheritor that never
+  writes* `-N.log`, and no fresh claimant can exist (they'd fail the same flock), so deleting the
+  data is safe — this is the *only* place the pid record overrides flock.
+
+So: **flock-acquire is the interlock, the pid record is the ghost-override.** "Never on flock" is
+wrong; "never on flock *alone* / never trust flock's LOCKED verdict without the pid record" is
+right. DELETE composes cleanly with this (idempotent unlink under the held lock); concat cannot
+(Strikes 1–2 persist even under the lock). **DELETE is the safest choice**, confirming R3 is about
+canonical continuity, not dead-slot resurrection.
+
+### Residual bounded-work note (ACCEPTABLE)
+Reap runs one-shot at startup beside `recover_interrupted_compression` (`:836-838`), before the
+compression thread does real work (invariant §5 respected). Cost is O(files in log dir) `stat`/
+`flock`/`unlink` — bounded by current disk state, idempotent, and self-reducing across restarts.
+Not unbounded per-record. Acceptable even with hundreds of legacy orphans.
+
+---
+
+## Scorecard
+
+| Target | Strike | Severity |
+|---|---|---|
+| Concat | crash mid-concat dup/truncate (non-idempotent) | **fatal** |
+| Concat | races own QueueListener thread + corrupts `count_bytes` | **fatal** |
+| Concat | mis-detected-live owner corruption (no flock interlock) | **fatal** |
+| Concat | out-of-time-order lines | mitigable |
+| Concat | abandons/over-merges `-N.*` rotation lineage | **fatal @ small** |
+| SINGLE-file | cross-process rename/compress/prune corruption (`FILE_LOCK` local) | **fatal** |
+| SINGLE-file | Lustre `O_APPEND` torn lines | **fatal on target FS** |
+| SINGLE-file | silent R7 violation | **fatal vs GOAL** |
+| DELETE (recommended) | needs flock-interlock + whole-lineage + host guard | mitigable (design it in) |
+| KEEP-slots (recommended) | "one file/host" only in serial regime | acceptable (expectation gap) |
+
+**Final recommendation:** reap = **DELETE whole `-N.*` lineage, interlocked by flock-acquire with
+the pid record as ghost-override**; architecture = **KEEP-slots (A)**. Reject concat and reject
+SINGLE-file.

--- a/src/hypershell/core/logging.py
+++ b/src/hypershell/core/logging.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Tuple, Dict, Any, Type, Final, Optional, List, Callable, TypeAlias
 from types import ModuleType
 
-# standard libraries
+# Standard libs
 import os
 import re
 import sys
@@ -17,6 +17,7 @@ import json
 import errno
 import atexit
 import socket
+import platform
 import importlib
 from datetime import datetime, timedelta
 from abc import abstractmethod, ABC
@@ -34,6 +35,7 @@ from logging import (
 from cmdkit.app import exit_status
 from cmdkit.config import Namespace, ConfigurationError
 from cmdkit.ansi import Ansi, COLOR_STDERR
+import psutil
 
 # Internal libs
 from hypershell.core.uuid import uuid
@@ -661,7 +663,7 @@ def default_file_for(role: str) -> str:
     return os.path.join(default_path.log, f'{stem}.log')
 
 
-class _LockUnsupported(Exception):
+class LockUnsupported(Exception):
     """Raised when the filesystem provides no advisory locking (degrade to canonical append)."""
 
 
@@ -670,28 +672,28 @@ class _LockUnsupported(Exception):
 # real process still holds the slot (start-time defeats PID reuse; the baked-in host
 # guarantees the PID is local and checkable). Version 1 record shape:
 #   {"v": 1, "pid": int, "create_time": float|null, "host": str, "instance": str}
-_LOCK_RECORD_VERSION: Final[int] = 1
+LOCK_RECORD_VERSION: Final[int] = 1
 
 
-def _process_create_time() -> Optional[float]:
+def process_create_time() -> Optional[float]:
     """This process's start time (epoch seconds) for pid-reuse defense in the owner record."""
     try:
-        import psutil
         return psutil.Process(os.getpid()).create_time()
     except Exception:  # psutil should always resolve our own pid; never fail claiming over it.
         return None
 
 
-def _write_lock_record(handle: Any) -> None:
-    """Stamp the (locked) sidecar with this process's owner record; keep the lock held.
+def write_lock_record(handle: Any) -> None:
+    """
+    Stamp the (locked) sidecar with this process's owner record; keep the lock held.
 
     Best-effort: the flock, not the record, is the single-writer gate, so a failed write
     never blocks slot claiming (the sidecar simply reads back as 'no live holder').
     """
     record = json.dumps({
-        'v': _LOCK_RECORD_VERSION,
+        'v': LOCK_RECORD_VERSION,
         'pid': os.getpid(),
-        'create_time': _process_create_time(),
+        'create_time': process_create_time(),
         'host': HOSTNAME_SHORT,
         'instance': INSTANCE,
     })
@@ -722,8 +724,9 @@ def read_lock_record(path: str) -> Optional[Dict[str, Any]]:
     return None
 
 
-def _owner_alive(record: Optional[Dict[str, Any]]) -> bool:
-    """Whether the process that wrote `record` is still alive on this host.
+def owner_alive(record: Optional[Dict[str, Any]]) -> bool:
+    """
+    Whether the process that wrote `record` is still alive on this host.
 
     Conservative: an empty, foreign-host, or malformed record reads as no live holder,
     but a live same-identity process we merely cannot inspect is treated as alive so we
@@ -734,7 +737,6 @@ def _owner_alive(record: Optional[Dict[str, Any]]) -> bool:
     pid = record.get('pid')
     if not isinstance(pid, int):
         return False
-    import psutil
     if not psutil.pid_exists(pid):
         return False
     try:
@@ -761,8 +763,9 @@ def _owner_alive(record: Optional[Dict[str, Any]]) -> bool:
 # process. The lock releases when the last descriptor on its open-file-description closes
 # (normally at process exit; a forked child that inherits the descriptor must close its
 # own copy or the slot stays held past the true owner's death).
-def _open_sidecar(path: str) -> Any:
-    """Open (creating if needed) a lock sidecar for read/write, never truncating.
+def open_sidecar(path: str) -> Any:
+    """
+    Open (creating if needed) a lock sidecar for read/write, never truncating.
 
     A losing probe must not blank the winner's record, so the open is non-truncating; only the
     winner rewrites the record after it holds the lock. The handle's '.name' is the sidecar path,
@@ -771,111 +774,125 @@ def _open_sidecar(path: str) -> Any:
     return open(path, mode='a+')
 
 
-try:
-    import fcntl
-    def _acquire_lock(handle: Any) -> bool:
-        """Take the advisory lock on `handle`: True if acquired, False on genuine contention;
-        raise `_LockUnsupported` if the filesystem provides no advisory locking."""
-        while True:
-            try:
-                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-                return True
-            except InterruptedError:
-                continue  # EINTR: retry the interrupted syscall.
-            except BlockingIOError:
-                return False  # A live holder has the slot.
-            except OSError as exc:
-                if exc.errno == errno.EINTR:
-                    continue
-                if exc.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
-                    return False
-                raise _LockUnsupported from exc  # No advisory locking on this filesystem.
-    _LOCKING = True
-except ImportError:
+# Filesystem implements locking mechanism
+LOCKING: bool = True
+
+if platform.system() == 'Windows':
     try:
         import msvcrt
-        def _acquire_lock(handle: Any) -> bool:
-            """Take the advisory lock on `handle`; msvcrt cannot distinguish contention from an
-            unsupported filesystem, so every failure reads as contention (conflict-only)."""
+
+        def acquire_lock(handle: Any) -> bool:
+            """
+            Take the advisory lock on `handle`; msvcrt cannot distinguish contention from an
+            unsupported filesystem, so every failure reads as contention (conflict-only).
+            """
             try:
                 msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
                 return True
             except OSError:
                 return False
-        _LOCKING = True
+
     except ImportError:
-        _acquire_lock = None
-        _LOCKING = False
-
-
-def _try_lock(path: str) -> Optional[Any]:
-    """Acquire an exclusive, non-blocking lock on the sidecar; return the held handle (with the
-    owner record written), None on genuine contention, or raise `_LockUnsupported` when the
-    filesystem lacks advisory locking."""
-    handle = _open_sidecar(path)
+        acquire_lock = None
+        LOCKING = False
+else:
     try:
-        acquired = _acquire_lock(handle)
-    except _LockUnsupported:
+        import fcntl
+
+        def acquire_lock(handle: Any) -> bool:
+            """
+            Take the advisory lock on `handle`: True if acquired, False on genuine contention;
+            raise `LockUnsupported` if the filesystem provides no advisory locking.
+            """
+            while True:
+                try:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    return True
+                except InterruptedError:
+                    continue  # EINTR: retry the interrupted syscall.
+                except BlockingIOError:
+                    return False  # A live holder has the slot.
+                except OSError as exc:
+                    if exc.errno == errno.EINTR:
+                        continue
+                    if exc.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
+                        return False
+                    raise LockUnsupported from exc  # No advisory locking on this filesystem.
+
+    except ImportError:
+        acquire_lock = None
+        LOCKING = False
+
+
+def try_lock(path: str) -> Optional[Any]:
+    """Acquire an exclusive, non-blocking lock on the sidecar; return the held handle (with the
+    owner record written), None on genuine contention, or raise `LockUnsupported` when the
+    filesystem lacks advisory locking."""
+    handle = open_sidecar(path)
+    try:
+        acquired = acquire_lock(handle)
+    except LockUnsupported:
         handle.close()
         raise
     if not acquired:
         handle.close()
         return None
-    _write_lock_record(handle)
+    write_lock_record(handle)
     return handle
 
 
 # Held lock handles keep claimed slots reserved for the life of the process. Each handle's
 # '.name' is its sidecar path, so a clean shutdown can unlink it while still holding the lock.
-_slot_locks: List[Any] = []
+slot_locks: List[Any] = []
 
 # The shutdown finalizer is registered once, on the first successful claim.
-_ATEXIT_REGISTERED: bool = False
-_FINALIZED: bool = False
+ATEXIT_REGISTERED: bool = False
+_FINAL: bool = False
 
 
 def claim_file_slot(path: str, max_slots: int = 100) -> str:
     """Return the first unclaimed per-process variant of `path`, holding its lock."""
-    global _ATEXIT_REGISTERED
+    global ATEXIT_REGISTERED
     os.makedirs(os.path.dirname(path) or '.', exist_ok=True)
     root, ext = os.path.splitext(path)
-    if _LOCKING:
+    if LOCKING:
         try:
             for n in range(1, max_slots + 1):
                 candidate = path if n == 1 else f'{root}-{n}{ext}'
-                handle = _try_lock(candidate + '.lock')
+                handle = try_lock(candidate + '.lock')
                 if handle is not None:
-                    _slot_locks.append(handle)
-                    if not _ATEXIT_REGISTERED:
+                    slot_locks.append(handle)
+                    if not ATEXIT_REGISTERED:
                         atexit.register(finalize_logging)  # Drop our sidecars on clean exit.
-                        _ATEXIT_REGISTERED = True
+                        ATEXIT_REGISTERED = True
                     return candidate
             warn(f'Exhausted {max_slots} log-file slots for \'{path}\'; using PID suffix')
             return f'{root}-{os.getpid()}{ext}'  # Genuine all-EAGAIN exhaustion: real concurrency.
-        except _LockUnsupported:
+        except LockUnsupported:
             return path  # Lockless filesystem: append to the canonical per-host path.
     return path  # No advisory-locking support at all: append to the canonical per-host path.
 
 
 def finalize_logging() -> None:
-    """Stop file logging and drop this process's own lock sidecars (best-effort, clean exit).
+    """
+    Stop file logging and drop this process's own lock sidecars (best-effort, clean exit).
 
     Registered via `atexit` on the first claim. File logging is stopped first so no record races
     the unlink, then each held sidecar is unlinked *while its lock is still held* (the R8
     only-unlink-under-the-held-lock safety invariant) and closed. Idempotent; a `SIGKILL`/OOM
     that skips this is swept by the next start's `prune_stale_sidecars`.
     """
-    global _FINALIZED
-    if _FINALIZED:
+    global _FINAL
+    if _FINAL:
         return
-    _FINALIZED = True
+    _FINAL = True
     if queue_listener is not None:
         try:
             queue_listener.stop()  # Flush and stop the writer thread: no further file writes.
         except Exception:
             pass
-    while _slot_locks:
-        handle = _slot_locks.pop()
+    while slot_locks:
+        handle = slot_locks.pop()
         try:
             os.unlink(handle.name)  # Unlink our own sidecar while still holding its lock.
         except OSError:
@@ -887,7 +904,8 @@ def finalize_logging() -> None:
 
 
 def close_inherited_slot_locks() -> None:
-    """Close slot-lock descriptors inherited by a forked child, without unlinking any sidecar.
+    """
+    Close slot-lock descriptors inherited by a forked child, without unlinking any sidecar.
 
     A fork-without-exec child (the queue-manager subprocess) inherits the parent's slot-lock
     open-file-descriptions and would keep their advisory locks held until it too exits, ghost-
@@ -896,8 +914,8 @@ def close_inherited_slot_locks() -> None:
     the parent still owns them (only-unlink-under-the-held-lock, R8). No-op where there is no
     fork / on Windows / when nothing is held.
     """
-    while _slot_locks:
-        handle = _slot_locks.pop()
+    while slot_locks:
+        handle = slot_locks.pop()
         try:
             handle.close()
         except OSError:
@@ -905,14 +923,15 @@ def close_inherited_slot_locks() -> None:
 
 
 def prune_stale_sidecars(canonical_path: str) -> None:
-    """Remove stale sibling '<root>-N<ext>.lock' sidecars that no live process holds.
+    """
+    Remove stale sibling '<root>-N<ext>.lock' sidecars that no live process holds.
 
     Only the process that won the canonical slot calls this. A candidate is removed only if its
     advisory lock can be acquired (no live holder) and *while that lock is held* (R8); a sidecar
     a live process holds is left untouched. Only '.lock' sidecars are ever removed — never the
     '-N<ext>' data, its rotated/compressed lineage, or the 'main' role (R5).
     """
-    if not _LOCKING:
+    if not LOCKING:
         return  # Nothing to prune where advisory locking is unavailable.
     root, ext = os.path.splitext(canonical_path)
     log_dir = os.path.dirname(canonical_path) or '.'
@@ -923,18 +942,18 @@ def prune_stale_sidecars(canonical_path: str) -> None:
         return
     for name in entries:
         if pattern.fullmatch(name):
-            _prune_one_sidecar(os.path.join(log_dir, name))
+            prune_one_sidecar(os.path.join(log_dir, name))
 
 
-def _prune_one_sidecar(path: str) -> None:
+def prune_one_sidecar(path: str) -> None:
     """Flock-guarded unlink of a single stale sidecar (the acquirable lock is the safety gate)."""
     try:
-        handle = _open_sidecar(path)
+        handle = open_sidecar(path)
     except OSError:
         return
     try:
-        acquired = _acquire_lock(handle)
-    except _LockUnsupported:
+        acquired = acquire_lock(handle)
+    except LockUnsupported:
         handle.close()
         return  # A lockless filesystem has no reclaimable sidecar to prune safely.
     if not acquired:

--- a/src/hypershell/core/logging.py
+++ b/src/hypershell/core/logging.py
@@ -48,8 +48,8 @@ from hypershell.core.config import (
 
 # Public interface
 __all__ = ['Logger', 'HOSTNAME', 'INSTANCE', 'initialize_logging', 'finalize_logging',
-           'DEFAULT_LOGGING_LEVEL', 'role_from_command', 'default_file_for', 'claim_file_slot',
-           'read_lock_record']
+           'close_inherited_slot_locks', 'DEFAULT_LOGGING_LEVEL', 'role_from_command',
+           'default_file_for', 'claim_file_slot', 'read_lock_record']
 
 
 # Cached for later use
@@ -880,6 +880,24 @@ def finalize_logging() -> None:
             os.unlink(handle.name)  # Unlink our own sidecar while still holding its lock.
         except OSError:
             pass
+        try:
+            handle.close()
+        except OSError:
+            pass
+
+
+def close_inherited_slot_locks() -> None:
+    """Close slot-lock descriptors inherited by a forked child, without unlinking any sidecar.
+
+    A fork-without-exec child (the queue-manager subprocess) inherits the parent's slot-lock
+    open-file-descriptions and would keep their advisory locks held until it too exits, ghost-
+    locking the slot if the parent is killed. The child closes its inherited copies so each lock
+    releases exactly when the true owner (the parent) exits. It must NOT unlink the sidecars —
+    the parent still owns them (only-unlink-under-the-held-lock, R8). No-op where there is no
+    fork / on Windows / when nothing is held.
+    """
+    while _slot_locks:
+        handle = _slot_locks.pop()
         try:
             handle.close()
         except OSError:

--- a/src/hypershell/core/logging.py
+++ b/src/hypershell/core/logging.py
@@ -15,6 +15,7 @@ import re
 import sys
 import json
 import errno
+import atexit
 import socket
 import importlib
 from datetime import datetime, timedelta
@@ -46,8 +47,9 @@ from hypershell.core.config import (
 )
 
 # Public interface
-__all__ = ['Logger', 'HOSTNAME', 'INSTANCE', 'initialize_logging', 'DEFAULT_LOGGING_LEVEL',
-           'role_from_command', 'default_file_for', 'claim_file_slot', 'read_lock_record']
+__all__ = ['Logger', 'HOSTNAME', 'INSTANCE', 'initialize_logging', 'finalize_logging',
+           'DEFAULT_LOGGING_LEVEL', 'role_from_command', 'default_file_for', 'claim_file_slot',
+           'read_lock_record']
 
 
 # Cached for later use
@@ -762,65 +764,79 @@ def _owner_alive(record: Optional[Dict[str, Any]]) -> bool:
 def _open_sidecar(path: str) -> Any:
     """Open (creating if needed) a lock sidecar for read/write, never truncating.
 
-    A losing probe must not blank the winner's record, so the open is non-truncating;
-    only the winner rewrites the record after it holds the lock.
+    A losing probe must not blank the winner's record, so the open is non-truncating; only the
+    winner rewrites the record after it holds the lock. The handle's '.name' is the sidecar path,
+    which the shutdown finalizer relies on to unlink it while still holding the lock.
     """
-    return os.fdopen(os.open(path, os.O_RDWR | os.O_CREAT, 0o644), 'r+')
+    return open(path, mode='a+')
 
 
 try:
     import fcntl
-    def _try_lock(path: str) -> Optional[Any]:
-        """Acquire an exclusive, non-blocking lock; return the held handle, None on genuine
-        contention, and raise `_LockUnsupported` when the filesystem lacks advisory locking."""
-        handle = _open_sidecar(path)
+    def _acquire_lock(handle: Any) -> bool:
+        """Take the advisory lock on `handle`: True if acquired, False on genuine contention;
+        raise `_LockUnsupported` if the filesystem provides no advisory locking."""
         while True:
             try:
                 fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                return True
             except InterruptedError:
                 continue  # EINTR: retry the interrupted syscall.
             except BlockingIOError:
-                handle.close()
-                return None  # A live sibling holds the slot; advance.
+                return False  # A live holder has the slot.
             except OSError as exc:
                 if exc.errno == errno.EINTR:
                     continue
                 if exc.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
-                    handle.close()
-                    return None
-                handle.close()
+                    return False
                 raise _LockUnsupported from exc  # No advisory locking on this filesystem.
-            _write_lock_record(handle)
-            return handle
     _LOCKING = True
 except ImportError:
     try:
         import msvcrt
-        def _try_lock(path: str) -> Optional[Any]:
-            """Acquire an exclusive, non-blocking lock; return the held handle or None.
-
-            msvcrt cannot distinguish contention from an unsupported filesystem, so every
-            failure is treated as contention (conflict-only)."""
-            handle = _open_sidecar(path)
+        def _acquire_lock(handle: Any) -> bool:
+            """Take the advisory lock on `handle`; msvcrt cannot distinguish contention from an
+            unsupported filesystem, so every failure reads as contention (conflict-only)."""
             try:
                 msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                return True
             except OSError:
-                handle.close()
-                return None
-            _write_lock_record(handle)
-            return handle
+                return False
         _LOCKING = True
     except ImportError:
-        _try_lock = None
+        _acquire_lock = None
         _LOCKING = False
 
 
-# Held lock handles keep claimed slots reserved for the life of the process.
+def _try_lock(path: str) -> Optional[Any]:
+    """Acquire an exclusive, non-blocking lock on the sidecar; return the held handle (with the
+    owner record written), None on genuine contention, or raise `_LockUnsupported` when the
+    filesystem lacks advisory locking."""
+    handle = _open_sidecar(path)
+    try:
+        acquired = _acquire_lock(handle)
+    except _LockUnsupported:
+        handle.close()
+        raise
+    if not acquired:
+        handle.close()
+        return None
+    _write_lock_record(handle)
+    return handle
+
+
+# Held lock handles keep claimed slots reserved for the life of the process. Each handle's
+# '.name' is its sidecar path, so a clean shutdown can unlink it while still holding the lock.
 _slot_locks: List[Any] = []
+
+# The shutdown finalizer is registered once, on the first successful claim.
+_ATEXIT_REGISTERED: bool = False
+_FINALIZED: bool = False
 
 
 def claim_file_slot(path: str, max_slots: int = 100) -> str:
     """Return the first unclaimed per-process variant of `path`, holding its lock."""
+    global _ATEXIT_REGISTERED
     os.makedirs(os.path.dirname(path) or '.', exist_ok=True)
     root, ext = os.path.splitext(path)
     if _LOCKING:
@@ -830,6 +846,9 @@ def claim_file_slot(path: str, max_slots: int = 100) -> str:
                 handle = _try_lock(candidate + '.lock')
                 if handle is not None:
                     _slot_locks.append(handle)
+                    if not _ATEXIT_REGISTERED:
+                        atexit.register(finalize_logging)  # Drop our sidecars on clean exit.
+                        _ATEXIT_REGISTERED = True
                     return candidate
             warn(f'Exhausted {max_slots} log-file slots for \'{path}\'; using PID suffix')
             return f'{root}-{os.getpid()}{ext}'  # Genuine all-EAGAIN exhaustion: real concurrency.
@@ -838,14 +857,95 @@ def claim_file_slot(path: str, max_slots: int = 100) -> str:
     return path  # No advisory-locking support at all: append to the canonical per-host path.
 
 
-def resolve_log_path(path: str, role: str, is_default: bool) -> str:
-    """Host-scope an explicit client path, then claim an exclusive per-process slot."""
+def finalize_logging() -> None:
+    """Stop file logging and drop this process's own lock sidecars (best-effort, clean exit).
+
+    Registered via `atexit` on the first claim. File logging is stopped first so no record races
+    the unlink, then each held sidecar is unlinked *while its lock is still held* (the R8
+    only-unlink-under-the-held-lock safety invariant) and closed. Idempotent; a `SIGKILL`/OOM
+    that skips this is swept by the next start's `prune_stale_sidecars`.
+    """
+    global _FINALIZED
+    if _FINALIZED:
+        return
+    _FINALIZED = True
+    if queue_listener is not None:
+        try:
+            queue_listener.stop()  # Flush and stop the writer thread: no further file writes.
+        except Exception:
+            pass
+    while _slot_locks:
+        handle = _slot_locks.pop()
+        try:
+            os.unlink(handle.name)  # Unlink our own sidecar while still holding its lock.
+        except OSError:
+            pass
+        try:
+            handle.close()
+        except OSError:
+            pass
+
+
+def prune_stale_sidecars(canonical_path: str) -> None:
+    """Remove stale sibling '<root>-N<ext>.lock' sidecars that no live process holds.
+
+    Only the process that won the canonical slot calls this. A candidate is removed only if its
+    advisory lock can be acquired (no live holder) and *while that lock is held* (R8); a sidecar
+    a live process holds is left untouched. Only '.lock' sidecars are ever removed — never the
+    '-N<ext>' data, its rotated/compressed lineage, or the 'main' role (R5).
+    """
+    if not _LOCKING:
+        return  # Nothing to prune where advisory locking is unavailable.
+    root, ext = os.path.splitext(canonical_path)
+    log_dir = os.path.dirname(canonical_path) or '.'
+    pattern = re.compile(rf'^{re.escape(os.path.basename(root))}-([0-9]+){re.escape(ext)}\.lock$')
+    try:
+        entries = os.listdir(log_dir)
+    except OSError:
+        return
+    for name in entries:
+        if pattern.fullmatch(name):
+            _prune_one_sidecar(os.path.join(log_dir, name))
+
+
+def _prune_one_sidecar(path: str) -> None:
+    """Flock-guarded unlink of a single stale sidecar (the acquirable lock is the safety gate)."""
+    try:
+        handle = _open_sidecar(path)
+    except OSError:
+        return
+    try:
+        acquired = _acquire_lock(handle)
+    except _LockUnsupported:
+        handle.close()
+        return  # A lockless filesystem has no reclaimable sidecar to prune safely.
+    if not acquired:
+        handle.close()  # A live process holds the slot; leave its sidecar in place.
+        return
+    record = read_lock_record(path)  # Diagnostics only; the flock-acquire is the safety gate.
+    try:
+        os.unlink(path)  # Unlink while holding the lock: closes the inode-reuse race (R8).
+        pid = record.get('pid') if record else None
+        debug(f'Pruned stale log-lock sidecar ({path})' + (f' (dead pid {pid})' if pid else ''))
+    except OSError:
+        pass
+    finally:
+        handle.close()
+
+
+def host_scoped_path(path: str, role: str, is_default: bool) -> str:
+    """Host-scope an explicit client path (the default is already host-scoped)."""
     if role == 'client' and not is_default:
         # A client-role process launched across many hosts must not share a user's
         # explicit path (the default is already host-scoped); decorate it per host.
         root, ext = os.path.splitext(path)
         path = f'{root}-client-{HOSTNAME_SHORT}{ext}'
-    return claim_file_slot(path)
+    return path
+
+
+def resolve_log_path(path: str, role: str, is_default: bool) -> str:
+    """Host-scope an explicit client path, then claim an exclusive per-process slot."""
+    return claim_file_slot(host_scoped_path(path, role, is_default))
 
 
 # Only permit calling initialize_logging once
@@ -879,7 +979,8 @@ def initialize_logging(role: str = DEFAULT_ROLE) -> None:
     merely_enabled = [True, 'enabled']
     if isinstance(file_config, (str, bool)):
         is_default = file_config in merely_enabled
-        file_path = resolve_log_path(default_file if is_default else file_config, role, is_default)
+        canonical_path = host_scoped_path(default_file if is_default else file_config, role, is_default)
+        file_path = claim_file_slot(canonical_path)
         file_handler = TimedRotatingFileHandler(filename=file_path)
         file_handler.setFormatter(Formatter(default_file_format, datefmt=datefmt))
         file_handler.setLevel(LEVEL_MAPPING[default_file_level])
@@ -893,7 +994,8 @@ def initialize_logging(role: str = DEFAULT_ROLE) -> None:
 
         requested = file_config.pop('path', default_config.logging.file.path)
         is_default = requested == PARAM_UNSET
-        file_path = resolve_log_path(default_file if is_default else requested, role, is_default)
+        canonical_path = host_scoped_path(default_file if is_default else requested, role, is_default)
+        file_path = claim_file_slot(canonical_path)
         file_policy = file_config.pop('rotate', DEFAULT_ROTATION_INTERVAL)
         file_compress = file_config.pop('compress', default_config.logging.file.compress)
         file_compress = file_compress if file_compress != PARAM_UNSET else None
@@ -960,4 +1062,6 @@ def initialize_logging(role: str = DEFAULT_ROLE) -> None:
 
     if file_handler is not None:
         recover_interrupted_compression(file_handler.filename)
+        if role in DISTRIBUTED_ROLES and file_path == canonical_path:
+            prune_stale_sidecars(canonical_path)  # Sweep crash-leftover sibling sidecars (R4).
         compression_jobs.put_nowait(False)  # Bookmark the completion of recovered files

--- a/src/hypershell/core/logging.py
+++ b/src/hypershell/core/logging.py
@@ -13,6 +13,8 @@ from types import ModuleType
 import os
 import re
 import sys
+import json
+import errno
 import socket
 import importlib
 from datetime import datetime, timedelta
@@ -45,7 +47,7 @@ from hypershell.core.config import (
 
 # Public interface
 __all__ = ['Logger', 'HOSTNAME', 'INSTANCE', 'initialize_logging', 'DEFAULT_LOGGING_LEVEL',
-           'role_from_command', 'default_file_for', 'claim_file_slot']
+           'role_from_command', 'default_file_for', 'claim_file_slot', 'read_lock_record']
 
 
 # Cached for later use
@@ -657,37 +659,156 @@ def default_file_for(role: str) -> str:
     return os.path.join(default_path.log, f'{stem}.log')
 
 
-# We enforce the single-writer invariant with an advisory lock on a per-file
-# '.lock' sidecar, held (by the OS, so it releases even on a crash) for the life
-# of the process. Contention is only ever same-host because the hostname is baked
-# into the filename, and same-host advisory locks are reliable even on shared
-# network filesystems. Contended slots fall through to 'name-2.log', 'name-3.log',
-# ..., bounding the file count by peak concurrency on a host rather than by the
-# total number of processes ever launched (which matters under autoscaling).
+class _LockUnsupported(Exception):
+    """Raised when the filesystem provides no advisory locking (degrade to canonical append)."""
+
+
+# The sidecar record identifies the live slot owner. It is one fixed-shape JSON line
+# written by the winner while holding the lock, so a later process can tell whether a
+# real process still holds the slot (start-time defeats PID reuse; the baked-in host
+# guarantees the PID is local and checkable). Version 1 record shape:
+#   {"v": 1, "pid": int, "create_time": float|null, "host": str, "instance": str}
+_LOCK_RECORD_VERSION: Final[int] = 1
+
+
+def _process_create_time() -> Optional[float]:
+    """This process's start time (epoch seconds) for pid-reuse defense in the owner record."""
+    try:
+        import psutil
+        return psutil.Process(os.getpid()).create_time()
+    except Exception:  # psutil should always resolve our own pid; never fail claiming over it.
+        return None
+
+
+def _write_lock_record(handle: Any) -> None:
+    """Stamp the (locked) sidecar with this process's owner record; keep the lock held.
+
+    Best-effort: the flock, not the record, is the single-writer gate, so a failed write
+    never blocks slot claiming (the sidecar simply reads back as 'no live holder').
+    """
+    record = json.dumps({
+        'v': _LOCK_RECORD_VERSION,
+        'pid': os.getpid(),
+        'create_time': _process_create_time(),
+        'host': HOSTNAME_SHORT,
+        'instance': INSTANCE,
+    })
+    try:
+        handle.seek(0)
+        handle.truncate()
+        handle.write(record + '\n')
+        handle.flush()  # Never close(): closing would drop the advisory lock.
+    except OSError as exc:
+        debug(f'Could not write lock record ({exc})')
+
+
+def read_lock_record(path: str) -> Optional[Dict[str, Any]]:
+    """Read a sidecar's owner record; None if empty, legacy, torn, or unparseable."""
+    for _ in range(2):  # Retry once: a probe can race the winner's single-line write.
+        try:
+            with open(path, mode='r') as handle:
+                line = handle.readline()
+        except OSError:
+            return None
+        if not line.strip():
+            return None  # Empty or legacy 0-byte sidecar records no live holder.
+        try:
+            record = json.loads(line)
+        except ValueError:
+            continue  # Possibly torn mid-write; re-read once before giving up.
+        return record if isinstance(record, dict) else None
+    return None
+
+
+def _owner_alive(record: Optional[Dict[str, Any]]) -> bool:
+    """Whether the process that wrote `record` is still alive on this host.
+
+    Conservative: an empty, foreign-host, or malformed record reads as no live holder,
+    but a live same-identity process we merely cannot inspect is treated as alive so we
+    never steal a slot from a running owner.
+    """
+    if not record or record.get('host') != HOSTNAME_SHORT:
+        return False
+    pid = record.get('pid')
+    if not isinstance(pid, int):
+        return False
+    import psutil
+    if not psutil.pid_exists(pid):
+        return False
+    try:
+        create_time = psutil.Process(pid).create_time()
+    except psutil.NoSuchProcess:
+        return False
+    except psutil.AccessDenied:
+        return True  # Live but owned by another user; never reclaim its slot.
+    recorded = record.get('create_time')
+    if not isinstance(recorded, (int, float)):
+        return True  # Live local pid but no checkable start-time; do not steal.
+    return abs(create_time - recorded) <= 2.0  # ~2s tolerance defeats pid reuse.
+
+
+# We enforce the single-writer invariant with an advisory lock on a per-file '.lock'
+# sidecar. The winner stamps the sidecar with an owner record (pid + start-time + short
+# host + app instance) while holding the lock, so a later process can tell whether a
+# live process holds the slot. Contention is only ever same-host (the hostname is baked
+# into the filename), and same-host advisory locks are reliable even on shared network
+# filesystems, so a genuinely contended slot falls through to 'name-2.log',
+# 'name-3.log', ..., bounding the file count by peak same-host concurrency. Only genuine
+# contention (EAGAIN) advances a slot; if the filesystem provides no advisory locking at
+# all, we append to the canonical per-host path rather than proliferating one file per
+# process. The lock releases when the last descriptor on its open-file-description closes
+# (normally at process exit; a forked child that inherits the descriptor must close its
+# own copy or the slot stays held past the true owner's death).
+def _open_sidecar(path: str) -> Any:
+    """Open (creating if needed) a lock sidecar for read/write, never truncating.
+
+    A losing probe must not blank the winner's record, so the open is non-truncating;
+    only the winner rewrites the record after it holds the lock.
+    """
+    return os.fdopen(os.open(path, os.O_RDWR | os.O_CREAT, 0o644), 'r+')
+
+
 try:
     import fcntl
     def _try_lock(path: str) -> Optional[Any]:
-        """Acquire an exclusive, non-blocking lock; return the held handle or None."""
-        handle = open(path, mode='w')
-        try:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        """Acquire an exclusive, non-blocking lock; return the held handle, None on genuine
+        contention, and raise `_LockUnsupported` when the filesystem lacks advisory locking."""
+        handle = _open_sidecar(path)
+        while True:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except InterruptedError:
+                continue  # EINTR: retry the interrupted syscall.
+            except BlockingIOError:
+                handle.close()
+                return None  # A live sibling holds the slot; advance.
+            except OSError as exc:
+                if exc.errno == errno.EINTR:
+                    continue
+                if exc.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
+                    handle.close()
+                    return None
+                handle.close()
+                raise _LockUnsupported from exc  # No advisory locking on this filesystem.
+            _write_lock_record(handle)
             return handle
-        except OSError:
-            handle.close()
-            return None
     _LOCKING = True
 except ImportError:
     try:
         import msvcrt
         def _try_lock(path: str) -> Optional[Any]:
-            """Acquire an exclusive, non-blocking lock; return the held handle or None."""
-            handle = open(path, mode='w')
+            """Acquire an exclusive, non-blocking lock; return the held handle or None.
+
+            msvcrt cannot distinguish contention from an unsupported filesystem, so every
+            failure is treated as contention (conflict-only)."""
+            handle = _open_sidecar(path)
             try:
                 msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
-                return handle
             except OSError:
                 handle.close()
                 return None
+            _write_lock_record(handle)
+            return handle
         _LOCKING = True
     except ImportError:
         _try_lock = None
@@ -703,14 +824,18 @@ def claim_file_slot(path: str, max_slots: int = 100) -> str:
     os.makedirs(os.path.dirname(path) or '.', exist_ok=True)
     root, ext = os.path.splitext(path)
     if _LOCKING:
-        for n in range(1, max_slots + 1):
-            candidate = path if n == 1 else f'{root}-{n}{ext}'
-            handle = _try_lock(candidate + '.lock')
-            if handle is not None:
-                _slot_locks.append(handle)
-                return candidate
-        warn(f'Exhausted {max_slots} log-file slots for \'{path}\'; using PID suffix')
-    return f'{root}-{os.getpid()}{ext}'
+        try:
+            for n in range(1, max_slots + 1):
+                candidate = path if n == 1 else f'{root}-{n}{ext}'
+                handle = _try_lock(candidate + '.lock')
+                if handle is not None:
+                    _slot_locks.append(handle)
+                    return candidate
+            warn(f'Exhausted {max_slots} log-file slots for \'{path}\'; using PID suffix')
+            return f'{root}-{os.getpid()}{ext}'  # Genuine all-EAGAIN exhaustion: real concurrency.
+        except _LockUnsupported:
+            return path  # Lockless filesystem: append to the canonical per-host path.
+    return path  # No advisory-locking support at all: append to the canonical per-host path.
 
 
 def resolve_log_path(path: str, role: str, is_default: bool) -> str:

--- a/src/hypershell/core/queue.py
+++ b/src/hypershell/core/queue.py
@@ -25,7 +25,7 @@ from multiprocessing import JoinableQueue
 
 # Internal libs
 from hypershell.core.config import default, config as _config
-from hypershell.core.logging import Logger
+from hypershell.core.logging import Logger, close_inherited_slot_locks
 from hypershell.core.types import NoneType, serialize
 from hypershell.core.tls import (TLSConfig, install_process_context,
                                  get_server_context, get_client_context, get_tls_config,
@@ -240,9 +240,17 @@ def secure_client(address, family=None, authkey: Optional[bytes] = None) -> Secu
 listener_client[TLS_SERIALIZER] = (SecureListener, secure_client)
 
 
-def _tls_bootstrap(cfg: TLSConfig, user_init, user_initargs) -> None:
-    """Initializer used by :class:`SecureManager.start` to install TLS state in the subprocess."""
-    install_process_context(cfg)
+def _child_bootstrap(cfg: Optional[TLSConfig], user_init, user_initargs) -> None:
+    """Initializer run in the forked manager child before it serves.
+
+    Closes log-slot lock descriptors inherited across the fork so the parent stays the sole
+    holder (a killed parent never leaves a ghost lock), installs the per-process TLS context
+    when TLS is active, then runs any user initializer. Ordered so the fd hygiene and TLS state
+    are in place before serving; touches neither the RPC framing, authkey, nor the handshake.
+    """
+    close_inherited_slot_locks()
+    if cfg is not None:
+        install_process_context(cfg)
     if user_init is not None:
         user_init(*user_initargs)
 
@@ -273,12 +281,10 @@ class SecureManager(BaseManager):
     def start(self: SecureManager,
               initializer: Optional[Callable[..., Any]] = None,
               initargs: Iterable[Any] = ()) -> None:
-        """Spawn the server subprocess, ensuring the TLS context is installed inside it."""
-        if self._tls is not None:
-            super().start(initializer=_tls_bootstrap,
-                          initargs=(self._tls, initializer, tuple(initargs)))
-        else:
-            super().start(initializer=initializer, initargs=initargs)
+        """Spawn the server subprocess, closing inherited log-slot locks (and installing the TLS
+        context when active) inside the forked child before any user initializer runs."""
+        super().start(initializer=_child_bootstrap,
+                      initargs=(self._tls, initializer, tuple(initargs)))
 
     def connect(self: SecureManager) -> None:
         """Install the local-process TLS context, then perform the manager handshake."""

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -25,7 +25,7 @@ from tests import main
 import hypershell.core.logging as log
 from hypershell.core.logging import (
     role_from_command, default_file_for, claim_file_slot, resolve_log_path,
-    read_lock_record, HOSTNAME_SHORT, INSTANCE, _LOCKING,
+    read_lock_record, HOSTNAME_SHORT, INSTANCE, LOCKING,
 )
 
 
@@ -34,17 +34,17 @@ def _clean_slot_locks():
     """Release and clear process-global slot-lock state after each test.
 
     Slot locks are held for the life of the owner and the finalizer runs once; without this a
-    claimed handle (or a tripped `_FINALIZED` flag) would leak across tests and skew later
+    claimed handle (or a tripped `_FINAL` flag) would leak across tests and skew later
     contention/liveness/finalize checks.
     """
     yield
-    for handle in log._slot_locks:
+    for handle in log.slot_locks:
         try:
             handle.close()
         except OSError:
             pass
-    log._slot_locks.clear()
-    log._FINALIZED = False
+    log.slot_locks.clear()
+    log._FINAL = False
 
 
 # A tiny program that claims a slot, announces it, and holds the lock while it sleeps.
@@ -87,7 +87,7 @@ def test_default_file_is_host_scoped_except_main() -> None:
 @mark.unit
 def test_resolve_log_path_decorates_only_explicit_client_paths(tmp_path: Path) -> None:
     """An explicit client path is host-scoped; the (already host-scoped) default is not."""
-    if not _LOCKING:
+    if not LOCKING:
         skip('requires advisory file locking')
     explicit = resolve_log_path(str(tmp_path / 'shared.log'), role='client', is_default=False)
     assert os.path.basename(explicit) == f'shared-client-{HOSTNAME_SHORT}.log'
@@ -101,7 +101,7 @@ def test_resolve_log_path_decorates_only_explicit_client_paths(tmp_path: Path) -
 @mark.unit
 def test_claim_file_slot_disambiguates_within_process(tmp_path: Path) -> None:
     """A second live claim on the same path falls through to the next slot."""
-    if not _LOCKING:
+    if not LOCKING:
         skip('requires advisory file locking')
     base = str(tmp_path / 'app.log')
     assert os.path.basename(claim_file_slot(base)) == 'app.log'
@@ -112,7 +112,7 @@ def test_claim_file_slot_disambiguates_within_process(tmp_path: Path) -> None:
 @mark.integration
 def test_slot_reclaimed_after_owner_dies(tmp_path: Path) -> None:
     """A crashed owner's slot is immediately reclaimable (OS releases the lock)."""
-    if not _LOCKING:
+    if not LOCKING:
         skip('requires advisory file locking')
     base = str(tmp_path / 'client.log')
     holder = Popen([sys.executable, '-c', _HOLDER, base], stdout=PIPE, env=os.environ)
@@ -152,19 +152,19 @@ def _raise_errno(code: int):
 @mark.parametrize('bad_errno', [errno.ENOSYS, errno.ENOLCK, errno.EPERM])
 def test_unsupported_lock_errno_degrades_to_canonical(tmp_path: Path, monkeypatch, bad_errno: int) -> None:
     """A non-contention lock error (lockless FS) appends to the canonical path, never a PID file."""
-    if not _LOCKING:
+    if not LOCKING:
         skip('requires advisory file locking')
     monkeypatch.setattr(log.fcntl, 'flock', _raise_errno(bad_errno))
     base = str(tmp_path / 'client.log')
     claimed = claim_file_slot(base)
     assert claimed == base  # canonical path, not '<root>-<pid>.log'
-    assert not log._slot_locks  # nothing held: we degraded rather than acquired
+    assert not log.slot_locks  # nothing held: we degraded rather than acquired
 
 
 @mark.unit
 def test_no_locking_support_uses_canonical(tmp_path: Path, monkeypatch) -> None:
     """With no advisory-locking support at all, the canonical path is reused (not per-PID)."""
-    monkeypatch.setattr(log, '_LOCKING', False)
+    monkeypatch.setattr(log, 'LOCKING', False)
     base = str(tmp_path / 'client.log')
     assert claim_file_slot(base) == base
 
@@ -172,7 +172,7 @@ def test_no_locking_support_uses_canonical(tmp_path: Path, monkeypatch) -> None:
 @mark.unit
 def test_contention_advances_to_next_slot(tmp_path: Path, monkeypatch) -> None:
     """Genuine contention (EAGAIN) on slot 1 advances to the '-2' slot."""
-    if not _LOCKING:
+    if not LOCKING:
         skip('requires advisory file locking')
     real_flock = log.fcntl.flock
     calls = {'n': 0}
@@ -189,7 +189,7 @@ def test_contention_advances_to_next_slot(tmp_path: Path, monkeypatch) -> None:
 @mark.unit
 def test_lock_record_round_trips(tmp_path: Path) -> None:
     """A won lock stamps the sidecar with this process's owner record, readable back."""
-    if not _LOCKING:
+    if not LOCKING:
         skip('requires advisory file locking')
     base = str(tmp_path / 'client.log')
     claimed = claim_file_slot(base)
@@ -199,13 +199,13 @@ def test_lock_record_round_trips(tmp_path: Path) -> None:
     assert record['pid'] == os.getpid()
     assert record['host'] == HOSTNAME_SHORT
     assert record['instance'] == INSTANCE
-    assert log._owner_alive(record) is True
+    assert log.owner_alive(record) is True
 
 
 @mark.unit
 def test_losing_probe_does_not_blank_the_record(tmp_path: Path) -> None:
     """A second (losing) claim opens the sidecar non-truncating, preserving the winner's record."""
-    if not _LOCKING:
+    if not LOCKING:
         skip('requires advisory file locking')
     base = str(tmp_path / 'client.log')
     claim_file_slot(base)                 # winner writes its record on slot 1
@@ -220,7 +220,7 @@ def test_legacy_empty_lock_record_reads_as_no_holder(tmp_path: Path) -> None:
     sidecar = tmp_path / 'client.log.lock'
     sidecar.write_bytes(b'')
     assert read_lock_record(str(sidecar)) is None
-    assert log._owner_alive(read_lock_record(str(sidecar))) is False
+    assert log.owner_alive(read_lock_record(str(sidecar))) is False
 
 
 @mark.unit
@@ -235,14 +235,14 @@ def test_torn_lock_record_reads_as_no_holder(tmp_path: Path) -> None:
 def test_owner_alive_lock_record_false_on_create_time_mismatch() -> None:
     """Our own live pid with a wrong start-time reads as dead (pid-reuse defense)."""
     record = {'v': 1, 'pid': os.getpid(), 'create_time': 1.0, 'host': HOSTNAME_SHORT, 'instance': 'x'}
-    assert log._owner_alive(record) is False
+    assert log.owner_alive(record) is False
 
 
 @mark.unit
 def test_owner_alive_lock_record_false_for_other_host() -> None:
     """A record stamped by another host is not a checkable local holder."""
     record = {'v': 1, 'pid': os.getpid(), 'create_time': 0.0, 'host': 'some-other-host', 'instance': 'x'}
-    assert log._owner_alive(record) is False
+    assert log.owner_alive(record) is False
 
 
 # A program that claims a slot then exits cleanly, so its atexit finalizer drops the sidecar.
@@ -256,7 +256,7 @@ _CLEAN_EXITER = (
 @mark.unit
 def test_finalize_logging_drops_own_sidecar(tmp_path: Path) -> None:
     """On clean shutdown a process removes its own held lock sidecar (best-effort, R3)."""
-    if not _LOCKING:
+    if not LOCKING:
         skip('requires advisory file locking')
     base = str(tmp_path / 'client.log')
     claimed = claim_file_slot(base)
@@ -264,13 +264,13 @@ def test_finalize_logging_drops_own_sidecar(tmp_path: Path) -> None:
     assert os.path.exists(sidecar)
     log.finalize_logging()
     assert not os.path.exists(sidecar)  # own sidecar removed while its lock was still held
-    assert not log._slot_locks
+    assert not log.slot_locks
 
 
 @mark.integration
 def test_clean_exit_removes_own_sidecar_via_atexit(tmp_path: Path) -> None:
     """A cleanly-exiting subprocess sweeps its own sidecar through the registered atexit hook."""
-    if not _LOCKING:
+    if not LOCKING:
         skip('requires advisory file locking')
     base = str(tmp_path / 'client.log')
     proc = Popen([sys.executable, '-c', _CLEAN_EXITER, base], stdout=PIPE, env=os.environ)
@@ -284,7 +284,7 @@ def test_clean_exit_removes_own_sidecar_via_atexit(tmp_path: Path) -> None:
 @mark.unit
 def test_prune_removes_stale_unlocked_sidecar(tmp_path: Path) -> None:
     """The canonical winner prunes a sibling '-N' sidecar that no live process holds (R4)."""
-    if not _LOCKING:
+    if not LOCKING:
         skip('requires advisory file locking')
     base = str(tmp_path / 'client.log')
     root, ext = os.path.splitext(base)
@@ -299,7 +299,7 @@ def test_prune_removes_stale_unlocked_sidecar(tmp_path: Path) -> None:
 @mark.unit
 def test_prune_keeps_live_held_sibling_sidecar(tmp_path: Path) -> None:
     """A sibling sidecar a live process holds is never pruned (flock-acquire is the safety gate)."""
-    if not _LOCKING:
+    if not LOCKING:
         skip('requires advisory file locking')
     base = str(tmp_path / 'client.log')
     root, ext = os.path.splitext(base)
@@ -314,7 +314,7 @@ def test_prune_keeps_live_held_sibling_sidecar(tmp_path: Path) -> None:
 @mark.unit
 def test_prune_sidecar_never_touches_data_or_rotated_files(tmp_path: Path) -> None:
     """Pruning removes only '.lock' sidecars, never '-N' data, its rotated lineage, or 'main' (R5)."""
-    if not _LOCKING:
+    if not LOCKING:
         skip('requires advisory file locking')
     base = str(tmp_path / 'client.log')
     root, ext = os.path.splitext(base)
@@ -356,10 +356,10 @@ def _fork_lock_probe(tmp_path: Path, child_closes: bool) -> bool:
     os.close(w)
     os.read(r, 1)           # Wait until the child has closed-or-not.
     os.close(r)
-    for handle in list(log._slot_locks):  # Parent releases its own handle (as on a clean exit).
+    for handle in list(log.slot_locks):  # Parent releases its own handle (as on a clean exit).
         handle.close()
-    log._slot_locks.clear()
-    probe = log._try_lock(sidecar)        # Acquirable iff no live descriptor holds the OFD.
+    log.slot_locks.clear()
+    probe = log.try_lock(sidecar)        # Acquirable iff no live descriptor holds the OFD.
     acquired = probe is not None
     if probe is not None:
         probe.close()
@@ -373,7 +373,7 @@ def _fork_lock_probe(tmp_path: Path, child_closes: bool) -> bool:
 def test_forked_child_keeping_inherited_lock_ghost_locks_parent_slot(tmp_path: Path) -> None:
     """The latent leak: a forked child that keeps the inherited descriptor holds the slot lock
     alive after the parent releases it (a killed parent would ghost-lock its slot)."""
-    if not _LOCKING:
+    if not LOCKING:
         skip('requires advisory file locking')
     assert _fork_lock_probe(tmp_path, child_closes=False) is False
 
@@ -383,7 +383,7 @@ def test_forked_child_keeping_inherited_lock_ghost_locks_parent_slot(tmp_path: P
 def test_forked_child_closing_inherited_lock_releases_parent_slot(tmp_path: Path) -> None:
     """P3's fix (R6): the child closing its inherited descriptor lets the slot lock release
     exactly when the true owner (the parent) exits — no ghost lock."""
-    if not _LOCKING:
+    if not LOCKING:
         skip('requires advisory file locking')
     assert _fork_lock_probe(tmp_path, child_closes=True) is True
 
@@ -396,7 +396,7 @@ _RUN_CLI = 'from hypershell import main; main()'
 def test_serial_generations_reclaim_canonical_and_leave_no_sidecars(tmp_path: Path) -> None:
     """Serial claim-and-exit generations each reclaim the canonical slot; sidecars never
     accumulate across clean restarts (R1: reclaim works; the count stays bounded)."""
-    if not _LOCKING:
+    if not LOCKING:
         skip('requires advisory file locking')
     base = str(tmp_path / 'client.log')
     for _ in range(4):
@@ -412,7 +412,7 @@ def test_serial_generations_reclaim_canonical_and_leave_no_sidecars(tmp_path: Pa
 def test_concurrent_holders_get_distinct_slots_and_data_survives(tmp_path: Path) -> None:
     """Genuinely concurrent same-host processes get distinct '-N' slots, and a canonical prune
     never removes their data or their live sidecars (R1: concurrency is legitimate; R5/R8)."""
-    if not _LOCKING:
+    if not LOCKING:
         skip('requires advisory file locking')
     base = str(tmp_path / 'client.log')
     holders = [Popen([sys.executable, '-c', _HOLDER, base], stdout=PIPE, env=os.environ)
@@ -436,7 +436,7 @@ def test_concurrent_holders_get_distinct_slots_and_data_survives(tmp_path: Path)
 @mark.integration
 def test_main_role_never_prunes_sidecars(temp_site: Path) -> None:
     """A real 'main'-role command never prunes sibling sidecars (R8: 'main' is left alone)."""
-    if not _LOCKING:
+    if not LOCKING:
         skip('requires advisory file locking')
     env = {**os.environ, 'HYPERSHELL_LOGGING_FILE': 'enabled'}
     # First run materializes the site log directory and main.log.

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -386,3 +386,66 @@ def test_forked_child_closing_inherited_lock_releases_parent_slot(tmp_path: Path
     if not _LOCKING:
         skip('requires advisory file locking')
     assert _fork_lock_probe(tmp_path, child_closes=True) is True
+
+
+# Runs the real 'hs' CLI in a fresh subprocess (so logging initializes from scratch each time).
+_RUN_CLI = 'from hypershell import main; main()'
+
+
+@mark.integration
+def test_serial_generations_reclaim_canonical_and_leave_no_sidecars(tmp_path: Path) -> None:
+    """Serial claim-and-exit generations each reclaim the canonical slot; sidecars never
+    accumulate across clean restarts (R1: reclaim works; the count stays bounded)."""
+    if not _LOCKING:
+        skip('requires advisory file locking')
+    base = str(tmp_path / 'client.log')
+    for _ in range(4):
+        proc = Popen([sys.executable, '-c', _CLEAN_EXITER, base], stdout=PIPE, env=os.environ)
+        claimed = proc.stdout.readline().decode().strip()
+        proc.wait()
+        assert proc.returncode == 0
+        assert os.path.basename(claimed) == 'client.log'  # canonical reclaimed every generation
+    assert list(tmp_path.glob('*.lock')) == []            # ephemeral: nothing left behind
+
+
+@mark.integration
+def test_concurrent_holders_get_distinct_slots_and_data_survives(tmp_path: Path) -> None:
+    """Genuinely concurrent same-host processes get distinct '-N' slots, and a canonical prune
+    never removes their data or their live sidecars (R1: concurrency is legitimate; R5/R8)."""
+    if not _LOCKING:
+        skip('requires advisory file locking')
+    base = str(tmp_path / 'client.log')
+    holders = [Popen([sys.executable, '-c', _HOLDER, base], stdout=PIPE, env=os.environ)
+               for _ in range(3)]
+    try:
+        claimed = [h.stdout.readline().decode().strip() for h in holders]
+        assert sorted(os.path.basename(c) for c in claimed) == \
+            ['client-2.log', 'client-3.log', 'client.log']  # distinct concurrent slots
+        for path in claimed:
+            Path(path).write_text('rank output')            # each rank writes its own data
+        log.prune_stale_sidecars(base)                       # a canonical sweep must not disturb live ranks
+        for path in claimed:
+            assert Path(path).read_text() == 'rank output'   # rank data preserved (R5)
+            assert os.path.exists(path + '.lock')            # live sibling sidecar retained (R8)
+    finally:
+        for holder in holders:
+            holder.terminate()
+            holder.wait()
+
+
+@mark.integration
+def test_main_role_never_prunes_sidecars(temp_site: Path) -> None:
+    """A real 'main'-role command never prunes sibling sidecars (R8: 'main' is left alone)."""
+    if not _LOCKING:
+        skip('requires advisory file locking')
+    env = {**os.environ, 'HYPERSHELL_LOGGING_FILE': 'enabled'}
+    # First run materializes the site log directory and main.log.
+    assert Popen([sys.executable, '-c', _RUN_CLI, 'initdb', '--yes'],
+                 env=env, stdout=PIPE, stderr=PIPE).wait() == 0
+    main_log = next(iter(Path(temp_site).rglob('main.log')), None)
+    assert main_log is not None
+    stale = main_log.parent / 'main-2.log.lock'
+    stale.write_bytes(b'')  # a sibling a distributed role would prune -- but 'main' must not
+    assert Popen([sys.executable, '-c', _RUN_CLI, 'list', '--count'],
+                 env=env, stdout=PIPE, stderr=PIPE).wait() == 0
+    assert stale.exists()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 # Standard libs
 import os
 import sys
+import time
 import errno
+import signal
 from pathlib import Path
 from subprocess import Popen, PIPE
 
@@ -330,3 +332,57 @@ def test_prune_sidecar_never_touches_data_or_rotated_files(tmp_path: Path) -> No
     for survivor in (data, rotated, partial, main_side):
         assert os.path.exists(survivor), survivor
         assert Path(survivor).read_text() == 'keep me'
+
+
+def _fork_lock_probe(tmp_path: Path, child_closes: bool) -> bool:
+    """Claim a slot, `os.fork()`, and (optionally) close the child's inherited copy.
+
+    Models the queue-manager fork: the child shares the parent's slot-lock open-file-description.
+    After the child has done its close-or-not and the parent releases its own handle, probe
+    whether the slot lock is re-acquirable. Returns True if released, False if a child that kept
+    the inherited descriptor is ghost-holding it. Isolates the fd mechanism (no multiprocessing).
+    """
+    base = str(tmp_path / 'server.log')
+    sidecar = claim_file_slot(base) + '.lock'
+    r, w = os.pipe()
+    pid = os.fork()
+    if pid == 0:  # Child: shares the parent's slot-lock OFD across the fork.
+        os.close(r)
+        if child_closes:
+            log.close_inherited_slot_locks()  # The P3 fix: drop the inherited copy.
+        os.write(w, b'x')   # Signal readiness (still holding the OFD if we did not close).
+        time.sleep(10)      # Linger so the parent can probe while we are alive.
+        os._exit(0)
+    os.close(w)
+    os.read(r, 1)           # Wait until the child has closed-or-not.
+    os.close(r)
+    for handle in list(log._slot_locks):  # Parent releases its own handle (as on a clean exit).
+        handle.close()
+    log._slot_locks.clear()
+    probe = log._try_lock(sidecar)        # Acquirable iff no live descriptor holds the OFD.
+    acquired = probe is not None
+    if probe is not None:
+        probe.close()
+    os.kill(pid, signal.SIGTERM)
+    os.waitpid(pid, 0)
+    return acquired
+
+
+@mark.unit
+@mark.skipif(os.name == 'nt', reason='POSIX fork semantics')
+def test_forked_child_keeping_inherited_lock_ghost_locks_parent_slot(tmp_path: Path) -> None:
+    """The latent leak: a forked child that keeps the inherited descriptor holds the slot lock
+    alive after the parent releases it (a killed parent would ghost-lock its slot)."""
+    if not _LOCKING:
+        skip('requires advisory file locking')
+    assert _fork_lock_probe(tmp_path, child_closes=False) is False
+
+
+@mark.unit
+@mark.skipif(os.name == 'nt', reason='POSIX fork semantics')
+def test_forked_child_closing_inherited_lock_releases_parent_slot(tmp_path: Path) -> None:
+    """P3's fix (R6): the child closing its inherited descriptor lets the slot lock release
+    exactly when the true owner (the parent) exits — no ghost lock."""
+    if not _LOCKING:
+        skip('requires advisory file locking')
+    assert _fork_lock_probe(tmp_path, child_closes=True) is True

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -29,10 +29,11 @@ from hypershell.core.logging import (
 
 @fixture(autouse=True)
 def _clean_slot_locks():
-    """Release and clear any held slot-lock handles after each test.
+    """Release and clear process-global slot-lock state after each test.
 
-    Slot locks are process-global and held for the life of the owner; without this a
-    claimed handle would leak across tests and skew later contention/liveness checks.
+    Slot locks are held for the life of the owner and the finalizer runs once; without this a
+    claimed handle (or a tripped `_FINALIZED` flag) would leak across tests and skew later
+    contention/liveness/finalize checks.
     """
     yield
     for handle in log._slot_locks:
@@ -41,6 +42,7 @@ def _clean_slot_locks():
         except OSError:
             pass
     log._slot_locks.clear()
+    log._FINALIZED = False
 
 
 # A tiny program that claims a slot, announces it, and holds the lock while it sleeps.
@@ -239,3 +241,92 @@ def test_owner_alive_lock_record_false_for_other_host() -> None:
     """A record stamped by another host is not a checkable local holder."""
     record = {'v': 1, 'pid': os.getpid(), 'create_time': 0.0, 'host': 'some-other-host', 'instance': 'x'}
     assert log._owner_alive(record) is False
+
+
+# A program that claims a slot then exits cleanly, so its atexit finalizer drops the sidecar.
+_CLEAN_EXITER = (
+    'import sys;'
+    'from hypershell.core.logging import claim_file_slot;'
+    'print(claim_file_slot(sys.argv[1]), flush=True)'
+)
+
+
+@mark.unit
+def test_finalize_logging_drops_own_sidecar(tmp_path: Path) -> None:
+    """On clean shutdown a process removes its own held lock sidecar (best-effort, R3)."""
+    if not _LOCKING:
+        skip('requires advisory file locking')
+    base = str(tmp_path / 'client.log')
+    claimed = claim_file_slot(base)
+    sidecar = claimed + '.lock'
+    assert os.path.exists(sidecar)
+    log.finalize_logging()
+    assert not os.path.exists(sidecar)  # own sidecar removed while its lock was still held
+    assert not log._slot_locks
+
+
+@mark.integration
+def test_clean_exit_removes_own_sidecar_via_atexit(tmp_path: Path) -> None:
+    """A cleanly-exiting subprocess sweeps its own sidecar through the registered atexit hook."""
+    if not _LOCKING:
+        skip('requires advisory file locking')
+    base = str(tmp_path / 'client.log')
+    proc = Popen([sys.executable, '-c', _CLEAN_EXITER, base], stdout=PIPE, env=os.environ)
+    claimed = proc.stdout.readline().decode().strip()
+    proc.wait()
+    assert proc.returncode == 0
+    assert os.path.basename(claimed) == 'client.log'
+    assert not os.path.exists(claimed + '.lock')  # atexit finalizer dropped it on clean exit
+
+
+@mark.unit
+def test_prune_removes_stale_unlocked_sidecar(tmp_path: Path) -> None:
+    """The canonical winner prunes a sibling '-N' sidecar that no live process holds (R4)."""
+    if not _LOCKING:
+        skip('requires advisory file locking')
+    base = str(tmp_path / 'client.log')
+    root, ext = os.path.splitext(base)
+    stale = f'{root}-2{ext}.lock'
+    open(stale, 'w').close()  # unlocked, legacy 0-byte sidecar: no live holder
+    assert os.path.exists(stale)
+    claim_file_slot(base)  # win the canonical slot (holds client.log.lock)
+    log.prune_stale_sidecars(base)
+    assert not os.path.exists(stale)
+
+
+@mark.unit
+def test_prune_keeps_live_held_sibling_sidecar(tmp_path: Path) -> None:
+    """A sibling sidecar a live process holds is never pruned (flock-acquire is the safety gate)."""
+    if not _LOCKING:
+        skip('requires advisory file locking')
+    base = str(tmp_path / 'client.log')
+    root, ext = os.path.splitext(base)
+    claim_file_slot(base)      # holds client.log.lock (canonical)
+    claim_file_slot(base)      # holds client-2.log.lock (a live sibling)
+    held = f'{root}-2{ext}.lock'
+    assert os.path.exists(held)
+    log.prune_stale_sidecars(base)
+    assert os.path.exists(held)  # live holder -> retained
+
+
+@mark.unit
+def test_prune_sidecar_never_touches_data_or_rotated_files(tmp_path: Path) -> None:
+    """Pruning removes only '.lock' sidecars, never '-N' data, its rotated lineage, or 'main' (R5)."""
+    if not _LOCKING:
+        skip('requires advisory file locking')
+    base = str(tmp_path / 'client.log')
+    root, ext = os.path.splitext(base)
+    stale = f'{root}-2{ext}.lock'
+    data = f'{root}-2{ext}'                          # client-2.log        (rank data)
+    rotated = f'{root}-2.20260723'                   # client-2.20260723   (rotated lineage)
+    partial = f'{root}-2.20260723.gz.partial'        # mid-compression child
+    main_side = str(tmp_path / 'main.log.lock')      # the 'main' role is never pruned
+    open(stale, 'w').close()
+    for survivor in (data, rotated, partial, main_side):
+        Path(survivor).write_text('keep me')
+    claim_file_slot(base)
+    log.prune_stale_sidecars(base)
+    assert not os.path.exists(stale)  # only the sidecar goes
+    for survivor in (data, rotated, partial, main_side):
+        assert os.path.exists(survivor), survivor
+        assert Path(survivor).read_text() == 'keep me'

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -10,19 +10,37 @@ from __future__ import annotations
 # Standard libs
 import os
 import sys
+import errno
 from pathlib import Path
 from subprocess import Popen, PIPE
 
 # External libs
-from pytest import mark, skip
+from pytest import mark, skip, fixture
 from cmdkit.app import exit_status
 
 # Internal libs
 from tests import main
+import hypershell.core.logging as log
 from hypershell.core.logging import (
     role_from_command, default_file_for, claim_file_slot, resolve_log_path,
-    HOSTNAME_SHORT, _LOCKING,
+    read_lock_record, HOSTNAME_SHORT, INSTANCE, _LOCKING,
 )
+
+
+@fixture(autouse=True)
+def _clean_slot_locks():
+    """Release and clear any held slot-lock handles after each test.
+
+    Slot locks are process-global and held for the life of the owner; without this a
+    claimed handle would leak across tests and skew later contention/liveness checks.
+    """
+    yield
+    for handle in log._slot_locks:
+        try:
+            handle.close()
+        except OSError:
+            pass
+    log._slot_locks.clear()
 
 
 # A tiny program that claims a slot, announces it, and holds the lock while it sleeps.
@@ -117,3 +135,107 @@ def test_file_logging_writes_role_named_file(temp_site: Path) -> None:
         assert matches, f'expected main.log somewhere under {temp_site}'
     finally:
         os.environ.pop('HYPERSHELL_LOGGING_FILE', None)
+
+
+def _raise_errno(code: int):
+    """Return a fake `flock` that always raises `OSError(code, ...)`."""
+    def _flock(_fd, _flags):
+        raise OSError(code, os.strerror(code))
+    return _flock
+
+
+@mark.unit
+@mark.parametrize('bad_errno', [errno.ENOSYS, errno.ENOLCK, errno.EPERM])
+def test_unsupported_lock_errno_degrades_to_canonical(tmp_path: Path, monkeypatch, bad_errno: int) -> None:
+    """A non-contention lock error (lockless FS) appends to the canonical path, never a PID file."""
+    if not _LOCKING:
+        skip('requires advisory file locking')
+    monkeypatch.setattr(log.fcntl, 'flock', _raise_errno(bad_errno))
+    base = str(tmp_path / 'client.log')
+    claimed = claim_file_slot(base)
+    assert claimed == base  # canonical path, not '<root>-<pid>.log'
+    assert not log._slot_locks  # nothing held: we degraded rather than acquired
+
+
+@mark.unit
+def test_no_locking_support_uses_canonical(tmp_path: Path, monkeypatch) -> None:
+    """With no advisory-locking support at all, the canonical path is reused (not per-PID)."""
+    monkeypatch.setattr(log, '_LOCKING', False)
+    base = str(tmp_path / 'client.log')
+    assert claim_file_slot(base) == base
+
+
+@mark.unit
+def test_contention_advances_to_next_slot(tmp_path: Path, monkeypatch) -> None:
+    """Genuine contention (EAGAIN) on slot 1 advances to the '-2' slot."""
+    if not _LOCKING:
+        skip('requires advisory file locking')
+    real_flock = log.fcntl.flock
+    calls = {'n': 0}
+    def _flock(fd, flags):
+        calls['n'] += 1
+        if calls['n'] == 1:
+            raise OSError(errno.EAGAIN, 'temporarily unavailable')  # slot 1 contended
+        return real_flock(fd, flags)  # slot 2 acquires for real
+    monkeypatch.setattr(log.fcntl, 'flock', _flock)
+    base = str(tmp_path / 'app.log')
+    assert os.path.basename(claim_file_slot(base)) == 'app-2.log'
+
+
+@mark.unit
+def test_lock_record_round_trips(tmp_path: Path) -> None:
+    """A won lock stamps the sidecar with this process's owner record, readable back."""
+    if not _LOCKING:
+        skip('requires advisory file locking')
+    base = str(tmp_path / 'client.log')
+    claimed = claim_file_slot(base)
+    record = read_lock_record(claimed + '.lock')
+    assert record is not None
+    assert record['v'] == 1
+    assert record['pid'] == os.getpid()
+    assert record['host'] == HOSTNAME_SHORT
+    assert record['instance'] == INSTANCE
+    assert log._owner_alive(record) is True
+
+
+@mark.unit
+def test_losing_probe_does_not_blank_the_record(tmp_path: Path) -> None:
+    """A second (losing) claim opens the sidecar non-truncating, preserving the winner's record."""
+    if not _LOCKING:
+        skip('requires advisory file locking')
+    base = str(tmp_path / 'client.log')
+    claim_file_slot(base)                 # winner writes its record on slot 1
+    claim_file_slot(base)                 # loser probes slot 1 (fails), advances to slot 2
+    record = read_lock_record(base + '.lock')
+    assert record is not None and record['pid'] == os.getpid()
+
+
+@mark.unit
+def test_legacy_empty_lock_record_reads_as_no_holder(tmp_path: Path) -> None:
+    """A legacy 0-byte sidecar carries no record and reads as 'no live holder'."""
+    sidecar = tmp_path / 'client.log.lock'
+    sidecar.write_bytes(b'')
+    assert read_lock_record(str(sidecar)) is None
+    assert log._owner_alive(read_lock_record(str(sidecar))) is False
+
+
+@mark.unit
+def test_torn_lock_record_reads_as_no_holder(tmp_path: Path) -> None:
+    """An unparseable (torn) record reads as 'no live holder' after the retry."""
+    sidecar = tmp_path / 'client.log.lock'
+    sidecar.write_text('{not valid json')
+    assert read_lock_record(str(sidecar)) is None
+
+
+@mark.unit
+def test_owner_alive_lock_record_false_on_create_time_mismatch() -> None:
+    """Our own live pid with a wrong start-time reads as dead (pid-reuse defense)."""
+    record = {'v': 1, 'pid': os.getpid(), 'create_time': 1.0, 'host': HOSTNAME_SHORT, 'instance': 'x'}
+    assert log._owner_alive(record) is False
+
+
+@mark.unit
+def test_owner_alive_lock_record_false_for_other_host() -> None:
+    """A record stamped by another host is not a checkable local holder."""
+    record = {'v': 1, 'pid': os.getpid(), 'create_time': 0.0, 'host': 'some-other-host', 'instance': 'x'}
+    assert log._owner_alive(record) is False


### PR DESCRIPTION
## Summary

Per-host file logging worked as designed — the originally-reported "reclaim bug" was refuted by
investigation (reclaim+append works on both Lustre and ZFS; the `-N.log` files were legitimate
concurrent `srun` ranks). This fix closes the *real* residual issues that investigation surfaced,
touching only `core/logging.py` and the `core/queue.py` fork seam:

- **Ephemeral sidecars.** `.lock` sidecars now carry their owner's identity (pid + start-time +
  short host + app instance), are removed best-effort on clean shutdown while the lock is held, and
  stale siblings are flock-guarded-pruned at startup — so a log directory no longer accumulates
  permanent 0-byte lock files.
- **Fork fd-leak closed.** A `server`/`cluster` role that forks the queue-manager child now closes
  the inherited log-slot lock descriptor in the child, so a SIGKILL/OOM'd parent can't ghost-lock
  its slot.
- **Lockless-FS footgun closed.** Lock failures are now classified by errno — genuine contention
  (`EAGAIN`/`EWOULDBLOCK`) advances to the next `-N` slot; any other lock error / no-locking-support
  degrades to the canonical per-host append path instead of proliferating one file per PID.

Legitimate `-N.log` data (and its rotated/compressed lineage) is never deleted, truncated, or
merged.

## Goal
[`GOAL.md`](https://github.com/hypershell/hypershell/blob/ed7668d05b7b85794a4679da7fb861309691ae1c/spec/logging-file-slot-reclaim/GOAL.md) — the locked contract (R1–R9). Re-scoped 2026-07-23 after the reclaim-bug premise was refuted by ground-truth evidence.

## Design
[`PLAN.md`](https://github.com/hypershell/hypershell/blob/ed7668d05b7b85794a4679da7fb861309691ae1c/spec/logging-file-slot-reclaim/PLAN.md) (historical design record).

## Research
Investigation record (retained, historical): synthesis [`research/09-revised-design.md`](https://github.com/hypershell/hypershell/blob/ed7668d05b7b85794a4679da7fb861309691ae1c/spec/logging-file-slot-reclaim/research/09-revised-design.md) (supersedes [`00-digest.md`](https://github.com/hypershell/hypershell/blob/ed7668d05b7b85794a4679da7fb861309691ae1c/spec/logging-file-slot-reclaim/research/00-digest.md)); evidence forensics + stress briefs [`04`](https://github.com/hypershell/hypershell/blob/ed7668d05b7b85794a4679da7fb861309691ae1c/spec/logging-file-slot-reclaim/research/04-evidence-forensics.md)–[`11`](https://github.com/hypershell/hypershell/blob/ed7668d05b7b85794a4679da7fb861309691ae1c/spec/logging-file-slot-reclaim/research/11-stress-reap.md).

## Phases completed
- **P1** — Self-describing sidecar record + errno discrimination + degrade-to-canonical (R2, R7, R8)
- **P2** — Ephemeral sidecar lifecycle: shutdown drop + flock-guarded startup prune (R3, R4, R5)
- **P3** — server/cluster fork fd-leak hardening in `core/queue.py` (R6)
- **P4** — End-to-end bound + regression + docs note (R1, R8, R9)

## Verification
Blind adversarial review (`/hs-review`, cycle 1 — **approved**), all by executed command:
- `pytest tests/test_logging.py` → **36 passed**; `-m integration` → **6 passed**
- Adjacent suites (`server`/`client`/`cluster`) → **86 passed**; `test_queue_tls.py` → **39 passed** (RPC framing / fingerprint intact — §9 honored)
- `sphinx-build docs docs/_build` → clean
- Real CLI drive in a throwaway site: 3 serial `hsx` generations → canonical `.log` reclaimed each, **0** sidecars left; planted stale sidecar swept while `-N.log` data survived
- Orchestrator independently re-ran `test_logging.py` (36 passed) and eyeballed the `core/queue.py` diff (confined to the R6 post-fork fd-close)

Full record: [`REVIEW.md`](https://github.com/hypershell/hypershell/blob/ed7668d05b7b85794a4679da7fb861309691ae1c/spec/logging-file-slot-reclaim/REVIEW.md).

## Docs & completions
No new CLI flag or config key → no `docs/_include/*.rst` or `share/` changes required. R9 is prose in the file-based-logging docs (`docs/logging.rst`), updated in the same build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
