### PR TITLE
[fix] Escape --from-json brackets in Zsh completion so hsx / hs cluster completes

### DIFF
--- a/share/zsh/site-functions/_hs
+++ b/share/zsh/site-functions/_hs
@@ -462,7 +462,7 @@ function _hs_submit() {
     _arguments -s -S \
         '(-h --help)'{-h,--help}'[Show this message and exit]' \
         '(-f --task-file --from-json)'{-f,--task-file}'[Path to task file ("-" for <stdin>)]:task file:_files' \
-        '(-f --task-file --from-json)--from-json[Read tasks from a JSON file ("FILE[@path]")]:json spec:_files' \
+        '(-f --task-file --from-json)--from-json[Read tasks from a JSON file ("FILE\[@path\]")]:json spec:_files' \
         '(-q --queue)'{-q,--queue}'[Submit to live queue instead of database]' \
         '(-H --host)'{-H,--host}'[Hostname for server (used with --queue)]:host:_hs_known_hosts' \
         '(-p --port)'{-p,--port}'[Port number for server (used with --queue)]:port:_hs_ports' \
@@ -559,7 +559,7 @@ function _hs_cluster() {
         '(-h --help)'{-h,--help}'[Show this message and exit]' \
         '(-N --num-threads)'{-N,--num-threads}'[Executor threads per client, 0=auto (default: 1)]:threads:_hs_thread_counts' \
         '(-t --template)'{-t,--template}'[Command-line template pattern (default "{}")]:template:' \
-        '(1)--from-json[Read tasks from a JSON file ("FILE[@path]")]:json spec:_files' \
+        '(1)--from-json[Read tasks from a JSON file ("FILE\[@path\]")]:json spec:_files' \
         '(-H --bind)'{-H,--bind}'[Special bind address (default localhost/0.0.0.0)]:address:(localhost 127.0.0.1 0.0.0.0)' \
         '(-p --port)'{-p,--port}'[Port number (default: 50001)]:port:_hs_ports' \
         '(--no-tls)--no-tls[Disable TLS for queue interface (not recommended)]' \

--- a/spec/hsx-zsh-completion/GOAL.md
+++ b/spec/hsx-zsh-completion/GOAL.md
@@ -1,0 +1,67 @@
+# GOAL — Fix Zsh completion for `hsx` / `hs cluster`
+
+> **Origin spec.** The *what* and *why* — the locked contract `hs-review` grades against.
+> The *how* lives in [`PLAN.md`](PLAN.md) and [`TECH.md`](TECH.md) (written by `hs-plan`).
+
+- **slug:** hsx-zsh-completion
+- **kind:** fix
+- **appetite:** small
+
+## Problem
+
+Zsh tab-completion is completely broken for `hsx` (and equivalently `hs cluster`). Any attempt to
+complete after `hsx`/`hs cluster` immediately aborts with:
+
+```
+_arguments:comparguments:327: invalid option definition: (1)--from-json[Read tasks from a JSON file ("FILE[@path]")]:json spec:_files
+```
+
+`_arguments` rejects the option-spec for `--from-json` in the cluster completion function before it can
+offer any candidates, so the user gets an error instead of completions. This appeared around the
+introduction of the new `--from-json` option. Every other completion context (e.g. `hs submit`) still
+works — only the cluster context is affected, because that is the one place `--from-json` is written
+with the `'(1)--from-json…'` exclusion form (`share/zsh/site-functions/_hs:562`) rather than the
+grouped `'(-f --task-file --from-json)…'` form used elsewhere (`:464`–`465`). Broken completions make
+the primary `hsx` entry point unpleasant to use interactively and undermine confidence in the shipped
+completion assets (which the wheel installs).
+
+## Outcome / vision
+
+Zsh completion for `hsx` / `hs cluster` works exactly like every other subcommand: pressing TAB offers
+option and argument candidates with no `_arguments`/`comparguments` error. `--from-json` completes to a
+file path in the cluster context, and no previously working completion is lost.
+
+## Acceptance criteria (the contract)
+
+- **R1** — WHEN a user triggers Zsh completion after `hsx` or `hs cluster`, the `_hs` completion SHALL
+  run to completion without raising the `_arguments: comparguments … invalid option definition` error.
+- **R2** — WHEN a user completes the `--from-json` option in the `hsx` / `hs cluster` context, the
+  completion SHALL offer file-path candidates for its argument (it names a JSON file).
+- **R3** — The corrected cluster completion SHALL continue to offer all other cluster options and the
+  positional input-file argument that it offered before the regression — no loss of existing
+  candidates.
+- **R4** — The fix SHALL leave the Zsh completion self-consistent with how `--from-json` is completed
+  in the other (working) contexts, so the same option does not use two conflicting, one-broken spec
+  forms.
+
+## Non-goals (no-gos)
+
+- Restructuring or rewriting the `_hs` completion file beyond what is needed to fix the cluster block.
+- Touching the bash completions under `share/bash_completion.d/` (not reported broken).
+- Any change to `hs`/`hsx` CLI behavior, argument parsing, or `--from-json` runtime semantics.
+- Adding new completion capabilities (e.g. completing inside the `FILE[@path]` sub-syntax).
+
+## Clarifications
+
+No open questions — the reported symptom, the affected context, and the expected behavior are
+unambiguous.
+
+## Related materials
+
+- `share/zsh/site-functions/_hs` — the Zsh completion. `_hs_cluster()` block:
+  - `:562` — `'(1)--from-json[…]:json spec:_files'` — the reported failure point.
+  - `:608` — `'(--from-json)1:input file:_files'` — the paired positional argument.
+  - `:464`–`:465` — the analogous `--from-json` in the submit block using the working grouped-exclusion
+    form, for comparison.
+- Completion assets are shipped in the wheel via `[tool.hatch.build.targets.wheel.shared-data]`, so a
+  broken `_hs` reaches installed users.

--- a/spec/hsx-zsh-completion/META.md
+++ b/spec/hsx-zsh-completion/META.md
@@ -1,0 +1,31 @@
+# META — Fix Zsh completion for `hsx` / `hs cluster`
+
+> **Harness feedback log** for this feature. Silence is the default; the bar is *was this the skill's
+> fault?* Read by `hs-publish` (surfaced in the PR) and applied by `/hs-harness`.
+
+- **slug:** hsx-zsh-completion
+
+## What worked well
+
+- `hs-plan:Step 3` — for a small fix, the guidance to skip the subagent fan-out and instead "do a
+  couple of targeted reads/tests yourself" + "verify by driving the CLI" was exactly right: a
+  hands-on real-zsh reproduction (not a research fan-out) is what exposed the true root cause.
+
+## Friction findings
+
+## F1 — Fix GOAL encoded an unverified root-cause hypothesis in an acceptance criterion
+`origin=hs-plan:step4 severity=low category=steering status=open target=.claude/skills/hs-feature/SKILL.md`
+- **What happened:** the shaped `GOAL.md` (from `/hs-feature`) baked the reporter's suspected
+  mechanism into the contract — the *Problem* blamed the `(1)` exclusion form and asserted "submit
+  works", and **R4** required the fix to "not use two conflicting, one-broken spec forms". `/hs-plan`
+  disproved all of it (real cause: an unescaped `]` in the option description; `hs submit` is broken
+  too). R4 then had to be *reinterpreted* to its intent in `PLAN.md` because the correct fix leaves two
+  different-but-both-valid spec forms.
+- **Skill cause:** `/hs-feature` is shaping-only and rightly does not root-cause, but it lacks a guard
+  steering acceptance criteria to be **observable-outcome-only** — especially for `kind: fix`, where the
+  root cause is unverified at shaping time. A criterion phrased as a mechanism ("does not use two
+  conflicting spec forms") is not a stable, observable contract.
+- **Recommended fix:** in `hs-feature` (Step 4) and/or the `GOAL.md` template, add: "For fixes, phrase
+  acceptance criteria as observable behavior (what the user sees), never as the suspected
+  cause/mechanism — the cause is unverified until `/hs-plan`."
+- **Confidence:** med · **Effort:** small

--- a/spec/hsx-zsh-completion/PLAN.md
+++ b/spec/hsx-zsh-completion/PLAN.md
@@ -1,0 +1,114 @@
+# PLAN — Fix Zsh completion for `hsx` / `hs cluster`
+
+> **Status:** Draft for review · **Last updated:** 2026-07-24
+> **Authoritative technical design.** The *how*. Vision/contract is [`GOAL.md`](GOAL.md);
+> the phased executable roadmap is [`TECH.md`](TECH.md).
+
+## 1. Summary
+
+The real root cause is **not** the `(1)` exclusion form the GOAL suspected. The `--from-json`
+option *description* contains an unescaped `]` — `[Read tasks from a JSON file ("FILE[@path]")]` —
+and zsh's `_arguments` closes a `[...]` description at the **first unescaped `]`**. So the
+description terminates early at `FILE[@path]`, the trailing `")]:json spec:_files` becomes garbage,
+and `comparguments` rejects the whole spec (`invalid option definition`), aborting the *entire*
+completion function. The fix is to escape the nested brackets: `("FILE\[@path\]")`. This was
+confirmed by driving real zsh completion (see §6). Appetite is small: a 4-character escaping change
+on two lines, plus a zsh-free regression test.
+
+## 2. Design
+
+Single hand-maintained asset: `share/zsh/site-functions/_hs` (pyproject maps it verbatim to
+`share/zsh/site-functions/_hs` in the wheel — there is **no generator**). Two spec lines carry the
+identical defect:
+
+- `:562` `'(1)--from-json[Read tasks from a JSON file ("FILE[@path]")]:json spec:_files'` — the
+  `_hs_cluster` function used by `hsx` / `hs cluster` (the reported symptom).
+- `:465` `'(-f --task-file --from-json)--from-json[Read tasks from a JSON file ("FILE[@path]")]:json spec:_files'`
+  — the `_hs_submit` function. **This context is broken too** (the GOAL's "submit works" premise is
+  wrong — verified: `hs submit -<TAB>` raises the same error).
+
+**Change:** in both descriptions, replace `("FILE[@path]")` with `("FILE\[@path\]")`. Nothing else
+changes — option names, the `(1)`/`(--from-json)` exclusions, the positional `1:input file:_files`
+(`:608`), and the `:json spec:_files` action are all left byte-identical. Once the description parses,
+the `(1)` positional-exclusion works fine (it never was the problem) and `_files` generates file
+candidates exactly as authored.
+
+**Regression guard:** a new `@mark.unit` test `tests/test_completions.py` that statically lints
+`share/zsh/site-functions/_hs` (no zsh/expect needed, so it is CI-portable): for every single-quoted
+`_arguments` spec with a `[...]` description, the first *unescaped* `]` after the description-opening
+`[` must be followed by `:` (an action), `'` (end of the quoted segment), or end-of-line. The buggy
+lines fail this (`]` followed by `"`); the fixed lines pass. Validated against both the pre-fix and
+post-fix file (catches exactly the 2 bad lines; zero false positives across the file, including the
+`[[ … ]]` shell-test lines in helper functions).
+
+No CLI behavior, help text, or `docs/_include/*.rst` snippet changes — this is a completion-asset bug
+fix, not a CLI change. The bash completions carry no `FILE[@path]` string and are out of scope.
+
+### Requirement → design map
+
+| R-ID | Design element(s) that satisfy it |
+|------|-----------------------------------|
+| R1   | Escaping `:562` makes `_hs_cluster`'s `_arguments` parse → `hsx`/`hs cluster` completion runs with no `comparguments` error (verified via real-zsh harness). |
+| R2   | The `:json spec:_files` action is unchanged; with the spec now valid, `--from-json <TAB>` offers files (verified: lists `alpha.json beta.json …`). |
+| R3   | Only description text changes; every other spec (options, positional `1`, exclusions) is byte-identical → no lost candidates. |
+| R4   | After the fix no spec uses a broken form: both the cluster `(1)` positional-exclusion and the submit grouped-option-exclusion are valid zsh; the "one broken form" the GOAL worried about was the bracket defect, now removed from **both** contexts. |
+
+## 3. Invariant gate (AGENTS.md constitution check)
+
+Checked against [`.agents/factory/invariants.md`](../../.agents/factory/invariants.md) before and
+after design. Only **§12 (project conventions)** is touched:
+
+- **§12 — `share/` completions kept in lockstep; wheel ships `share/`; CI asserts the paths.** The
+  edit is in place, so the installed path `share/zsh/site-functions/_hs` is unchanged — the CI
+  metadata job (which asserts *paths*, not content) stays green. No `docs/_include` update is due
+  because CLI help text does not change.
+- **§12 — tests tagged `@mark.unit`/`@mark.integration` under `--strict-markers`.** The new test is
+  `@mark.unit`.
+
+Sections §1–§11 (task lifecycle, `exit_status`, retries, server modes, FSM/threads, sentinels,
+resources, signals, queue/TLS, config, cluster argv) are **not touched** — no Python runtime code
+changes.
+
+### Deviation justifications
+
+| Deviation | Why needed | Simpler alternative rejected because |
+|-----------|-----------|--------------------------------------|
+| Fix also edits `:465` (`hs submit`), beyond the GOAL's literal "cluster only" framing | Same root cause, identical defect; `hs submit -<TAB>` is verifiably broken | Fixing only `:562` leaves an identical known-broken completion in a sibling context — indefensible in review and contrary to R4's "no broken form remains" intent |
+
+**GOAL correction (transparent, not silent drift):** the GOAL's *Problem* section attributes the bug
+to the `(1)` exclusion vs the grouped form and states other contexts work. Research disproved both:
+the cause is the unescaped bracket, and `hs submit` shares it. The R-IDs remain the contract and are
+all satisfied by the correct fix; this correction is surfaced here and will be surfaced again at
+`/hs-publish` for the human's review.
+
+## 4. Rabbit holes (resolved)
+
+- **What actually breaks the spec?** → Not `(1)`. Dropping the exclusion entirely still errored;
+  escaping the description brackets fixed it. zsh closes a `[...]` description at the first
+  *unescaped* `]`. Established with a real-zsh reproduction harness (`expect` + `compinit`), not
+  theory.
+- **Is `_hs` generated?** → No. `pyproject.toml` `[tool.hatch.build.targets.wheel.shared-data]`
+  maps it verbatim; edit the file directly.
+- **Can we guard this without zsh in CI?** → Yes. A static lint over the spec lines detects the
+  premature-close pattern; prototyped against pre/post-fix files with correct results.
+
+## 5. Risks & open questions
+
+- **Interactive-only verification isn't in CI.** The definitive proof (real zsh completion) needs
+  zsh + `expect`, which the maintainer has locally but CI does not. Mitigation: the CI gate is the
+  zsh-free static lint; the real-zsh drive is run locally during build and recorded here.
+- No open questions blocking build.
+
+## 6. Verification strategy
+
+- **Reproduce & confirm (local, real zsh):** drive completion in a pty against a candidate copy of
+  `_hs` and assert the `comparguments … invalid option definition` line is gone for `hsx -`,
+  `hs cluster -`, and `hs submit -`; and that `hsx --from-json <TAB>` lists `.json` files. (Harness
+  used during planning: `expect` + `fpath=(<dir> $fpath); compinit -u`; the cached `hsx→_hs` name
+  mapping plus fpath-prepend autoloads the candidate function body.)
+- **Syntax gate:** `zsh -n share/zsh/site-functions/_hs` (passes).
+- **Regression gate (CI-portable):** `uv run pytest -m unit -k completion` — the new static lint.
+
+---
+
+*Lean plan (small fix): no `research/` directory; findings inlined above.*

--- a/spec/hsx-zsh-completion/REVIEW.md
+++ b/spec/hsx-zsh-completion/REVIEW.md
@@ -1,0 +1,79 @@
+# REVIEW — Fix Zsh completion for `hsx` / `hs cluster`
+
+> Adversarial QA by `hs-review`, run with a blind correctness pass delegated to a fresh subagent. The
+> correctness pass grades the branch diff against [`GOAL.md`](GOAL.md) + the AGENTS.md invariants
+> **only** — it does not see `PLAN.md`/`TECH.md` (avoids grading-its-own-homework / plan-sycophancy).
+> Every finding cites an **executed** command, not an assertion.
+
+- **Reviewed commit:** bc38f4276c9a088ef77b5919a2aea27413bce60d  ·  **Base:** develop  ·  **Date:** 2026-07-24
+- **Verdict:** approved
+- **Cycle:** 1 of ≤3 — mirrors `review.cycle` in `TECH.md`
+
+## Verification run
+
+Commands actually executed and their outcomes (the spine of the review):
+
+- `zsh -n share/zsh/site-functions/_hs` → exit 0 (syntax OK), on both base and HEAD.
+- `uv run pytest -m unit -k completion` → **4 passed**, 411 deselected (orchestrator re-ran independently; reviewer subagent likewise saw 4 passed).
+- Real zsh 5.9 completion harness (zpty-driven `compinit -u`, working-tree `share/zsh/site-functions`
+  prepended to `fpath`):
+  - **Pre-fix (develop):** `hsx -<TAB>`, `hs cluster -<TAB>`, **and** `hs submit -<TAB>` all emit the
+    `invalid option definition` error with `opts=0` — no candidates offered.
+  - **Post-fix (HEAD):** all three run clean — `hsx`/`hs cluster` offer 49 options, `hs submit` offers
+    23; no `comparguments` error.
+  - `hsx --from-json <TAB>` in a dir with `tasks.json data.json other.txt` → lists exactly
+    `data.json  other.txt  tasks.json` (via `_files`), no error.
+- `git status --porcelain` → empty at reviewer hand-back and after orchestrator sanity check (clean tree).
+
+## Requirement → evidence matrix
+
+Bidirectional traceability. Flag requirements with no implementing change **and** changes that map to
+no requirement (scope creep).
+
+| R-ID | Implemented by (file/commit) | Verified how | Status |
+|------|------------------------------|--------------|--------|
+| R1 — completion runs with no `comparguments` error | `share/zsh/site-functions/_hs:562` (bc38f42) | Real zsh harness: pre-fix all three contexts errored w/ 0 opts; post-fix all clean | ✅ |
+| R2 — `--from-json` offers file candidates in cluster | `share/zsh/site-functions/_hs:562` (bc38f42) | `hsx --from-json <TAB>` listed the `.json`/other files via `_files`, no error | ✅ |
+| R3 — no loss of other cluster options / positional | `_hs:562` unchanged elsewhere (bc38f42) | Full 49-option menu rendered post-fix (vs 0 pre-fix); positional `:608` untouched; `hsx <TAB>` still offers files | ✅ |
+| R4 — self-consistent `--from-json` spec form | `_hs:465` + `_hs:562` both escaped (bc38f42) | Both specs now use `("FILE\[@path\]")`; description renders as literal `Read tasks from a JSON file ("FILE[@path]")` | ✅ |
+
+Unmapped changes (possible scope creep): **none.** The fix also escapes the **submit** spec at
+`_hs:465`. The GOAL frames submit as already-working, but the reviewer confirmed by execution that the
+pre-fix submit context was **also** broken by the identical unescaped `("FILE[@path]")` — the real root
+cause is the unescaped nested `]`, independent of the `(1)` vs `(-f --task-file --from-json)` exclusion
+prefix the GOAL fingered. Touching `:465` is therefore correct and necessary for **R4** (self-consistency)
+and repairs a second real breakage; it maps cleanly to R4/R1 intent, not scope creep. This root-cause
+correction was recorded transparently by `hs-plan` (per TECH.md) and is not a fresh GOAL contradiction.
+`tests/test_completions.py` maps to the regression-guard intent of R1/R4 (tagged `@mark.unit`).
+
+## Findings
+
+**None.** The blind reviewer actively tried to break the fix with a real zsh 5.9 completion harness and
+adversarial inputs to the test linter; everything held. The diff is a two-spec bracket-escaping change
+to a shipped completion asset plus a regression test — **zero `src/` changes**, so no runtime/behavioral
+blast radius and no high-blast-radius core file touched.
+
+Non-blocking note (not raised as a finding — cannot manifest against the guarded asset): the linter
+`iter_bad_arg_specs` (`tests/test_completions.py:38`) has two theoretical edge cases that do not fire on
+`_hs` — (a) it could false-positive on a non-spec line starting with `'` that contains `[...]` (none
+exist), and (b) it could false-negative on a malformed spec not starting with `'` (impossible — every
+spec here is single-quoted). It correctly flags the defect class and accepts paren-containing / escaped
+/ multi-`]` descriptions. LOW at most; the file lints clean today.
+
+## §12 project conventions
+
+Clean: completion-only change with no CLI surface change (so no `docs/_include/*.rst` update is due),
+bash completions untouched (explicit non-goal; bash uses no `[...]` description syntax), new tests tagged
+`@mark.unit` under `--strict-markers`, no version hardcoding.
+
+## Human-gate triggers
+
+None. No CONFIRMED finding, and no high-blast-radius core file (`data/model.py`, `server.py`,
+`client.py`, `core/queue|tls|fsm|thread|signal.py`, `cluster/remote|ssh.py`) or security/DB-lifecycle
+invariant is touched. The diff is confined to `share/zsh/site-functions/_hs` and a new test file.
+
+## Optional completeness sub-pass (separate reviewer; may see TECH.md)
+
+Not run (single-phase, small-appetite fix). The single planned phase P1 is marked `done` and its
+`verify:` gate (`uv run pytest -m unit -k completion`) passes; scope did not balloon (2 asset lines + 1
+test file, matching the appetite).

--- a/spec/hsx-zsh-completion/TECH.md
+++ b/spec/hsx-zsh-completion/TECH.md
@@ -1,0 +1,80 @@
+---
+slug: hsx-zsh-completion
+title: "Fix Zsh completion for hsx / hs cluster"
+kind: fix
+appetite: small
+status: in_progress
+branch: fix/hsx-zsh-completion
+base: develop
+current_phase: P1
+last_updated: "2026-07-24"
+phases:
+  - id: P1
+    name: "Escape --from-json description brackets + add completion regression test"
+    status: pending
+    satisfies: [R1, R2, R3, R4]
+    depends_on: []
+    parallel: false
+    hammerable: false
+    hill: crest
+    verify: "uv run pytest -m unit -k completion"
+review:
+  last_reviewed_commit: ""
+  verdict: none
+  blocked_reason: ""
+  cycle: 0
+---
+
+# TECH.md — Fix Zsh completion for `hsx` / `hs cluster`
+
+The **context engine and finite-state machine** for building this fix. The YAML frontmatter is the
+resume ground-truth (`uv run python .agents/factory/bin/next_phase.py spec/hsx-zsh-completion/TECH.md`);
+the per-phase checklist below is the work.
+
+- **Vision / requirements (locked):** [`GOAL.md`](GOAL.md) — R-IDs are the contract.
+- **Authoritative design:** [`PLAN.md`](PLAN.md).
+
+## Conventions (apply to every phase)
+
+- Commit conventions, code style, and load-bearing invariants come from [`AGENTS.md`](../../AGENTS.md);
+  the curated footgun list is [`.agents/factory/invariants.md`](../../.agents/factory/invariants.md).
+- One atomic commit containing **both** the code and the `TECH.md` state change. Subject:
+  `[fix] Build hsx-zsh-completion P1: …`. **No `Co-Authored-By` trailer.**
+- This is a completion-asset bug fix with no CLI/help-text change, so no `docs/_include/*.rst` update
+  is due. Only `share/zsh/site-functions/_hs` (path unchanged) and a new test are touched.
+
+---
+
+## Phase P1 — Escape `--from-json` description brackets + add completion regression test
+**Satisfies:** R1, R2, R3, R4 · **Depends on:** —
+**Goal:** `hsx` / `hs cluster` (and `hs submit`) Zsh completion runs with no `comparguments` error,
+`--from-json` still completes files, and a CI-portable test prevents the defect class from returning.
+
+- [ ] In `share/zsh/site-functions/_hs`, edit **both** `--from-json` spec lines (`_hs_submit` ~`:465`
+      and `_hs_cluster` ~`:562`): replace `("FILE[@path]")` with `("FILE\[@path\]")`. Change nothing
+      else — option names, the `(1)` / `(--from-json)` exclusions, the positional `1:input file:_files`,
+      and the `:json spec:_files` action stay byte-identical.
+- [ ] Confirm shell syntax: `zsh -n share/zsh/site-functions/_hs`.
+- [ ] Drive **real zsh completion** and record the result (needs `zsh` + `expect`, present locally):
+      assert the `invalid option definition` line is gone for `hsx -`, `hs cluster -`, and
+      `hs submit -`, and that `hsx --from-json <TAB>` lists `.json` files. (Prepend the working-tree
+      `share/zsh/site-functions` to `fpath`, `compinit -u`, then TAB.)
+- [ ] Add `tests/test_completions.py` (`@mark.unit`, SPDX header, `REPO = Path(__file__).parent.parent`
+      style à la `tests/test_meta_status.py`): a static lint of `share/zsh/site-functions/_hs`. For
+      every stripped line starting with `'` that contains `[`, take the first `[` as the description
+      open and scan for the first *unescaped* `]`; assert the following char is `:`, `'`, or
+      end-of-line. Assert zero offending lines (guards the whole file, incl. `--from-json`).
+- **Verify:** `uv run pytest -m unit -k completion`.
+- **Touches:** `share/zsh/site-functions/_hs`, `tests/test_completions.py`.
+
+---
+
+## How `hs-build` drives this
+
+1. `next_phase.py` prints the next actionable phase.
+2. Pre-flight: clean tree, on `fix/hsx-zsh-completion`, `develop` reachable.
+3. Execute every `[ ]` in P1 (consult `PLAN.md` for detail).
+4. Run the `verify:` command — never advance on a checkbox alone.
+5. Mark P1 `done`, `--touch`; one `[fix]` commit; stop and report. STOP and escalate only on a
+   `GOAL.md` contradiction (note: the PLAN already records the transparent GOAL root-cause correction —
+   that is *not* a fresh contradiction to escalate).

--- a/spec/hsx-zsh-completion/TECH.md
+++ b/spec/hsx-zsh-completion/TECH.md
@@ -3,7 +3,7 @@ slug: hsx-zsh-completion
 title: Fix Zsh completion for hsx / hs cluster
 kind: fix
 appetite: small
-status: in_review
+status: done
 branch: fix/hsx-zsh-completion
 base: develop
 current_phase: done

--- a/spec/hsx-zsh-completion/TECH.md
+++ b/spec/hsx-zsh-completion/TECH.md
@@ -1,30 +1,33 @@
 ---
 slug: hsx-zsh-completion
-title: "Fix Zsh completion for hsx / hs cluster"
+title: Fix Zsh completion for hsx / hs cluster
 kind: fix
 appetite: small
-status: in_progress
+status: in_review
 branch: fix/hsx-zsh-completion
 base: develop
-current_phase: P1
-last_updated: "2026-07-24"
+current_phase: done
+last_updated: '2026-07-24'
 phases:
-  - id: P1
-    name: "Escape --from-json description brackets + add completion regression test"
-    status: pending
-    satisfies: [R1, R2, R3, R4]
-    depends_on: []
-    parallel: false
-    hammerable: false
-    hill: crest
-    verify: "uv run pytest -m unit -k completion"
+- id: P1
+  name: Escape --from-json description brackets + add completion regression test
+  status: done
+  satisfies:
+  - R1
+  - R2
+  - R3
+  - R4
+  depends_on: []
+  parallel: false
+  hammerable: false
+  hill: downhill
+  verify: uv run pytest -m unit -k completion
 review:
-  last_reviewed_commit: ""
+  last_reviewed_commit: ''
   verdict: none
-  blocked_reason: ""
+  blocked_reason: ''
   cycle: 0
 ---
-
 # TECH.md — Fix Zsh completion for `hsx` / `hs cluster`
 
 The **context engine and finite-state machine** for building this fix. The YAML frontmatter is the
@@ -50,20 +53,21 @@ the per-phase checklist below is the work.
 **Goal:** `hsx` / `hs cluster` (and `hs submit`) Zsh completion runs with no `comparguments` error,
 `--from-json` still completes files, and a CI-portable test prevents the defect class from returning.
 
-- [ ] In `share/zsh/site-functions/_hs`, edit **both** `--from-json` spec lines (`_hs_submit` ~`:465`
-      and `_hs_cluster` ~`:562`): replace `("FILE[@path]")` with `("FILE\[@path\]")`. Change nothing
+- [x] In `share/zsh/site-functions/_hs`, edit **both** `--from-json` spec lines (`_hs_submit` `:465`
+      and `_hs_cluster` `:562`): replace `("FILE[@path]")` with `("FILE\[@path\]")`. Changed nothing
       else — option names, the `(1)` / `(--from-json)` exclusions, the positional `1:input file:_files`,
       and the `:json spec:_files` action stay byte-identical.
-- [ ] Confirm shell syntax: `zsh -n share/zsh/site-functions/_hs`.
-- [ ] Drive **real zsh completion** and record the result (needs `zsh` + `expect`, present locally):
-      assert the `invalid option definition` line is gone for `hsx -`, `hs cluster -`, and
-      `hs submit -`, and that `hsx --from-json <TAB>` lists `.json` files. (Prepend the working-tree
-      `share/zsh/site-functions` to `fpath`, `compinit -u`, then TAB.)
-- [ ] Add `tests/test_completions.py` (`@mark.unit`, SPDX header, `REPO = Path(__file__).parent.parent`
+- [x] Confirmed shell syntax: `zsh -n share/zsh/site-functions/_hs` → OK.
+- [x] Drove **real zsh completion** (via `expect` + `compinit -u` with the working-tree
+      `share/zsh/site-functions` prepended to `fpath`): the `invalid option definition` line is gone for
+      `hsx -`, `hs cluster -`, and `hs submit -`, and `hsx --from-json <TAB>` lists `.json` files
+      (`alpha.json`, `beta.json`).
+- [x] Added `tests/test_completions.py` (`@mark.unit`, SPDX header, `REPO = Path(__file__).parent.parent`
       style à la `tests/test_meta_status.py`): a static lint of `share/zsh/site-functions/_hs`. For
-      every stripped line starting with `'` that contains `[`, take the first `[` as the description
-      open and scan for the first *unescaped* `]`; assert the following char is `:`, `'`, or
-      end-of-line. Assert zero offending lines (guards the whole file, incl. `--from-json`).
+      every stripped line starting with `'` that contains `[`, it takes the first `[` as the description
+      open and scans for the first *unescaped* `]`; asserts the following char is `:`, `'`, or
+      end-of-line. Guards the whole file (incl. both `--from-json` specs) plus a targeted
+      escaped-brackets check and a self-test of the linter against the known defect.
 - **Verify:** `uv run pytest -m unit -k completion`.
 - **Touches:** `share/zsh/site-functions/_hs`, `tests/test_completions.py`.
 

--- a/spec/hsx-zsh-completion/TECH.md
+++ b/spec/hsx-zsh-completion/TECH.md
@@ -23,10 +23,10 @@ phases:
   hill: downhill
   verify: uv run pytest -m unit -k completion
 review:
-  last_reviewed_commit: ''
-  verdict: none
+  last_reviewed_commit: bc38f4276c9a088ef77b5919a2aea27413bce60d
+  verdict: approved
   blocked_reason: ''
-  cycle: 0
+  cycle: 1
 ---
 # TECH.md — Fix Zsh completion for `hsx` / `hs cluster`
 

--- a/tests/test_completions.py
+++ b/tests/test_completions.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2026 Geoffrey Lentner
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for the shipped shell completions (share/).
+
+Zsh `_arguments` closes an option-description ``[ ... ]`` at the first *unescaped*
+``]``. A description that embeds a literal bracket (e.g. ``("FILE[@path]")``) therefore
+terminates early, and `comparguments` rejects the whole spec with "invalid option
+definition", aborting the entire completion function. This module lints the committed
+`_hs` completion so that defect class cannot return: for every `_arguments` spec with a
+description, the first unescaped ``]`` must be followed by an action (``:``), the end of
+the quoted segment (``'``), or end-of-line.
+"""
+
+
+# Type annotations
+from __future__ import annotations
+from typing import Iterator, Tuple
+
+# Standard libs
+from pathlib import Path
+
+# External libs
+from pytest import mark
+
+# The hand-maintained zsh completion shipped in the wheel (share/).
+REPO = Path(__file__).parent.parent
+ZSH_COMPLETION = REPO / 'share' / 'zsh' / 'site-functions' / '_hs'
+
+
+def iter_bad_arg_specs(text: str) -> Iterator[Tuple[int, str]]:
+    """
+    Yield ``(lineno, line)`` for each `_arguments` spec whose option-description
+    contains an unescaped ``]`` that prematurely closes the ``[ ... ]`` bracket.
+
+    Heuristic (matches how zsh parses specs in this file): a spec is a line whose
+    stripped form starts with a single quote and contains ``[``. The first ``[`` opens
+    the description; the char after its first *unescaped* ``]`` must be ``:``, ``'``, or
+    end-of-line. Anything else means the description closed early.
+    """
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        s = raw.strip()
+        if not s.startswith("'") or '[' not in s:
+            continue
+        i = s.index('[')
+        j = i + 1
+        while j < len(s):
+            if s[j] == '\\':
+                j += 2  # Escaped char (e.g. \[ or \]) is literal; skip both.
+                continue
+            if s[j] == ']':
+                nxt = s[j + 1] if j + 1 < len(s) else ''
+                if nxt not in (':', "'", ''):
+                    yield lineno, s
+                break
+            j += 1
+
+
+@mark.unit
+def test_zsh_completion_exists() -> None:
+    """The zsh completion asset must be present (the wheel ships it)."""
+    assert ZSH_COMPLETION.is_file(), f'missing completion: {ZSH_COMPLETION}'
+
+
+@mark.unit
+def test_zsh_completion_descriptions_well_formed() -> None:
+    """No `_arguments` spec may close its description bracket early (see module docstring)."""
+    bad = list(iter_bad_arg_specs(ZSH_COMPLETION.read_text()))
+    assert not bad, 'malformed _arguments description bracket(s):\n' + '\n'.join(
+        f'  L{n}: {line}' for n, line in bad)
+
+
+@mark.unit
+def test_from_json_brackets_are_escaped() -> None:
+    """Both `--from-json` specs must keep the nested brackets escaped as ``FILE\\[@path\\]``."""
+    lines = [ln for ln in ZSH_COMPLETION.read_text().splitlines() if '--from-json[' in ln]
+    assert lines, 'no --from-json option spec found in completion'
+    for ln in lines:
+        assert r'"FILE\[@path\]"' in ln, f'unescaped FILE[@path] in: {ln.strip()}'
+
+
+@mark.unit
+def test_lint_detects_known_defect() -> None:
+    """The linter itself must flag the pre-fix (unescaped) form and accept the fixed form."""
+    broken = '''        '(1)--from-json[Read tasks from a JSON file ("FILE[@path]")]:json spec:_files' \\'''
+    fixed = '''        '(1)--from-json[Read tasks from a JSON file ("FILE\\[@path\\]")]:json spec:_files' \\'''
+    assert list(iter_bad_arg_specs(broken)), 'linter failed to flag the known defect'
+    assert not list(iter_bad_arg_specs(fixed)), 'linter false-positived on the fixed form'


### PR DESCRIPTION
## Summary

Zsh tab-completion aborted immediately for `hsx` / `hs cluster` (and, as verified during review, `hs submit` too) with `_arguments:comparguments: invalid option definition`. Root cause: the `--from-json` option description embedded a literal `[…]` (`"FILE[@path]"`), and Zsh's `_arguments` closes a description `[…]` at the first *unescaped* `]`, so the spec terminated early and `comparguments` rejected the whole completion function. This escapes the nested brackets (`"FILE\[@path\]"`) in **both** `--from-json` specs and adds a CI-portable regression test that lints the shipped `_hs` asset for the defect class.

## Goal

[GOAL.md](https://github.com/hypershell/hypershell/blob/0abc6ebf24fc64905533df267b2b73c21a013c6e/spec/hsx-zsh-completion/GOAL.md)

## Design

[PLAN.md](https://github.com/hypershell/hypershell/blob/0abc6ebf24fc64905533df267b2b73c21a013c6e/spec/hsx-zsh-completion/PLAN.md) (historical design record)

## Phases completed

- **P1** — Escape `--from-json` description brackets + add completion regression test · satisfies **R1, R2, R3, R4**

## Verification

- Real zsh 5.9 completion harness (zpty `compinit -u`, working-tree `share/` on `fpath`): pre-fix `hsx` / `hs cluster` / `hs submit` all errored with 0 candidates; post-fix all clean (49 / 49 / 23 options); `hsx --from-json <TAB>` lists `.json` files via `_files`.
- `uv run pytest -m unit -k completion` → **4 passed**.
- `zsh -n share/zsh/site-functions/_hs` → OK.
- Full review: [REVIEW.md](https://github.com/hypershell/hypershell/blob/0abc6ebf24fc64905533df267b2b73c21a013c6e/spec/hsx-zsh-completion/REVIEW.md)

## Docs & completions

Same-commit rule honored: this is a completion-asset fix with no CLI/help-text surface change, so no `docs/_include/*.rst` update is due; only `share/zsh/site-functions/_hs` (path unchanged) and a new test are touched. Bash completions intentionally untouched (explicit non-goal; bash descriptions don't use `[...]` syntax).

## 🔧 Harness feedback

- **What worked well:** `hs-plan` Step 3's steer to skip subagent fan-out for a small fix and do hands-on real-zsh CLI reproduction is what exposed the true root cause.
- **F1 · low · steering** — the shaped `GOAL.md` baked the reporter's *unverified* root-cause hypothesis into an acceptance criterion (R4-as-mechanism; the "submit works" premise), which `/hs-plan` disproved. Suggests `/hs-feature` should steer `fix` acceptance criteria to observable-outcome-only. (Open; for `/hs-harness`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
