### PR TITLE
[fix] Emit a clean 'cron' extra hint when croniter is missing for log rotation

### DIFF
--- a/spec/croniter-missing-guidance/GOAL.md
+++ b/spec/croniter-missing-guidance/GOAL.md
@@ -1,0 +1,96 @@
+# GOAL — Graceful guidance when croniter is missing for time-based log rotation
+
+> **Origin spec.** The *what* and *why* — the locked contract `hs-review` grades against.
+> The *how* lives in [`PLAN.md`](PLAN.md) and [`TECH.md`](TECH.md) (written by `hs-plan`).
+> Keep this at the right altitude: solved and bounded, but not over-specified — leave design
+> freedom for the plan. Edit requirements here; do **not** silently drift them during build.
+
+- **slug:** croniter-missing-guidance
+- **kind:** fix
+- **appetite:** small
+
+## Problem
+
+`croniter` is an *optional* dependency, gated behind the `cron` install extra
+(`pyproject.toml`: `cron = ["croniter>=6.2.2"]`). It is only needed for **time/cron-like log
+rotation** (`logging.file.rotate` values such as `@daily`, `@midnight`, or a cron expression).
+
+A user who installs HyperShell without the `cron` extra (e.g. `uv tool install hypershell`) but
+whose config sets a time-like rotation policy gets a hard crash at startup — on **every** `hs`/`hsx`
+invocation, before the requested command can run. Worse, the crash is a confusing **double
+traceback**: a `ValueError: Memory string '@daily' is not a valid memory unit` from an internal
+size-parse probe, chained ("During handling of the above exception, another exception occurred") to
+a raw `ModuleNotFoundError: No module named 'croniter'`. Neither traceback tells the user what is
+actually wrong or how to fix it.
+
+The project already handles other missing optional dependencies gracefully — a missing `psycopg`
+prints a single clear "Missing optional dependency … needed for PostgreSQL" line and exits cleanly
+(`data/core.py`). Missing `croniter` should behave the same way: one clear, actionable message
+naming the missing package and the remedy (install the `cron` extra), with no traceback. A friendly
+message for exactly this case appears to already be *intended* in the code but is not the behavior a
+user actually gets (see Clarifications for the suspected mechanism — to be confirmed in `/hs-plan`).
+
+## Outcome / vision
+
+Running any `hs`/`hsx` command with a time-like `logging.file.rotate` policy configured but
+`croniter` not installed produces a single, clear, actionable error — comparable to the existing
+missing-`psycopg` experience — and a clean non-zero exit. No Python traceback, no chained
+double traceback. When `croniter` *is* installed, time-based rotation works exactly as before, and
+size-based rotation is unaffected either way.
+
+## Acceptance criteria (the contract)
+
+- **R1** — WHEN `croniter` is not installed AND `logging.file.rotate` is set to a time/cron-like
+  policy (e.g. `@daily`), running an `hs`/`hsx` command SHALL terminate with a single, clear message
+  that names the missing `croniter` dependency and states the remedy (install the `cron` extra), and
+  SHALL exit with a non-zero status — not raise an uncaught exception.
+- **R2** — IF the missing-`croniter` condition is hit, THEN the program output SHALL NOT contain a
+  Python traceback, and in particular SHALL NOT contain a chained "During handling of the above
+  exception, another exception occurred" double traceback.
+- **R3** — WHEN `croniter` *is* installed, time/cron-like rotation policies (e.g. `@daily`,
+  `@midnight`, and cron expressions) SHALL continue to configure a working time-based rotating log
+  handler, unchanged from today (no regression).
+- **R4** — Size-like rotation policies (e.g. `2GB`) SHALL continue to work whether or not `croniter`
+  is installed; a missing `croniter` SHALL NOT affect size-based rotation.
+- **R5** — The graceful missing-`croniter` handling SHALL be consistent in spirit with the existing
+  missing-`psycopg` guidance (single critical line + clean exit), not a bespoke divergent style.
+
+## Non-goals (no-gos)
+
+- Making `croniter` a hard (non-optional) dependency — it stays behind the `cron` extra.
+- Adding, removing, or changing the set of supported rotation policies or their semantics.
+- Redesigning file logging, the rotating-handler class hierarchy, or the size-vs-time policy
+  discrimination beyond what is needed to fix the crash and deliver the graceful message.
+- Changing any behavior when `croniter` is present.
+- Broader "audit every optional dependency for graceful handling" sweep — this fix is scoped to the
+  `croniter` / time-based-rotation path only.
+
+## Clarifications
+
+- **Q:** Should the remedy text explicitly name the `cron` install extra (not just the `croniter`
+  package)? — **A:** Yes; the user must be told to install with the `cron` extra (resolved
+  2026-07-24).
+- **Q:** Is a specific exit code required? — **A:** No; a clean non-zero exit consistent with the
+  existing missing-dependency precedent is sufficient. The exact code is a `/hs-plan` decision.
+- **Suspected mechanism (a lead for `/hs-plan`, NOT an acceptance criterion — root-cause to be
+  confirmed):** `initialize_logging` uses `parse_bytes(file_policy)` as a size-vs-time
+  *discriminator* — a `ValueError` means "treat as time-like." In the time-like branch the
+  `TimedRotatingFileHandler` is constructed *before* the friendly missing-`croniter` check, and the
+  handler's `__init__ → reset_interval()` imports `croniter` eagerly, so it crashes first; the
+  intended graceful `panic(...)` for missing `croniter` is therefore effectively dead code. Because
+  the crash happens inside the `except ValueError:` block, the size-parse `ValueError` becomes the
+  chained context of the `ModuleNotFoundError`, producing the double traceback. `/hs-plan` should
+  verify this and decide the fix (e.g. probe croniter availability before constructing the handler
+  and/or break the exception chain).
+
+## Related materials
+
+- User-reported traceback: `~/ISSUE.md` (double traceback from `uv tool install hypershell` without
+  the `cron` extra, config `logging.file.rotate = @daily`).
+- Source (crash site): `src/hypershell/core/logging.py` — `initialize_logging` rotation-policy block
+  (`parse_bytes` probe, `except ValueError` time-like branch, the post-construction `panic(...)`
+  croniter check), `TimedRotatingFileHandler.reset_interval` / `RotatingFileHandler.__init__`,
+  `DATE_ELIGIBLE`, `ROTATE_NEVER`, `panic`.
+- Reference pattern (graceful optional-dependency handling): `src/hypershell/data/core.py` missing
+  `psycopg` / `libpq` branch (`display_critical` + clean `sys.exit`).
+- Packaging: `pyproject.toml` — `cron = ["croniter>=6.2.2"]` extra.

--- a/spec/croniter-missing-guidance/PLAN.md
+++ b/spec/croniter-missing-guidance/PLAN.md
@@ -1,0 +1,171 @@
+# PLAN — Graceful guidance when croniter is missing for time-based log rotation
+
+> **Status:** Draft for review · **Last updated:** 2026-07-24
+> **Authoritative technical design.** The *how*. Vision/contract is [`GOAL.md`](GOAL.md);
+> the phased executable roadmap is [`TECH.md`](TECH.md). Backing detail is in
+> [`research/`](research/). Every design element traces to a GOAL R-ID.
+
+## 1. Summary
+
+A single, localized fix in `core/logging.py`'s `initialize_logging()`. The missing-`croniter`
+failure is an **ordering bug**: the intended friendly guard runs *after* the
+`TimedRotatingFileHandler` is constructed, but the constructor eagerly imports `croniter` and
+crashes first — inside an `except ValueError:` block, so the size-parse `ValueError` chains into the
+`ModuleNotFoundError` (the reported **double traceback**). We move the availability check **before**
+handler construction, gate it on the rotation policy actually needing croniter (`file_policy !=
+ROTATE_NEVER`), emit the existing repo-standard "missing optional dependency" message via `panic()`,
+and delete the now-dead guard. Appetite is `small`: ~10 lines of source plus targeted tests, no new
+surface area, no behavior change when croniter is present.
+
+## 2. Design
+
+Everything lives in **`src/hypershell/core/logging.py`**, `initialize_logging()`'s `[logging.file]`
+**Namespace** branch (currently `~:1046-1067`). See [`research/00-digest.md`](research/00-digest.md)
+for the triple-verified root cause and full path enumeration.
+
+**Extract a helper** (module-level, near `panic()`):
+
+```python
+def require_croniter() -> None:
+    """Missing croniter is fatal only for time-based rotation; guide to the 'cron' extra."""
+    try:
+        import croniter  # noqa: F401
+    except ImportError:
+        panic('Missing optional dependency "croniter" (the "cron" extra) needed for time-based log rotation')
+```
+
+**Rewrite the discriminator's time-like branch** so the check precedes construction and the
+exception chain is broken (handler is no longer built inside a nested failure path):
+
+```python
+try:
+    total_bytes = parse_bytes(file_policy)
+    set_naming_policy('count')
+    file_handler = SizeRotatingFileHandler(filename=file_path, interval=file_policy)
+    info = [ ... ]                                   # size-like (unchanged)
+except ValueError:
+    if file_policy != ROTATE_NEVER:                  # 'never' also lands here but needs no croniter
+        require_croniter()                           # panic-before-construct if absent
+    set_naming_policy('date' if file_policy in DATE_ELIGIBLE else 'datetime')
+    file_handler = TimedRotatingFileHandler(filename=file_path, interval=file_policy)
+    info = [ ... ]                                   # time-like (unchanged)
+
+# DELETE the dead block:
+#   if isinstance(file_handler, TimedRotatingFileHandler):
+#       try: from croniter import croniter
+#       except ImportError: panic('Missing optional dependency \'croniter\' needed for time-based rotation')
+```
+
+**Why this is correct and complete:**
+- `panic()` raises `SystemExit(int)`; raising it *before* `:1057` means no `TimedRotatingFileHandler`
+  is constructed, no `croniter` import fires, and there is no nested exception to become
+  `__context__` → **no traceback, no double traceback**.
+- The `file_policy != ROTATE_NEVER` gate mirrors `TimedRotatingFileHandler.reset_interval`'s own
+  `interval != ROTATE_NEVER` guard, so we require croniter in exactly the cases the handler would
+  actually import it. This **also closes a latent bug (D2)**: today a `[logging.file]` Namespace with
+  no `rotate=` (defaults to `'never'`) + missing croniter falsely reaches the dead guard and panics.
+- A **single upfront probe** suffices: `reset_interval` (the only croniter site, reached from
+  `__init__` and the SIGHUP `rotate()` path) cannot start needing croniter later — module presence is
+  fixed per process.
+
+**Message & exit:** the repo-standard optional-dependency wording (double-quoted package + `(the
+"cron" extra)` + purpose), delivered via the local `panic()` (`critical()` +
+`sys.exit(exit_status.bad_config)`), which is already the idiom for the other bad-logging-config exits
+in this function. Consistent in spirit with the missing-`psycopg` guidance (R5). No invented integer
+literal (§12).
+
+### Requirement → design map
+
+| R-ID | Design element(s) that satisfy it |
+|------|-----------------------------------|
+| R1 | `require_croniter()` panics **before** handler construction with a message naming `croniter` + the `cron` extra; `panic()` → `sys.exit(exit_status.bad_config)` (non-zero, clean). |
+| R2 | Check moved out of the nested `except`-block construction path → `SystemExit` exits with no traceback and no chained `__context__` double traceback. |
+| R3 | `if file_policy != ROTATE_NEVER` gate skips the check for `'never'`/default; with croniter present, `@daily`/`@midnight`/cron construct the timed handler exactly as before (branch body unchanged). |
+| R4 | Size policies parse successfully in the `try:` → the `except` (and the whole croniter path) is never entered; independent of croniter. |
+| R5 | Reuses `panic()` + the `data/core.py`-style "Missing optional dependency …" wording — same single-critical-line + clean-exit shape as the psycopg case. |
+
+## 3. Invariant gate (AGENTS.md constitution check)
+
+Checked against [`invariants.md`](../../.agents/factory/invariants.md) before research and again
+after this design. Touched sections:
+
+- **§8 Signals** — The SIGHUP → `rotate()` → `reset_interval()` path also imports croniter. The
+  upfront probe guarantees croniter is present for the entire process whenever a cron timed handler
+  is built, so every later `rotate()`/`reset_interval()` succeeds. The signal handling itself is not
+  modified; no `reset_signal()` added/removed. **Honored.**
+- **§10 Configuration** — Gate uses the `ROTATE_NEVER` sentinel; no mutation of the config singleton;
+  reads the same `file_policy`/`DATE_ELIGIBLE` as today. **Honored.**
+- **§12 Conventions** — Uses the `cmdkit.app.exit_status.bad_config` constant (no literal). No
+  CLI/help/completion surface change and behavior-with-croniter is unchanged, so no same-commit
+  `docs/_include`/`share/` edit is required (existing docs already state the requirement). New tests
+  tagged `@mark.unit`/`@mark.integration`. **Honored.**
+
+`core/logging.py` is a footgun file but **not** in the high-blast-radius set (§16 list:
+`data/model.py`, `server.py`, `client.py`, `core/queue.py|tls.py|fsm.py|thread.py|signal.py`,
+`cluster/remote.py|ssh.py`) — no mandatory human gate is triggered by touching it.
+
+### Deviation justifications
+
+| Deviation | Why needed | Simpler alternative rejected because |
+|-----------|-----------|--------------------------------------|
+| — | — | — |
+
+## 4. Rabbit holes (resolved)
+
+- **Is it really a bug, or just a missing message?** → Confirmed a genuine **ordering + exception-
+  chaining** bug: the friendly guard is unreachable for the reported case; the double traceback is
+  the size-parse `ValueError` chained to the croniter `ModuleNotFoundError`
+  ([`research/01-root-cause.md`](research/01-root-cause.md), adversarially re-derived).
+- **Will fixing it regress rotation-off users?** → Yes it would, if ungated: `'never'`/default also
+  enters the `except ValueError:` branch. The `file_policy != ROTATE_NEVER` gate is load-bearing and
+  additionally **closes** the latent `'never'` false-positive (D2)
+  ([`research/02-policy-path-enum.md`](research/02-policy-path-enum.md)).
+- **Do other code paths need croniter (so one probe isn't enough)?** → No; `reset_interval` is the
+  sole site; one upfront probe covers `__init__` and the SIGHUP `rotate()` path
+  ([`research/03-imports-and-packaging.md`](research/03-imports-and-packaging.md)).
+- **How do we test a missing package that CI always installs?** → `monkeypatch.setitem(sys.modules,
+  'croniter', None)` (unit) and the same injection in a subprocess (integration), both verified
+  ([`research/04-test-strategy.md`](research/04-test-strategy.md)).
+- **`panic()` vs `display_critical`, and which exit code?** → `panic()` + `exit_status.bad_config`,
+  for local consistency ([`research/05-message-and-exit.md`](research/05-message-and-exit.md)).
+
+## 5. Risks & open questions
+
+- **Pre-existing, out of scope — digit-leading cron expressions are misrouted.**
+  `parse_bytes('30 2 * * *') → 30`, `parse_bytes('0 0 * * *') → 0`, so a numeric-leading cron
+  expression is silently sent to `SizeRotatingFileHandler` (rotate every N bytes) and never reaches
+  the time path or croniter. This predates the reported bug and is excluded by the GOAL non-goals
+  (no discriminator redesign). It is **not a regression** (already broken today), so R3 — which
+  covers `@daily`/`@midnight` and "unchanged from today" — still holds. **Open question for the
+  human:** worth a separate follow-up fix? (Not addressed here.)
+- **Broader hardening (noted, not in scope):** `initialize_logging` runs before cmdkit's exception
+  mapping, so *any* init-time error still yields a raw traceback. This fix only covers the croniter
+  path; a general init-error wrapper is a larger, separate effort.
+- **Lint:** `import croniter  # noqa: F401` is a probe-only import; the existing (to-be-deleted) dead
+  block imported croniter unused without a noqa, so the repo tolerates it, but the `noqa` keeps
+  intent explicit.
+
+## 6. Verification strategy
+
+Seeds the per-phase `verify:` commands in [`TECH.md`](TECH.md). croniter is present in dev/CI, so the
+missing path is exercised only via `sys.modules['croniter'] = None` injection.
+
+- **Unit (R1):** `test_require_croniter_panics_when_absent` — `monkeypatch.setitem(sys.modules,
+  'croniter', None)`; assert `SystemExit`, `code == exit_status.bad_config`, and `'croniter'` &
+  `'cron'` in `caplog.text`. Plus `test_require_croniter_noop_when_present` — no raise when
+  importable.
+- **Integration (R1+R2, user-visible):** `test_missing_croniter_is_clean_not_double_traceback` — a
+  subprocess `python -c "import sys; sys.modules['croniter']=None; from hypershell import main;
+  sys.exit(main())" list --count` with `HYPERSHELL_LOGGING_FILE_ROTATE='@daily'`; assert stderr has
+  the guidance and **not** `Traceback (most recent call last)` / `During handling of the above
+  exception` / `ModuleNotFoundError`, and returncode ≠ 0.
+- **Regression (R3+R4):** subprocess with croniter absent + `HYPERSHELL_LOGGING_FILE_ROTATE='never'`
+  → starts cleanly (D2 closed); + `='2GB'` → starts cleanly (size path unaffected).
+- **Positive CLI drive (R3, croniter present):**
+  `.agents/factory/bin/temp_site.sh sh -c "HYPERSHELL_LOGGING_FILE_ROTATE=@daily uv run hs list --count"`
+  starts cleanly and configures time-based rotation.
+- **Full gate:** `uv run pytest -v tests/test_logging.py` green.
+
+---
+
+*Backing research: [`research/00-digest.md`](research/00-digest.md).*

--- a/spec/croniter-missing-guidance/REVIEW.md
+++ b/spec/croniter-missing-guidance/REVIEW.md
@@ -1,0 +1,71 @@
+# REVIEW — Graceful guidance when croniter is missing for time-based log rotation
+
+> Adversarial QA by `hs-review`, run in an isolated/clean context. The correctness pass grades the
+> branch diff against [`GOAL.md`](GOAL.md) + the AGENTS.md invariants **only** — it does not see
+> `PLAN.md`/`TECH.md` (avoids grading-its-own-homework / plan-sycophancy). Every finding cites an
+> **executed** command, not an assertion.
+
+- **Reviewed commit:** 44905d19a148f2419e49316f2950d52b61638292  ·  **Base:** develop  ·  **Date:** 2026-07-24
+- **Verdict:** approved
+- **Cycle:** 1 of ≤3 — mirrors `review.cycle` in `TECH.md`
+
+## Verification run
+
+Commands actually executed (blind `general-purpose` reviewer, curated inputs: `GOAL.md` + spec-excluded
+diff + `invariants.md` + `review-rubric.md`; denied `PLAN.md`/`TECH.md`/`research/`/`META.md`):
+
+- `git diff develop...HEAD -- . ':(exclude)spec/'` → only `src/hypershell/core/logging.py` and
+  `tests/test_logging.py` changed (blind-review pathspec confirmed applied).
+- `uv run pytest -v tests/test_logging.py` → **42 passed**.
+- `uv run pytest -q -m unit` → **169 passed, 252 deselected** (no regressions).
+- **R1/R2 independent repro** — subprocess injecting `sys.modules['croniter']=None`,
+  `HYPERSHELL_LOGGING_FILE_ROTATE=@daily`, real CLI in a throwaway site
+  (`.agents/factory/bin/temp_site.sh`): stderr =
+  `CRITICAL [core.logging] Missing optional dependency "croniter" (the "cron" extra) needed for time-based log rotation`,
+  `EXIT=3` (`exit_status.bad_config`). **No** `Traceback (most recent call last)`, **no** `During
+  handling of the above exception`, **no** `ModuleNotFoundError`. Reproduced identically with `@hourly`.
+- **R3** — croniter present, `@daily` / `@midnight` / raw cron `0 3 * * *` → all `EXIT=0`.
+- **R4** — `2GB`, croniter **absent** and **present** → both `EXIT=0`.
+- **`never` edge** (croniter absent) → `EXIT=0`, no croniter panic (closed false-positive verified).
+- Orchestrator sanity check: re-inspected the spec-excluded diff and confirmed the code matches the
+  reviewer's account; `git status --porcelain` empty at hand-back (no instrumentation left behind).
+
+## Requirement → evidence matrix
+
+| R-ID | Implemented by (file/commit) | Verified how | Status |
+|------|------------------------------|--------------|--------|
+| R1 | `require_croniter()` + gated probe, `core/logging.py` (2bd9c63) | Subprocess `@daily`+croniter-absent → single CRITICAL line naming `croniter` and the `cron` extra, `EXIT=3` non-zero | ✅ |
+| R2 | dead post-construction block removed, `core/logging.py` (2bd9c63) | Same run: no `Traceback`, no `During handling of the above exception`, no `ModuleNotFoundError` | ✅ |
+| R3 | probe is a no-op when croniter present (unchanged handler path), `core/logging.py` | `@daily`/`@midnight`/`0 3 * * *` with croniter present → `EXIT=0` | ✅ |
+| R4 | size policies succeed in the `try` branch, never reach the gate | `2GB` with croniter absent **and** present → `EXIT=0` | ✅ |
+| R5 | reuses `panic()` (single critical line + clean exit), message style mirrors `data/core.py` | Message format matches the `data/core.py` optional-dep precedents; `exit_status` constant, not a magic literal | ✅ |
+
+Unmapped changes (possible scope creep): **none**. The `raises` import supports the new unit test.
+No CLI-surface / help-text / `share/` completion change, so the §12 docs-in-same-commit rule does not
+apply (behavior with croniter present is unchanged).
+
+## Findings
+
+**None.** No candidate finding survived the refutation protocol.
+
+Actively refuted and dropped:
+- *Would `never`/default falsely demand croniter?* — No. `if file_policy != ROTATE_NEVER:` gates the
+  probe and mirrors `TimedRotatingFileHandler.reset_interval`'s own `ROTATE_NEVER` guard
+  (`core/logging.py:441`). Verified by execution (`never` + croniter absent → `EXIT=0`).
+- *Does the probe faithfully predict the handler's eager import?* — Yes. The probe's `import croniter`
+  and the handler's `from croniter import croniter` (`core/logging.py:442`) both fail under the same
+  `sys.modules['croniter']=None` injection, matching the real uninstalled case.
+- *Any invariant touched?* — No. §8 signals (no stray `reset_signal()`), §10 config, and the
+  `exit_status`-constants rule are all respected; `core/logging.py` is not high-blast-radius.
+
+## Human-gate triggers
+
+None. No CONFIRMED finding (indeed, no findings at all), and `core/logging.py` is not in the
+high-blast-radius core list; no security/DB-lifecycle invariant is touched. Human sign-off gate **not**
+triggered.
+
+## Optional completeness sub-pass (separate reviewer; may see TECH.md)
+
+Not run (clean correctness pass on a small, well-scoped fix). Both planned phases (P1 core fix + unit
+proof; P2 end-to-end regression proof) are marked `done` in `TECH.md`, and the requirement→evidence
+matrix above shows full R1–R5 coverage with no scope creep.

--- a/spec/croniter-missing-guidance/TECH.md
+++ b/spec/croniter-missing-guidance/TECH.md
@@ -3,7 +3,7 @@ slug: croniter-missing-guidance
 title: Graceful guidance when croniter is missing for time-based log rotation
 kind: fix
 appetite: small
-status: in_review
+status: done
 branch: fix/croniter-missing-guidance
 base: develop
 current_phase: done

--- a/spec/croniter-missing-guidance/TECH.md
+++ b/spec/croniter-missing-guidance/TECH.md
@@ -1,39 +1,46 @@
 ---
 slug: croniter-missing-guidance
-title: "Graceful guidance when croniter is missing for time-based log rotation"
+title: Graceful guidance when croniter is missing for time-based log rotation
 kind: fix
 appetite: small
 status: in_progress
 branch: fix/croniter-missing-guidance
 base: develop
-current_phase: P1
-last_updated: "2026-07-24"
+current_phase: P2
+last_updated: '2026-07-24'
 phases:
-  - id: P1
-    name: "Core fix + unit proof (message, exit, no eager crash)"
-    status: pending
-    satisfies: [R1, R5]
-    depends_on: []
-    parallel: false
-    hammerable: false
-    hill: crest
-    verify: "uv run pytest -v -m unit tests/test_logging.py -k croniter"
-  - id: P2
-    name: "End-to-end regression proof (no double traceback; never/size/cron-present unaffected)"
-    status: pending
-    satisfies: [R2, R3, R4]
-    depends_on: [P1]
-    parallel: false
-    hammerable: false
-    hill: crest
-    verify: "uv run pytest -v -m integration tests/test_logging.py -k croniter && .agents/factory/bin/temp_site.sh sh -c \"HYPERSHELL_LOGGING_FILE_ROTATE=@daily uv run hs list --count\""
+- id: P1
+  name: Core fix + unit proof (message, exit, no eager crash)
+  status: done
+  satisfies:
+  - R1
+  - R5
+  depends_on: []
+  parallel: false
+  hammerable: false
+  hill: crest
+  verify: uv run pytest -v -m unit tests/test_logging.py -k croniter
+- id: P2
+  name: End-to-end regression proof (no double traceback; never/size/cron-present
+    unaffected)
+  status: pending
+  satisfies:
+  - R2
+  - R3
+  - R4
+  depends_on:
+  - P1
+  parallel: false
+  hammerable: false
+  hill: crest
+  verify: uv run pytest -v -m integration tests/test_logging.py -k croniter && .agents/factory/bin/temp_site.sh
+    sh -c "HYPERSHELL_LOGGING_FILE_ROTATE=@daily uv run hs list --count"
 review:
-  last_reviewed_commit: ""
+  last_reviewed_commit: ''
   verdict: none
-  blocked_reason: ""
+  blocked_reason: ''
   cycle: 0
 ---
-
 # TECH.md — Graceful guidance when croniter is missing for time-based log rotation
 
 The **context engine and finite-state machine** for building this fix. The YAML frontmatter above is
@@ -65,7 +72,7 @@ spec/croniter-missing-guidance/TECH.md`); the per-phase checklists below are the
 actionable message + non-zero exit, delivered *before* any handler is constructed. Proven directly by
 unit tests on an extracted helper (no `_INIT`/full-init gymnastics).
 
-- [ ] In `src/hypershell/core/logging.py`, add a module-level helper near `panic()`:
+- [x] In `src/hypershell/core/logging.py`, add a module-level helper near `panic()`:
       ```python
       def require_croniter() -> None:
           """Missing croniter is fatal only for time-based rotation; guide to the 'cron' extra."""
@@ -74,7 +81,7 @@ unit tests on an extracted helper (no `_INIT`/full-init gymnastics).
           except ImportError:
               panic('Missing optional dependency "croniter" (the "cron" extra) needed for time-based log rotation')
       ```
-- [ ] In `initialize_logging()`'s `[logging.file]` Namespace branch, inside the `except ValueError:`
+- [x] In `initialize_logging()`'s `[logging.file]` Namespace branch, inside the `except ValueError:`
       time-like branch, **before** `file_handler = TimedRotatingFileHandler(...)`, insert the gated
       call:
       ```python
@@ -83,11 +90,11 @@ unit tests on an extracted helper (no `_INIT`/full-init gymnastics).
       ```
       (The gate is load-bearing: `'never'`/default also raises in `parse_bytes` and lands here but
       needs no croniter — mirrors `reset_interval`'s `interval != ROTATE_NEVER` guard.)
-- [ ] **Delete** the now-dead, ordering-broken block that follows the `try/except`
+- [x] **Delete** the now-dead, ordering-broken block that follows the `try/except`
       (`if isinstance(file_handler, TimedRotatingFileHandler): try: from croniter import croniter …
       except ImportError: panic(...)`). This is what caused the reachable-but-wrong `'never'`
       false-positive; removing it plus the earlier gated check subsumes it.
-- [ ] Add unit tests in `tests/test_logging.py` (import path style matches the file's `import
+- [x] Add unit tests in `tests/test_logging.py` (import path style matches the file's `import
       hypershell.core.logging as log` / `from cmdkit.app import exit_status`):
       - `test_require_croniter_panics_when_absent` (`@mark.unit`): `monkeypatch.setitem(sys.modules,
         'croniter', None)`; `with caplog.at_level('CRITICAL', logger='hypershell.core.logging'):`

--- a/spec/croniter-missing-guidance/TECH.md
+++ b/spec/croniter-missing-guidance/TECH.md
@@ -1,0 +1,140 @@
+---
+slug: croniter-missing-guidance
+title: "Graceful guidance when croniter is missing for time-based log rotation"
+kind: fix
+appetite: small
+status: in_progress
+branch: fix/croniter-missing-guidance
+base: develop
+current_phase: P1
+last_updated: "2026-07-24"
+phases:
+  - id: P1
+    name: "Core fix + unit proof (message, exit, no eager crash)"
+    status: pending
+    satisfies: [R1, R5]
+    depends_on: []
+    parallel: false
+    hammerable: false
+    hill: crest
+    verify: "uv run pytest -v -m unit tests/test_logging.py -k croniter"
+  - id: P2
+    name: "End-to-end regression proof (no double traceback; never/size/cron-present unaffected)"
+    status: pending
+    satisfies: [R2, R3, R4]
+    depends_on: [P1]
+    parallel: false
+    hammerable: false
+    hill: crest
+    verify: "uv run pytest -v -m integration tests/test_logging.py -k croniter && .agents/factory/bin/temp_site.sh sh -c \"HYPERSHELL_LOGGING_FILE_ROTATE=@daily uv run hs list --count\""
+review:
+  last_reviewed_commit: ""
+  verdict: none
+  blocked_reason: ""
+  cycle: 0
+---
+
+# TECH.md — Graceful guidance when croniter is missing for time-based log rotation
+
+The **context engine and finite-state machine** for building this fix. The YAML frontmatter above is
+the resume ground-truth (read it with `uv run python .agents/factory/bin/next_phase.py
+spec/croniter-missing-guidance/TECH.md`); the per-phase checklists below are the work.
+
+- **Vision / requirements (locked):** [`GOAL.md`](GOAL.md) — R-IDs are the contract.
+- **Authoritative design:** [`PLAN.md`](PLAN.md).
+- **Backing research:** [`research/00-digest.md`](research/00-digest.md) + briefs `01`–`05`.
+
+## Conventions (apply to every phase)
+
+- Invariants and code style come from [`AGENTS.md`](../../AGENTS.md) /
+  [`invariants.md`](../../.agents/factory/invariants.md). Touched sections: **§8** (signals / SIGHUP
+  rotate path — one upfront probe covers it), **§10** (config sentinels — gate on `ROTATE_NEVER`),
+  **§12** (use `exit_status.bad_config`, tag tests; no docs/`share` change needed — behavior with
+  croniter present is unchanged).
+- One phase per `hs-build` invocation; one atomic commit containing **both** the code and the
+  `TECH.md` state change. Subjects: `[fix] Build croniter-missing-guidance P<n>: …`.
+- **No `Co-Authored-By` trailer** (repo convention).
+- croniter is present in dev/CI (`pyproject` `dev` group), so the missing path is exercised only by
+  injecting `sys.modules['croniter'] = None` — never by uninstalling.
+
+---
+
+## Phase P1 — Core fix + unit proof
+**Satisfies:** R1, R5 · **Depends on:** —
+**Goal:** The missing-`croniter` failure for a time-based rotation policy becomes a single, clean,
+actionable message + non-zero exit, delivered *before* any handler is constructed. Proven directly by
+unit tests on an extracted helper (no `_INIT`/full-init gymnastics).
+
+- [ ] In `src/hypershell/core/logging.py`, add a module-level helper near `panic()`:
+      ```python
+      def require_croniter() -> None:
+          """Missing croniter is fatal only for time-based rotation; guide to the 'cron' extra."""
+          try:
+              import croniter  # noqa: F401
+          except ImportError:
+              panic('Missing optional dependency "croniter" (the "cron" extra) needed for time-based log rotation')
+      ```
+- [ ] In `initialize_logging()`'s `[logging.file]` Namespace branch, inside the `except ValueError:`
+      time-like branch, **before** `file_handler = TimedRotatingFileHandler(...)`, insert the gated
+      call:
+      ```python
+      if file_policy != ROTATE_NEVER:
+          require_croniter()
+      ```
+      (The gate is load-bearing: `'never'`/default also raises in `parse_bytes` and lands here but
+      needs no croniter — mirrors `reset_interval`'s `interval != ROTATE_NEVER` guard.)
+- [ ] **Delete** the now-dead, ordering-broken block that follows the `try/except`
+      (`if isinstance(file_handler, TimedRotatingFileHandler): try: from croniter import croniter …
+      except ImportError: panic(...)`). This is what caused the reachable-but-wrong `'never'`
+      false-positive; removing it plus the earlier gated check subsumes it.
+- [ ] Add unit tests in `tests/test_logging.py` (import path style matches the file's `import
+      hypershell.core.logging as log` / `from cmdkit.app import exit_status`):
+      - `test_require_croniter_panics_when_absent` (`@mark.unit`): `monkeypatch.setitem(sys.modules,
+        'croniter', None)`; `with caplog.at_level('CRITICAL', logger='hypershell.core.logging'):`
+        assert `pytest.raises(SystemExit)`, `ei.value.code == exit_status.bad_config`, and both
+        `'croniter'` and `'cron'` appear in `caplog.text`.  *(R1 message + clean exit; R5 mechanism.)*
+      - `test_require_croniter_noop_when_present` (`@mark.unit`): with croniter importable,
+        `log.require_croniter()` returns `None` and raises nothing.
+- **Verify:** `uv run pytest -v -m unit tests/test_logging.py -k croniter`
+- **Touches:** `src/hypershell/core/logging.py`, `tests/test_logging.py`.
+
+## Phase P2 — End-to-end regression proof
+**Satisfies:** R2, R3, R4 · **Depends on:** P1
+**Goal:** Prove the user-visible behavior end to end: the double traceback is gone, and the
+`'never'`/size/cron-present paths are unaffected.
+
+- [ ] Add integration tests in `tests/test_logging.py` (subprocess pattern already used there —
+      `Popen([sys.executable, '-c', <src>, <argv...>], env=..., stdout=PIPE, stderr=PIPE)`):
+      - `test_missing_croniter_is_clean_not_double_traceback` (`@mark.integration`): run
+        `python -c "import sys; sys.modules['croniter']=None; from hypershell import main;
+        sys.exit(main())" list --count` with `env={**os.environ,
+        'HYPERSHELL_LOGGING_FILE_ROTATE': '@daily'}` (this env var alone forces the Namespace
+        branch — verified). Assert `returncode != 0`; stderr **contains** `'croniter'` and `'cron'`;
+        stderr does **not** contain `Traceback (most recent call last)`, `During handling of the
+        above exception`, or `ModuleNotFoundError`.  *(R2 + R1 end-to-end.)*
+      - `test_missing_croniter_never_policy_starts_clean` (`@mark.integration`): same injection with
+        `HYPERSHELL_LOGGING_FILE_ROTATE='never'` → `returncode == 0`, no `'croniter'` panic in
+        stderr (guards the closed `'never'` false-positive; supports R3).
+      - `test_missing_croniter_size_policy_starts_clean` (`@mark.integration`): same injection with
+        `HYPERSHELL_LOGGING_FILE_ROTATE='2GB'` → `returncode == 0` (size rotation unaffected by a
+        missing croniter; R4).
+      - (Optional, croniter **present** — R3 happy path) a subprocess *without* the injection and
+        `HYPERSHELL_LOGGING_FILE_ROTATE='@daily'` → `returncode == 0`.
+      Use a `temp_site`-style env so nothing touches a real DB (follow the existing integration
+      tests' fixture usage in this file).
+- [ ] Confirm the reproduction from `~/ISSUE.md` no longer double-tracebacks (covered by the first
+      test).
+- **Verify:** `uv run pytest -v -m integration tests/test_logging.py -k croniter && .agents/factory/bin/temp_site.sh sh -c "HYPERSHELL_LOGGING_FILE_ROTATE=@daily uv run hs list --count"`
+- **Touches:** `tests/test_logging.py`.
+
+---
+
+## How `hs-build` drives this
+
+1. `next_phase.py` prints the next actionable phase (statuses authoritative).
+2. Pre-flight: clean tree, on `fix/croniter-missing-guidance`, `develop` reachable.
+3. Execute every `[ ]` in the phase (consult `PLAN.md` / `research/` for detail).
+4. Run the phase's `verify:` command — never advance on a checkbox alone.
+5. Amend this file if reality diverges; STOP and escalate only on a `GOAL.md` contradiction (e.g. if
+   the pre-existing digit-leading-cron misroute turns out to be in scope after all — see PLAN §5).
+6. Mark the phase `done`, advance `current_phase`, `--touch`; one `[fix]` commit; stop and report.

--- a/spec/croniter-missing-guidance/TECH.md
+++ b/spec/croniter-missing-guidance/TECH.md
@@ -36,10 +36,10 @@ phases:
   verify: uv run pytest -v -m integration tests/test_logging.py -k croniter && .agents/factory/bin/temp_site.sh
     sh -c "HYPERSHELL_LOGGING_FILE_ROTATE=@daily uv run hs list --count"
 review:
-  last_reviewed_commit: ''
-  verdict: none
+  last_reviewed_commit: 44905d19a148f2419e49316f2950d52b61638292
+  verdict: approved
   blocked_reason: ''
-  cycle: 0
+  cycle: 1
 ---
 # TECH.md — Graceful guidance when croniter is missing for time-based log rotation
 

--- a/spec/croniter-missing-guidance/TECH.md
+++ b/spec/croniter-missing-guidance/TECH.md
@@ -3,10 +3,10 @@ slug: croniter-missing-guidance
 title: Graceful guidance when croniter is missing for time-based log rotation
 kind: fix
 appetite: small
-status: in_progress
+status: in_review
 branch: fix/croniter-missing-guidance
 base: develop
-current_phase: P2
+current_phase: done
 last_updated: '2026-07-24'
 phases:
 - id: P1
@@ -23,7 +23,7 @@ phases:
 - id: P2
   name: End-to-end regression proof (no double traceback; never/size/cron-present
     unaffected)
-  status: pending
+  status: done
   satisfies:
   - R2
   - R3
@@ -110,7 +110,7 @@ unit tests on an extracted helper (no `_INIT`/full-init gymnastics).
 **Goal:** Prove the user-visible behavior end to end: the double traceback is gone, and the
 `'never'`/size/cron-present paths are unaffected.
 
-- [ ] Add integration tests in `tests/test_logging.py` (subprocess pattern already used there —
+- [x] Add integration tests in `tests/test_logging.py` (subprocess pattern already used there —
       `Popen([sys.executable, '-c', <src>, <argv...>], env=..., stdout=PIPE, stderr=PIPE)`):
       - `test_missing_croniter_is_clean_not_double_traceback` (`@mark.integration`): run
         `python -c "import sys; sys.modules['croniter']=None; from hypershell import main;
@@ -129,7 +129,7 @@ unit tests on an extracted helper (no `_INIT`/full-init gymnastics).
         `HYPERSHELL_LOGGING_FILE_ROTATE='@daily'` → `returncode == 0`.
       Use a `temp_site`-style env so nothing touches a real DB (follow the existing integration
       tests' fixture usage in this file).
-- [ ] Confirm the reproduction from `~/ISSUE.md` no longer double-tracebacks (covered by the first
+- [x] Confirm the reproduction from `~/ISSUE.md` no longer double-tracebacks (covered by the first
       test).
 - **Verify:** `uv run pytest -v -m integration tests/test_logging.py -k croniter && .agents/factory/bin/temp_site.sh sh -c "HYPERSHELL_LOGGING_FILE_ROTATE=@daily uv run hs list --count"`
 - **Touches:** `tests/test_logging.py`.

--- a/spec/croniter-missing-guidance/research/00-digest.md
+++ b/spec/croniter-missing-guidance/research/00-digest.md
@@ -1,0 +1,132 @@
+# 00 — Research digest (consolidated decisions)
+
+Synthesis of briefs `01`–`05` plus an adversarial re-derivation of the root cause. Where briefs
+disagreed, the single recommendation is stated here. All claims were verified against the current
+tree (`croniter` **is** installed in dev/CI, so the failure only surfaces via simulated absence).
+
+## Root cause — CONFIRMED (triple-verified, incl. adversarial pass)
+
+In `initialize_logging()`'s `[logging.file]` **Namespace** branch (`core/logging.py`):
+
+1. `parse_bytes(file_policy)` is used as a **size-vs-time discriminator**. It raises `ValueError`
+   for any non-`[KMGT]B` string — `'@daily'`, `'@midnight'`, `'@weekly'`, **and** `'never'` all
+   raise (`types.py:100`; `MEMORY_PATTERN` is `re.match`-anchored with a required numeric group).
+2. The `except ValueError:` branch (`core/logging.py:1055`) constructs
+   `TimedRotatingFileHandler(interval=file_policy)` (`:1057`) → `__init__` (`:381`) →
+   `reset_interval()` (`:388`) → `if self.interval != ROTATE_NEVER:` (`:441`) →
+   `from croniter import croniter` (`:442`) → **`ModuleNotFoundError`** when croniter is absent.
+3. That error is raised **while the `ValueError` is still being handled** (line 1057 is lexically
+   inside the `except`), so Python sets `ModuleNotFoundError.__context__ = ValueError` — the
+   **double traceback** ("During handling of the above exception, another exception occurred").
+   Neither is caught; `initialize_logging` runs in `main()` *before* cmdkit's exception mapping, so
+   the raw chained traceback prints and the process exits 1.
+4. The intended friendly guard at `core/logging.py:1063-1067`
+   (`if isinstance(file_handler, TimedRotatingFileHandler): try: from croniter import croniter …
+   except ImportError: panic(...)`) is **unreachable for the reported case** — construction at
+   `:1057` already crashed.
+
+## Two in-scope defects (one fix closes both)
+
+- **D1 (reported):** time/cron policy (`@daily`) + missing croniter → chained double-traceback
+  crash on every `hs`/`hsx` invocation.
+- **D2 (latent, closely related — corrected by the adversarial pass):** the guard block is **not**
+  globally dead. For `rotate='never'` (or a `[logging.file]` Namespace with *any* sub-key and no
+  `rotate=`, which defaults to `'never'`) + missing croniter, construction **succeeds**
+  (`reset_interval` skips croniter for `'never'`), control reaches `:1063`, and the unconditional
+  `import croniter` there fires a **false** "croniter required" panic. So a rotation-off user is
+  wrongly told to install the `cron` extra. The fix must **not** regress this.
+
+## Chosen fix (minimal; agreed by all briefs + adversarial verifier)
+
+Relocate the croniter check **into** the `except ValueError:` branch, **before** constructing the
+handler, **gated on the policy**, and delete the dead `:1063-1067` block. Extract a tiny
+directly-unit-testable helper:
+
+```python
+def require_croniter() -> None:
+    """Missing croniter is fatal only for time-based rotation; guide to the 'cron' extra."""
+    try:
+        import croniter  # noqa: F401
+    except ImportError:
+        panic('Missing optional dependency "croniter" (the "cron" extra) needed for time-based log rotation')
+```
+
+Call site:
+
+```python
+except ValueError:
+    if file_policy != ROTATE_NEVER:
+        require_croniter()                     # panic-before-construct; skipped for 'never'
+    set_naming_policy('date' if file_policy in DATE_ELIGIBLE else 'datetime')
+    file_handler = TimedRotatingFileHandler(filename=file_path, interval=file_policy)
+    info = [...]
+# (delete the old `if isinstance(file_handler, TimedRotatingFileHandler): …` block)
+```
+
+Why it satisfies the contract:
+- **R1/R2** — `@daily` + missing: `require_croniter()` panics **before** `:1057`, so `panic` →
+  `critical()` + `sys.exit(exit_status.bad_config)` raises `SystemExit(int)`; the interpreter exits
+  without rendering any traceback and there is no `except`-nested error to chain → single clean line,
+  no double traceback.
+- **R3** — `'never'`/default: the `file_policy != ROTATE_NEVER` gate skips the check; construction
+  skips croniter → no panic (also **closes D2**). With croniter **present**, `@daily`/`@midnight`
+  behave exactly as today.
+- **R4** — size policy (`2GB`): `parse_bytes` succeeds, the `except` is never entered → untouched.
+
+The `file_policy != ROTATE_NEVER` gate is the **load-bearing** detail (mirrors `reset_interval`'s
+own `interval != ROTATE_NEVER` guard). An ungated pre-check would reproduce D2.
+
+## Message & exit — DECIDED
+
+- **Message:** `Missing optional dependency "croniter" (the "cron" extra) needed for time-based log
+  rotation` — mirrors the `data/core.py` uuid7/psycopg convention (double-quoted package name,
+  `(the "X" extra)`, purpose clause). Names the dependency *and* the remedy (R1, R5).
+- **Mechanism:** the local `panic()` helper (`= critical()` + `sys.exit(exit_status.bad_config)`),
+  **not** `display_critical`+`runtime_error`. Rationale: `panic()` is already the idiom for every
+  other bad-logging-config failure inside `initialize_logging` (`_set_compression`,
+  `_set_retention`, the invalid-`logging.file` branch) and is what the dead guard already used — the
+  real fix is *ordering*, not swapping mechanism. `critical()` is visible here because
+  `stream_handler` is attached at `:1003`, before the file block. `exit_status.bad_config` (3) is
+  non-zero and semantically apt (a config error), satisfying §12 (no invented literal). This is
+  "consistent in spirit" with the psycopg guidance (R5).
+
+## Scope facts
+
+- **Only croniter import site** in `src/` is `reset_interval` (reached from `__init__` and
+  `rotate()`; `rotate()` fires on SIGHUP or `should_rotate`). A **single upfront probe at init**
+  covers all later `reset_interval`/`rotate` calls — croniter presence is fixed per process
+  (`sys.modules` caches). No change to the signal/rotation path itself (invariant §8 honored).
+- **Packaging:** croniter is only in the `cron` optional extra (`pyproject.toml:61`) for end users
+  and separately in the `dev` group (`:72`) — hence present in CI/dev; the crash never surfaces in
+  the suite unless absence is simulated.
+- **Docs/`share` (§12):** no CLI/help/completion surface changes and behavior-with-croniter is
+  unchanged, so no same-commit docs/completion edit is required. Existing docs already document the
+  requirement (`docs/…/install.rst`, `logging.rst`).
+
+## Test strategy — DECIDED (see `04-test-strategy.md`)
+
+- Simulate absence with `monkeypatch.setitem(sys.modules, 'croniter', None)` (makes `import
+  croniter` raise `ImportError`; verified). Full `initialize_logging` is not re-run in-process
+  (`_INIT` one-shot guard) — unit-test the extracted helper directly; prove the end-to-end
+  no-double-traceback via a subprocess.
+- **Unit (R1):** `require_croniter()` with croniter absent → `SystemExit(exit_status.bad_config)`
+  and `'croniter'`+`'cron'` in `caplog.text`; with croniter present → returns `None`, no raise.
+- **Integration (R2, user-visible):** subprocess `python -c "import sys;
+  sys.modules['croniter']=None; from hypershell import main; sys.exit(main())" <cmd>` with
+  `HYPERSHELL_LOGGING_FILE_ROTATE='@daily'` (alone triggers the Namespace branch — verified);
+  assert stderr contains the guidance but **not** `Traceback (most recent call last)`, `During
+  handling of the above exception`, or `ModuleNotFoundError`, and returncode ≠ 0.
+- **Regression (R3/R4):** subprocess with croniter absent + `HYPERSHELL_LOGGING_FILE_ROTATE='never'`
+  → clean start (D2 closed); + `='2GB'` → clean start (size unaffected). Plus a positive CLI drive
+  with croniter present via `temp_site.sh`.
+
+## Pre-existing bug — OUT OF SCOPE (flagged as a risk, not fixed here)
+
+`parse_bytes` misroutes **digit-leading cron expressions**: `parse_bytes('30 2 * * *') → 30`,
+`parse_bytes('0 0 * * *') → 0` (the regex consumes the leading number; the unit group is optional
+and unanchored at the end). Such crons are silently sent to `SizeRotatingFileHandler` (rotate every
+N bytes) and never reach the time path or croniter. This is independent of the croniter issue,
+predates it, and is excluded by the GOAL non-goals (do not redesign the size-vs-time discriminator).
+R3 speaks to `@daily`/`@midnight` (`DATE_ELIGIBLE`) and cron working "unchanged from today"; since
+digit-leading crons are already broken today, leaving them is **not a regression**. Surfaced to the
+human as an open question for a possible follow-up.

--- a/spec/croniter-missing-guidance/research/01-root-cause.md
+++ b/spec/croniter-missing-guidance/research/01-root-cause.md
@@ -1,0 +1,88 @@
+# Root cause: double traceback for `rotate='@daily'` without `croniter`
+
+Slug: croniter-missing-guidance. Read-only research. All line numbers verified against
+current source (2026-07-24, branch `develop`).
+
+## Exact control flow (confirmed)
+
+Entry: `initialize_logging()`, the `elif isinstance(file_config, Namespace):` branch,
+`src/hypershell/core/logging.py`.
+
+1. **`file_policy = '@daily'`** is read at `logging.py:1036`.
+2. **`try:` at `logging.py:1046`** calls **`parse_bytes(file_policy)` at `logging.py:1047`**.
+3. **`parse_bytes('@daily')` raises `ValueError`** — `src/hypershell/core/types.py:95-100`.
+   `MEMORY_PATTERN` (`types.py:85`, `r'(?P<num>\d+(?:\.\d+)?)\s*(?P<unit>[KMGT]B)?'`) is
+   applied via `re.match(value.upper())` at `types.py:97`. `re.match` is start-anchored and the
+   `num` group is **required**; `'@DAILY'` begins with `@` (not `\d`), so the match fails
+   entirely → `None` → `raise ValueError(...)` at `types.py:100`.
+   Empirically confirmed: `MEMORY_PATTERN.match('@DAILY')` → no match. (Note `'never'` also
+   fails to match and raises — it too takes the except branch; see gotcha below.)
+4. **`except ValueError:` at `logging.py:1055`** runs. At **`logging.py:1057`** it constructs
+   **`TimedRotatingFileHandler(filename=file_path, interval='@daily')`**.
+5. Construction → `RotatingFileHandler.__init__` (`logging.py:381`) → calls
+   **`self.reset_interval()` at `logging.py:388`**.
+6. `TimedRotatingFileHandler.reset_interval` (`logging.py:438-443`): guard
+   `if self.interval != ROTATE_NEVER:` at `logging.py:441` is **True** (`'@daily' != 'never'`),
+   so **`from croniter import croniter` at `logging.py:442`** executes and raises
+   **`ModuleNotFoundError`** (a subclass of `ImportError`) when the `cron` extra is absent.
+
+## Claim-by-claim
+
+- **(a) parse_bytes → ValueError (regex no-match): CONFIRMED.** `types.py:97-100`; verified empirically.
+- **(b) except branch builds `TimedRotatingFileHandler` → `reset_interval` → croniter import →
+  ModuleNotFoundError: CONFIRMED.** `logging.py:1057` → `:388` → `:442`.
+- **(c) the standalone friendly block is UNREACHABLE (dead code) when croniter is missing:
+  CONFIRMED.** The guard lives at `logging.py:1064-1068`:
+  ```
+  1064  if isinstance(file_handler, TimedRotatingFileHandler):
+  1065      try:
+  1066          from croniter import croniter
+  1067      except ImportError:
+  1068          panic('Missing optional dependency \'croniter\' needed for time-based rotation')
+  ```
+  Control can only reach line 1064 if line 1057 (construction) *succeeded*. When croniter is
+  missing, line 1057 raises first, so lines 1064-1068 never run. Worse: the block is **dead in
+  both cases** — if croniter is present the import at 1066 also succeeds, so `panic` at 1068 is
+  never taken. The guard was clearly *intended* to catch the missing dep but was placed *after*
+  the construction that already imports it. The good message text already exists at 1068 —
+  only its position is wrong.
+- **(d) why the two tracebacks chain: CONFIRMED.** The `ModuleNotFoundError` (step 6) is raised
+  *while the interpreter is still handling the `ValueError`* — construction at `logging.py:1057`
+  sits lexically inside the `except ValueError:` block (opened at 1055). Python sets the new
+  exception's `__context__` to the in-flight `ValueError` (implicit chaining), so the default
+  traceback printer emits the `ValueError` traceback, then
+  *"During handling of the above exception, another exception occurred:"*, then the
+  `ModuleNotFoundError` traceback. Neither is caught, so both propagate to the top and both print.
+
+## Minimal structural change
+
+Break the chain **and** reach the friendly path by performing the croniter availability check
+*before* the `TimedRotatingFileHandler` is constructed — i.e. move the guard (currently
+`logging.py:1064-1068`) into the `except ValueError:` block ahead of the construction at
+`logging.py:1057`. Because the check then runs *before* any exception is in flight (the
+`ValueError` from `parse_bytes` is already handled and no new `except` is nested), a missing
+`croniter` yields a single clean `panic(...)` (log CRITICAL + `sys.exit(exit_status.bad_config)`;
+`panic` at `logging.py:587-590`, `critical = getLogger(__name__).critical` at `logging.py:619`)
+with **no** traceback and no chaining. The now-redundant block at 1064-1068 should be removed.
+
+**Required gate (do not skip):** the check must fire **only when `file_policy != ROTATE_NEVER`**
+(`ROTATE_NEVER='never'`, `logging.py:365`). `'never'` (and the Namespace-branch default,
+`file_policy = DEFAULT_ROTATION_INTERVAL = 'never'`, `logging.py:366`/`:1036`) *also* fails
+`parse_bytes` and enters the same `except` branch, but `reset_interval`'s guard at
+`logging.py:441` skips the croniter import for `'never'` — so rotation-off configs work fine
+without the extra today. An ungated pre-construction check would `panic` for those users =
+a regression. Equivalent forms: gate on `file_policy != ROTATE_NEVER`, or on
+`file_policy in DATE_ELIGIBLE or <looks-like-cron>` (broadest correct gate is simply
+`!= ROTATE_NEVER`, since every non-`never` policy reaching this branch needs croniter).
+
+## Pre-existing / possibly out of scope
+
+- The friendly `panic` message text at `logging.py:1068` does not follow the psycopg/uuid7
+  wording convention (`Missing optional dependency "croniter" (the "cron" extra) needed for
+  time-based log rotation`). Improving wording is a separate (small) call — noted, not required
+  by this root-cause topic.
+- The reference psycopg pattern (`data/core.py:266-284`) uses `display_critical` +
+  `sys.exit(exit_status.runtime_error)`; the in-module `panic` uses the logger's `critical` +
+  `exit_status.bad_config`. Both are traceback-free; `panic` is the established convention
+  *inside* `logging.py`. Choice of exit code / emitter is a design decision for the plan, not a
+  correctness issue.

--- a/spec/croniter-missing-guidance/research/02-policy-path-enum.md
+++ b/spec/croniter-missing-guidance/research/02-policy-path-enum.md
@@ -1,0 +1,101 @@
+# 02 — Rotation-policy path enumeration
+
+Trace of every `logging.file` rotation-policy input through
+`initialize_logging()` (`src/hypershell/core/logging.py`), for croniter present
+and absent. Verified against source and live `parse_bytes` runs.
+
+## parse_bytes ground truth (measured)
+
+`parse_bytes` (`core/types.py:95`) does `MEMORY_PATTERN.match(value.upper())`
+where `MEMORY_PATTERN = r'(?P<num>\d+(?:\.\d+)?)\s*(?P<unit>[KMGT]B)?'`. Because
+`re.match` anchors only at the start and the `unit` group is optional, any
+**digit-leading** string matches (consumes the leading number, ignores the rest).
+
+| value | parse_bytes | raises ValueError? |
+|-------|-------------|--------------------|
+| `'never'` | — | YES |
+| `'2GB'` | 2147483648 | no |
+| `'@daily'` | — | YES |
+| `'@midnight'` | — | YES |
+| `'@weekly'` | — | YES |
+| `'30 2 * * *'` | **30** | **no** (misroute) |
+| `'0 0 * * *'` | **0** | **no** (misroute) |
+
+## Two config shapes reach the handler build
+
+- **plain string / bool** (`logging.file = "/path"` or `= true`), lines 1017–1028:
+  always builds `TimedRotatingFileHandler(filename=...)` with the **default
+  interval `'never'`**. `parse_bytes` is **not** called; there is **no** standalone
+  croniter check. `reset_interval` skips croniter when `interval == 'never'`
+  (`logging.py:441`). → works with **and without** croniter.
+- **`[logging.file]` Namespace** (any sub-key set, incl. `rotate=`), lines 1030–1073:
+  `file_policy = rotate or 'never'`; `try parse_bytes → SizeRotatingFileHandler`
+  else `except ValueError → TimedRotatingFileHandler`; then a **standalone**
+  `if isinstance(...TimedRotatingFileHandler): import croniter else panic(...)`
+  block at **1064–1068**.
+
+## Full policy → behavior table (Namespace branch unless noted)
+
+| policy input | shape | parse_bytes | handler | needs croniter? | w/ croniter | w/o croniter |
+|---|---|---|---|---|---|---|
+| default `'never'` | plain str/bool | (not called) | Timed(`never`) | no | OK, no rotation | **OK** (no check, croniter skipped) |
+| default `'never'` (no `rotate`) | Namespace | ValueError | Timed(`never`), naming `datetime` | no | OK, no rotation | **PANIC (false-positive)** at 1068 |
+| `'2GB'` | Namespace | 2147483648 | Size, naming `count` | no | OK | OK |
+| `'@daily'` | Namespace | ValueError | Timed(`@daily`), naming `date` | yes | OK | **DOUBLE traceback** at ctor 1057 |
+| `'@midnight'` | Namespace | ValueError | Timed(`@midnight`), naming `date` | yes | OK | **DOUBLE traceback** at ctor 1057 |
+| `'@weekly'` | Namespace | ValueError | Timed(`@weekly`), naming `datetime` | yes | OK | **DOUBLE traceback** at ctor 1057 |
+| `'30 2 * * *'` | Namespace | **30** | **Size**, `count`, interval=30 bytes | no | **rotates every 30 B** | same wrong behavior |
+| `'0 0 * * *'` | Namespace | **0** | **Size**, `count`, interval=0 | no | **rotates every message** | same wrong behavior |
+
+## Answers to the critical questions
+
+**Q1 — Does default `'never'` in a Namespace hit the standalone croniter panic
+(false-positive)?** YES. `parse_bytes('never')` raises ValueError → `except`
+branch builds `TimedRotatingFileHandler(interval='never')`. Its `__init__ →
+reset_interval` **skips** croniter (`interval == ROTATE_NEVER`), so construction
+succeeds even without croniter. Control then reaches the standalone
+`isinstance(file_handler, TimedRotatingFileHandler)` check (1064), which
+unconditionally imports croniter and `panic()`s if absent — a **false positive**:
+`'never'` never needs croniter. So a user who merely sets, e.g.,
+`logging.file.level = 'info'` (a `[logging.file]` section with no `rotate`) and
+lacks croniter gets a spurious "Missing optional dependency 'croniter'" exit.
+This is a real bug and directly adjacent to the reported fix — the fix must not
+demand croniter for `'never'`.
+
+**Q2 — Is a digit-leading cron expr misrouted to SizeRotatingFileHandler?**
+YES (pre-existing, separate bug). `parse_bytes('30 2 * * *') → 30` and
+`parse_bytes('0 0 * * *') → 0`; neither raises, so both take the **size** path:
+`SizeRotatingFileHandler(interval='30 2 * * *')` with `count_interval=30`
+(rotate every 30 bytes) or `0` (`should_rotate` is `count_bytes >= 0` → rotates
+on **every** record). croniter is never consulted, so behavior is identical with
+or without croniter — it just silently does the wrong thing. **Pre-existing /
+out of scope** for the croniter-guidance fix, but worth flagging: the size-vs-time
+discrimination via `parse_bytes` is unsound for any cron field list starting with
+a number. (`@`-prefixed nicknames and word crons are safe because they fail the
+regex.)
+
+## Key structural finding for the fix
+
+The reported **double traceback** is thrown at **line 1057** (the
+`TimedRotatingFileHandler(...)` constructor, via `reset_interval`'s
+`from croniter import croniter`) **inside the `except ValueError:` block** — so
+Python chains it onto the just-handled `parse_bytes` ValueError ("During handling
+of the above exception, another exception occurred"). The **standalone croniter
+check at 1064–1068 is never reached** for `@daily`/`@midnight`/`@weekly`/named
+crons — the constructor crashes first. That block is therefore effectively
+**dead code for every real time policy**, and its **only** live effect is the
+`'never'` **false-positive** in Q1.
+
+Consequence for a fix: guarding croniter only at 1064 cannot prevent the reported
+double traceback — the guard must precede/replace the `TimedRotatingFileHandler`
+construction (e.g. probe `import croniter` and `panic()` cleanly before building
+the timed handler when `file_policy != ROTATE_NEVER`, mirroring the
+`data/core.py:266-284` psycopg pattern: catch `ImportError`, `display_critical`
+naming `'croniter'` + the `'cron'` extra, `sys.exit`). The `'never'` case must be
+exempted so the false-positive disappears.
+
+Reference message style (`data/core.py`): `Missing optional dependency "psycopg"
+(or its system "libpq") needed for PostgreSQL`; uuid7: `Missing optional
+dependency "uuid-utils" (the "uuid7" extra) needed for TimescaleDB`. Extra name
+is `cron` (`pyproject.toml [project.optional-dependencies] cron =
+["croniter>=6.2.2"]`).

--- a/spec/croniter-missing-guidance/research/03-imports-and-packaging.md
+++ b/spec/croniter-missing-guidance/research/03-imports-and-packaging.md
@@ -1,0 +1,83 @@
+# 03 — croniter imports & packaging
+
+## Every croniter reference in `src/` (grep -rn croniter src/)
+
+Only **one file** references croniter: `src/hypershell/core/logging.py`.
+
+| Line | Context | Kind |
+|------|---------|------|
+| 442  | `from croniter import croniter` inside `TimedRotatingFileHandler.reset_interval()` | **functional import** |
+| 443  | `self.next_rotation = croniter(self.interval, self.prev_rotation).get_next(datetime)` | functional use |
+| 1066 | `from croniter import croniter` — the availability probe in `initialize_logging()` | probe (import for side effect) |
+| 1068 | `panic('Missing optional dependency \'croniter\' needed for time-based rotation')` | error message |
+
+That's it — no other module imports or names croniter.
+
+## The only functional import is `reset_interval`, reached from two call sites
+
+`reset_interval()` is the sole place croniter is actually *used*. It is called from:
+- `RotatingFileHandler.__init__` → `self.reset_interval()` (logging.py:388), and
+- `RotatingFileHandler.rotate()` → `self.reset_interval()` (logging.py:411).
+
+`rotate()` fires from `emit()` on either a SIGHUP (logging.py:417-419, on-demand log rotation) or
+when `should_rotate()` trips (logging.py:420-421). So croniter is needed at handler construction
+**and** on every subsequent rotation for the life of the process. The import at 442 is guarded by
+`if self.interval != ROTATE_NEVER:` (ROTATE_NEVER = `'never'`, the default), so a `'never'` interval
+never imports croniter; `@daily`/cron intervals do.
+
+## A single upfront probe at init is sufficient
+
+Confirmed. croniter's presence is fixed for the process lifetime — a module either imports at first
+touch or never will; `sys.modules` caches the success, and an absent package stays absent. So one
+availability check during `initialize_logging()` covers **all** later `reset_interval`/`rotate` calls
+in the same process. This is exactly the intent of the probe at 1064-1068 (it warms `sys.modules` so
+line 442 is a cache hit thereafter).
+
+## Root-cause note (why the probe is currently ineffective — double traceback)
+
+The probe at 1064-1068 sits **after** the handler is constructed at line 1057. In the reported case
+(`rotate='@daily'`, croniter absent):
+1. `parse_bytes('@daily')` raises `ValueError` → `except ValueError:` block (1055).
+2. `TimedRotatingFileHandler(interval='@daily')` → `__init__` → `reset_interval()` → `from croniter
+   import croniter` → **`ModuleNotFoundError`**, raised *inside* the `except ValueError` block.
+3. Python chains it → "During handling of the above exception, another exception occurred" → the
+   double traceback. The panic probe at 1066 is **never reached**.
+
+The fix must probe/panic **before** constructing the `TimedRotatingFileHandler`. (Design detail, not
+this brief's topic; noted for the planner. Also: `panic()` at logging.py:587 logs via
+`getLogger(__name__).critical` then `sys.exit(exit_status.bad_config)` — the data/core.py reference
+uses `display_critical`; worth confirming the logger is usable mid-init, but out of scope here.)
+
+### Pre-existing / possibly out of scope
+The probe condition is `isinstance(file_handler, TimedRotatingFileHandler)` (1064), which is **also
+true for `interval='never'`** (the default when `[logging.file]` is configured without `rotate`, since
+`parse_bytes('never')` raises ValueError and falls into the timed branch). A `'never'` handler never
+imports croniter, yet the current probe would `panic` on it if croniter were absent. So file logging
+with default/no rotation would spuriously demand the `cron` extra. Any fix should gate the probe on
+`interval != ROTATE_NEVER` (or `interval in DATE_ELIGIBLE`/is-a-cron-expr) to avoid this regression.
+
+## Packaging
+
+- **End users:** croniter is *only* in the optional extra — `pyproject.toml:61`
+  `cron = ["croniter>=6.2.2"]`. Not a base dependency. Confirmed absent unless `hypershell[cron]`.
+- **Dev/CI:** separately listed in the `dev` dependency-group (`pyproject.toml:72`
+  `"croniter>=6.2.2"`), which `uv sync` installs by default — so croniter **is present in CI/dev**,
+  which is why the crash never surfaces in the test suite.
+- `uv.lock` pins croniter 6.2.2 (lock lines 328-336; extra marker line 669; dev line 687).
+
+## Docs / share — does invariants.md §12 apply?
+
+§12 (`.agents/factory/invariants.md:134-138`) requires same-commit updates to `docs/_include/*.rst`
+help snippets **and** `share/` completions **for a CLI/feature change**. This fix is neither: it only
+improves the error message emitted when croniter is *absent*; behavior with croniter **present is
+unchanged**, and no CLI surface, flag, or help snippet changes. So §12's same-commit doc/share rule
+**does not strictly apply**.
+
+Existing docs already document the requirement correctly and need no edit:
+- `docs/install.rst:59` — the `cron` extra enables croniter-backed schedules.
+- `docs/logging.rst:361-363` — "A cron expression (requires the `croniter` package)…".
+- `share/man/man1/{hs,hsx,hyper-shell}.1:~2156` — "…`croniter` package). Sending SIGHUP rotates…".
+
+(The `share/` `--rotate` completion hits are for the unrelated `hs initdb --rotate` DB-partition flag,
+not `logging.file.rotate` — no overlap.) No doc/share change is functionally required; a planner could
+optionally tweak wording so the new runtime message matches docs, but nothing is stale.

--- a/spec/croniter-missing-guidance/research/04-test-strategy.md
+++ b/spec/croniter-missing-guidance/research/04-test-strategy.md
@@ -1,0 +1,122 @@
+# 04 — Test strategy: croniter-missing-guidance
+
+All claims below were run against the current tree (croniter IS installed in dev/CI).
+
+## The bug, precisely (needed to design assertions)
+
+In `initialize_logging()`'s `Namespace` branch, `parse_bytes(file_policy)` raises `ValueError`
+for a time-like policy (`'@daily'`). Inside that `except ValueError:` block the code constructs
+`TimedRotatingFileHandler(...)`, whose `__init__` → `reset_interval()` does `from croniter import
+croniter` (`logging.py:442`) — raising `ModuleNotFoundError` **while the ValueError is being
+handled**, producing a chained **double traceback**. The intended guard at `logging.py:1064-1068`
+is **dead code**: it runs only *after* the handler is already built (and has already crashed).
+Reproduced verbatim; the two load-bearing markers in stderr are:
+`Traceback (most recent call last):` and `During handling of the above exception, another
+exception occurred:`, ending in `ModuleNotFoundError` for croniter.
+
+Because `initialize_logging` runs in `main()` (`__init__.py:139`) **before** `HyperShellApp.main`,
+the exception escapes cmdkit's exception mapping entirely → raw traceback, exit code 1. Desired:
+`panic(...)` → single CRITICAL line + `sys.exit(exit_status.bad_config)` (== 3).
+
+## (1) Existing logging tests (`tests/test_logging.py`)
+
+- Pattern: **unit** tests call small helpers directly (`role_from_command`, `default_file_for`,
+  `claim_file_slot`, `resolve_log_path`, `read_lock_record`, `owner_alive`, `prune_stale_sidecars`)
+  and monkeypatch module state (`log.fcntl.flock`, `log.LOCKING`); **integration** tests shell out
+  via `Popen([sys.executable, '-c', _RUN_CLI, 'initdb', '--yes'], env=...)` or `tests.main([...])`.
+- **Nothing currently exercises `initialize_logging` in-process, nor the rotation-policy /
+  croniter branch.** No test resets the `_INIT` one-shot guard — confirming the convention:
+  drive full init only out-of-process; unit-test the small helpers directly.
+- Autouse fixture `_clean_slot_locks` resets `log.slot_locks` / `log._FINAL` after each test.
+
+## (2) Simulating croniter absence — VERIFIED
+
+`monkeypatch.setitem(sys.modules, 'croniter', None)` makes `import croniter` raise
+`ModuleNotFoundError: import of croniter halted; None in sys.modules` (an `ImportError` subclass,
+so the existing `except ImportError` catches it). Confirmed in-process and, for the subprocess
+route, by injecting the same line before `from hypershell import main` (croniter is imported only
+lazily, so hypershell import still succeeds and only rotation setup crashes).
+
+## (3) Extract a directly-unit-testable helper (recommended)
+
+Avoid resetting `_INIT` / running full `initialize_logging`. Extract the availability check into a
+tiny module-level helper so the fix and its test bypass all init state:
+
+```python
+def require_croniter() -> None:
+    """Panic (single actionable message) when time-based rotation needs the absent croniter."""
+    try:
+        import croniter  # noqa: F401
+    except ImportError:
+        panic('Missing optional dependency "croniter" (the "cron" extra) needed for time-based rotation')
+```
+
+The classification (time-like vs size-like vs `'never'`) stays in `initialize_logging`'s existing
+`try parse_bytes / except ValueError` control flow; the fix calls `require_croniter()` inside the
+`except ValueError:` branch **guarded by `if file_policy != ROTATE_NEVER:`** (parse_bytes also
+raises ValueError for `'never'`, which needs NO croniter), **before** constructing the handler.
+Message wording mirrors the repo idiom (`data/core.py:276`, uuid7 example): names the module and
+the extra. Alternative shape: a pure predicate `rotation_needs_croniter(policy) -> bool`
+(True for `'@daily'`/`'@midnight'`/other non-size non-`never`, False for `'512MB'`/`'never'`) plus
+an inline guard — also fine; the no-arg guard is the smallest testable unit.
+
+## (4) Asserting R1 (single actionable message) and R2 (no traceback / no chaining)
+
+- **R1 (unit):** `panic`/`require_croniter` emits via `getLogger('hypershell.core.logging')
+  .critical` and `sys.exit(bad_config)`. VERIFIED that `caplog` captures it even without full init
+  (NullHandler doesn't block propagation):
+  ```python
+  def test_require_croniter_panics_when_absent(monkeypatch, caplog):
+      monkeypatch.setitem(sys.modules, 'croniter', None)
+      with caplog.at_level('CRITICAL', logger='hypershell.core.logging'):
+          with pytest.raises(SystemExit) as ei:
+              log.require_croniter()
+      assert ei.value.code == exit_status.bad_config           # 3, single clean exit
+      assert 'croniter' in caplog.text and 'cron' in caplog.text  # names dep + extra
+  ```
+  And a positive test: with croniter present, `require_croniter()` returns None, raises nothing.
+- **R2 (integration, user-visible):** the definitive proof is a subprocess whose **stderr contains
+  the guidance but neither traceback marker**. Raising `SystemExit` (not a re-raised error) is what
+  structurally guarantees no chained traceback, so assert on the real process output:
+  ```python
+  _RUN_CLI_NO_CRONITER = "import sys; sys.modules['croniter'] = None; from hypershell import main; sys.exit(main())"
+
+  @mark.integration
+  def test_missing_croniter_is_clean_not_double_traceback(temp_site):
+      env = {**os.environ, 'HYPERSHELL_LOGGING_FILE_ROTATE': '@daily'}
+      proc = Popen([sys.executable, '-c', _RUN_CLI_NO_CRONITER, 'list', '--count'],
+                   env=env, stdout=PIPE, stderr=PIPE)
+      _, err = proc.communicate(); err = err.decode()
+      assert proc.returncode != 0
+      assert 'croniter' in err and 'cron' in err                      # R1 actionable
+      assert 'Traceback (most recent call last)' not in err           # R2 no traceback
+      assert 'During handling of the above exception' not in err      # R2 no chaining
+      assert 'ModuleNotFoundError' not in err                         # raw dep error not leaked
+  ```
+  (`HYPERSHELL_LOGGING_FILE_ROTATE='@daily'` alone puts `logging.file` into the `Namespace` branch —
+  VERIFIED; no explicit `file=enabled` needed.)
+
+## (5) CLI-drive / `temp_site.sh` angle
+
+`temp_site.sh` runs with croniter **present**, so it can only verify the **happy/size/never** paths,
+NOT the missing path. Optional positive CLI check (should now start cleanly):
+`.agents/factory/bin/temp_site.sh sh -c "HYPERSHELL_LOGGING_FILE_ROTATE=@daily uv run hs list --count"`.
+The missing-croniter path is only reachable via the `sys.modules['croniter']=None` injection —
+either the in-process unit test (R1) or the subprocess integration test (R2) above.
+
+## Recommended tests to write
+
+1. `test_require_croniter_panics_when_absent` (unit) — R1: SystemExit(bad_config) + message names
+   `croniter` and `cron` (via `caplog`, `monkeypatch.setitem(sys.modules,'croniter',None)`).
+2. `test_require_croniter_noop_when_present` (unit) — no raise when croniter importable.
+3. (If a predicate is chosen) `test_rotation_needs_croniter_classification` (unit, parametrized) —
+   `'@daily'`/`'@midnight'` → True; `'512MB'`/`'never'` → False.
+4. `test_missing_croniter_is_clean_not_double_traceback` (integration) — R2: subprocess stderr has
+   guidance, no `Traceback`/`During handling`/`ModuleNotFoundError`, nonzero exit.
+
+## Pre-existing / possibly out of scope
+
+- The guard block at `logging.py:1064-1068` is unreachable dead code once the fix moves the check
+  earlier; it should be removed as part of the fix (not a separate bug, but note it).
+- `initialize_logging` runs before cmdkit exception handling, so *any* init-time error yields a raw
+  traceback + exit 1 — a broader hardening opportunity, out of scope here.

--- a/spec/croniter-missing-guidance/research/05-message-and-exit.md
+++ b/spec/croniter-missing-guidance/research/05-message-and-exit.md
@@ -1,0 +1,86 @@
+# 05 — Message text & exit mechanism
+
+Topic: recommend the exact user-facing message and the exit mechanism for the missing-`croniter`
+case, consistent with existing conventions.
+
+## Reference conventions
+
+**data/core.py missing-optional-dependency family** (import-time, DB engine):
+- turso (`core.py:221`): `display_critical('Missing optional dependency "sqlalchemy-turso" needed for Turso', module=__name__)` → `sys.exit(exit_status.runtime_error)`
+- uuid-utils (`:229`): `display_critical('Missing optional dependency "uuid-utils" (the "uuid7" extra) needed for TimescaleDB', ...)` → `runtime_error`
+- psycopg (`:276`): `display_critical('Missing optional dependency "psycopg" (or its system "libpq") needed for PostgreSQL', ...)` → `runtime_error`
+
+Pattern: **double-quoted package name**, `(the "<extra>" extra)`, `needed for <purpose>`.
+
+**logging.py local idiom** (`panic`, `logging.py:587`):
+```python
+def panic(_msg: str) -> None:
+    critical(_msg)                       # = getLogger('hypershell.core.logging').critical
+    sys.exit(exit_status.bad_config)     # 3
+```
+Used everywhere else in `initialize_logging` for bad logging config: `_set_compression`
+(`:599`), `_set_retention` (`:608`), and the invalid-`logging.file` branch (`:1077`). The
+**existing (currently dead) croniter guard at `:1064-1068` already calls `panic(...)`**.
+
+`display_critical` (`exceptions.py:51`) is a `functools.partial(_display_message, 'CRITICAL', ...)`
+that `print(...)`s straight to `sys.stderr` — it bypasses the logging subsystem entirely.
+
+## (1) Message wording — recommendation
+
+```python
+panic('Missing optional dependency "croniter" (the "cron" extra) needed for time-based log rotation')
+```
+
+- Mirrors the uuid7 template exactly: package `"croniter"`, extra `"cron"` (pyproject:
+  `cron = ["croniter>=6.2.2"]`), purpose clause.
+- Double-quote the names (matches the data/core.py family; a user greps for that shape). The
+  logging.py string literals use `'…'` as the outer delimiter, so `"croniter"`/`"cron"` need no
+  escaping.
+- "time-based log rotation" is marginally clearer than the existing dead guard's "time-based
+  rotation"; either is fine — keep it terse.
+
+## (2) Exit mechanism — recommendation: **use the local `panic()`** (`critical()` + `exit_status.bad_config`)
+
+Reasoning (local consistency wins over the cross-module reference):
+
+1. **`panic` is the established idiom for the entire block.** Every other bad-logging-config
+   failure in `initialize_logging` (`_set_compression`, `_set_retention`, invalid `logging.file`)
+   panics. This is the same class of failure — a config value the install can't honor.
+2. **Minimal diff / matches existing intent.** The maintainer already wrote the croniter guard
+   with `panic` (`:1068`); the real fix is *ordering* (guard must run before the
+   `TimedRotatingFileHandler(...)` construction at `:1057`, whose `__init__ → reset_interval`
+   does `from croniter import croniter` at `:442` and raises during construction — that is the
+   double traceback, chained off the `parse_bytes` `ValueError`). Keeping `panic` means not
+   also swapping the reporting mechanism.
+3. **`critical()` is reliable at this point.** `stream_handler` is attached to the `hypershell`
+   logger at `:1003`, before the file block. `critical = getLogger('hypershell.core.logging')
+   .critical` propagates up to `hypershell` and emits via `stream_handler` to stderr. The
+   queue/file handlers aren't attached until `:1080`, but that's irrelevant — the other
+   in-function panics at `:1072-1073` depend on exactly this same stream-handler path and work.
+4. **`bad_config` (3) is semantically apt.** `logging.file.rotate = '@daily'` without the extra
+   is a bad-config condition. psycopg/uuid-utils use `runtime_error` because they're a *different
+   subsystem* (DB engine import in data/core.py) with its own convention and pre-logging context
+   (hence `display_critical`'s direct-to-stderr print). Matching the local block beats matching a
+   cross-module handler.
+
+Honest counter-argument: `display_critical(...) + sys.exit(exit_status.runtime_error)` would make
+the message grep-identical to the turso/uuid-utils/psycopg family and is guaranteed-stderr even
+if the stream handler were somehow absent. logging.py already imports from exceptions
+(`write_traceback`, `:45`) and exceptions.py does **not** import `hypershell.core.logging` (only
+stdlib `logging`), so adding `display_critical` to that import is circular-import-safe. But it is
+strictly worse on *local* consistency and adds an import for no reliability gain here. **Prefer
+`panic`.**
+
+## (3) exit_status constant — verified
+
+`cmdkit.app.exit_status` exposes: `success=0, usage=1, bad_argument=2, bad_config=3,
+keyboard_interrupt=4, runtime_error=5, uncaught_exception=6`. Both `bad_config` (3) and
+`runtime_error` (5) exist and are **non-zero**. Recommended: `exit_status.bad_config` (3), reached
+via `panic()` — no invented integer literal (invariants.md §12).
+
+## Pre-existing note (out of scope for this topic)
+
+The guard at `:1064-1068` is **dead code** for the reported path: the `ModuleNotFoundError` fires
+during `TimedRotatingFileHandler` construction at `:1057` (and again if size-parse fails), before
+control reaches `:1064`. Fixing that ordering is the substance of the fix; this topic only fixes
+the *message and exit* the guard should emit. Flagged as the core defect other briefs own.

--- a/src/hypershell/core/logging.py
+++ b/src/hypershell/core/logging.py
@@ -590,6 +590,14 @@ def panic(_msg: str) -> None:
     sys.exit(exit_status.bad_config)
 
 
+def require_croniter() -> None:
+    """Missing croniter is fatal only for time-based rotation; guide to the 'cron' extra."""
+    try:
+        import croniter  # noqa: F401 (probe only; TimedRotatingFileHandler imports it at rotate time)
+    except ImportError:
+        panic('Missing optional dependency "croniter" (the "cron" extra) needed for time-based log rotation')
+
+
 def _set_compression(policy: str) -> None:
     """Local wrapper to catch exception."""
     _label = blame(config, 'logging', 'file', 'compress')
@@ -1053,6 +1061,12 @@ def initialize_logging(role: str = DEFAULT_ROLE) -> None:
                 f'Using file-naming policy \'{FILE_NAMING_POLICY}\'',
             ]
         except ValueError:
+            # A time-like policy needs croniter; probe before constructing the handler so a missing
+            # dependency yields one clean message instead of a ModuleNotFoundError chained onto this
+            # size-parse ValueError. 'never' also lands here (parse_bytes rejects it) but skips
+            # croniter, mirroring TimedRotatingFileHandler.reset_interval's own ROTATE_NEVER guard.
+            if file_policy != ROTATE_NEVER:
+                require_croniter()
             set_naming_policy('date' if file_policy in DATE_ELIGIBLE else 'datetime')
             file_handler = TimedRotatingFileHandler(filename=file_path, interval=file_policy)
             info = [
@@ -1060,12 +1074,6 @@ def initialize_logging(role: str = DEFAULT_ROLE) -> None:
                 f'Rotation policy \'{file_policy}\' (time-like) with {compression_info}',
                 f'Using file-naming policy \'{FILE_NAMING_POLICY}\'',
             ]
-
-        if isinstance(file_handler, TimedRotatingFileHandler):
-            try:
-                from croniter import croniter
-            except ImportError:
-                panic('Missing optional dependency \'croniter\' needed for time-based rotation')
 
         file_handler.setFormatter(Formatter(file_format, datefmt=config.logging.datefmt))
         file_handler.setLevel(file_level)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -467,3 +467,54 @@ def test_require_croniter_panics_when_absent(monkeypatch, caplog) -> None:
 def test_require_croniter_noop_when_present() -> None:
     """With croniter installed (dev/CI default), the probe is a silent no-op."""
     assert log.require_croniter() is None
+
+
+# croniter is installed in dev/CI, so the end-user "no cron extra" state is simulated by neutralizing
+# the module in a fresh subprocess before importing hypershell (the import is lazy, so hypershell
+# itself still loads and only rotation setup sees the absence).
+_RUN_CLI_NO_CRONITER = (
+    "import sys; sys.modules['croniter'] = None; from hypershell import main; sys.exit(main())"
+)
+
+
+def _run_cli(temp_site: Path, rotate: str, *, croniter: bool) -> tuple[int, str]:
+    """Run a real CLI command in a subprocess under a given rotation policy; return (rc, stderr)."""
+    src = _RUN_CLI if croniter else _RUN_CLI_NO_CRONITER
+    env = {**os.environ, 'HYPERSHELL_LOGGING_FILE_ROTATE': rotate}  # sub-key alone -> Namespace branch
+    proc = Popen([sys.executable, '-c', src, 'initdb', '--yes'], env=env, stdout=PIPE, stderr=PIPE)
+    _, err = proc.communicate()
+    return proc.returncode, err.decode()
+
+
+@mark.integration
+def test_missing_croniter_is_clean_not_double_traceback(temp_site: Path) -> None:
+    """A missing croniter under a time-based policy is one actionable line, not a chained traceback."""
+    rc, err = _run_cli(temp_site, '@daily', croniter=False)
+    assert rc == exit_status.bad_config                        # clean non-zero exit
+    assert 'croniter' in err and 'cron' in err                # names the dependency and the remedy
+    assert 'Traceback (most recent call last)' not in err     # no raw traceback
+    assert 'During handling of the above exception' not in err  # no chained double traceback
+    assert 'ModuleNotFoundError' not in err                   # raw dependency error not leaked
+
+
+@mark.integration
+def test_missing_croniter_never_policy_starts_clean(temp_site: Path) -> None:
+    """'never' (the default) needs no croniter, so its absence must not raise a false demand."""
+    rc, err = _run_cli(temp_site, 'never', croniter=False)
+    assert rc == 0
+    assert 'croniter' not in err  # no spurious "cron extra" panic for a rotation-off user
+
+
+@mark.integration
+def test_missing_croniter_size_policy_starts_clean(temp_site: Path) -> None:
+    """Size-based rotation is independent of croniter; a missing croniter must not affect it."""
+    rc, err = _run_cli(temp_site, '2GB', croniter=False)
+    assert rc == 0
+    assert 'croniter' not in err
+
+
+@mark.integration
+def test_present_croniter_time_policy_starts_clean(temp_site: Path) -> None:
+    """With croniter installed, a time-based policy configures rotation and starts normally."""
+    rc, _ = _run_cli(temp_site, '@daily', croniter=True)
+    assert rc == 0

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from subprocess import Popen, PIPE
 
 # External libs
-from pytest import mark, skip, fixture
+from pytest import mark, skip, fixture, raises
 from cmdkit.app import exit_status
 
 # Internal libs
@@ -449,3 +449,21 @@ def test_main_role_never_prunes_sidecars(temp_site: Path) -> None:
     assert Popen([sys.executable, '-c', _RUN_CLI, 'list', '--count'],
                  env=env, stdout=PIPE, stderr=PIPE).wait() == 0
     assert stale.exists()
+
+
+@mark.unit
+def test_require_croniter_panics_when_absent(monkeypatch, caplog) -> None:
+    """A missing croniter yields one actionable CRITICAL line + clean exit, not a raw ImportError."""
+    monkeypatch.setitem(sys.modules, 'croniter', None)  # makes `import croniter` raise ImportError
+    with caplog.at_level('CRITICAL', logger='hypershell.core.logging'):
+        with raises(SystemExit) as exc_info:
+            log.require_croniter()
+    assert exc_info.value.code == exit_status.bad_config  # single clean, non-zero exit
+    assert 'croniter' in caplog.text  # names the missing dependency
+    assert 'cron' in caplog.text      # names the remedy (the 'cron' extra)
+
+
+@mark.unit
+def test_require_croniter_noop_when_present() -> None:
+    """With croniter installed (dev/CI default), the probe is a silent no-op."""
+    assert log.require_croniter() is None


### PR DESCRIPTION
## Summary

A user who installs HyperShell without the `cron` extra but configures a time-like `logging.file.rotate` policy (e.g. `@daily`) hit a hard crash on **every** `hs`/`hsx` invocation — a confusing chained double traceback (`ValueError` from the size-parse probe → `ModuleNotFoundError: croniter`) with no hint of the cause or remedy. This fix probes `croniter` availability *before* constructing the `TimedRotatingFileHandler` and emits a single, actionable message naming the `cron` extra, then exits cleanly — matching the existing missing-`psycopg` experience. Behavior when `croniter` is present is unchanged, and size-based rotation is unaffected either way.

The old post-construction croniter check was dead code (the handler's eager import crashed first) **and** misfired on the `never`/default policy; both are fixed by moving the probe earlier behind a `ROTATE_NEVER` gate that mirrors `reset_interval`'s own guard.

## Goal

[`GOAL.md`](https://github.com/hypershell/hypershell/blob/37e649244367f15ea7146e9c2cd826940996dd7b/spec/croniter-missing-guidance/GOAL.md) — the locked contract (R1–R5).

## Design

[`PLAN.md`](https://github.com/hypershell/hypershell/blob/37e649244367f15ea7146e9c2cd826940996dd7b/spec/croniter-missing-guidance/PLAN.md) (historical design record).

## Research

[`00-digest`](https://github.com/hypershell/hypershell/blob/37e649244367f15ea7146e9c2cd826940996dd7b/spec/croniter-missing-guidance/research/00-digest.md) · [`01-root-cause`](https://github.com/hypershell/hypershell/blob/37e649244367f15ea7146e9c2cd826940996dd7b/spec/croniter-missing-guidance/research/01-root-cause.md) · [`02-policy-path-enum`](https://github.com/hypershell/hypershell/blob/37e649244367f15ea7146e9c2cd826940996dd7b/spec/croniter-missing-guidance/research/02-policy-path-enum.md) · [`03-imports-and-packaging`](https://github.com/hypershell/hypershell/blob/37e649244367f15ea7146e9c2cd826940996dd7b/spec/croniter-missing-guidance/research/03-imports-and-packaging.md) · [`04-test-strategy`](https://github.com/hypershell/hypershell/blob/37e649244367f15ea7146e9c2cd826940996dd7b/spec/croniter-missing-guidance/research/04-test-strategy.md) · [`05-message-and-exit`](https://github.com/hypershell/hypershell/blob/37e649244367f15ea7146e9c2cd826940996dd7b/spec/croniter-missing-guidance/research/05-message-and-exit.md)

## Phases completed

- **P1** · Core fix + unit proof (message, exit, no eager crash) · satisfies **R1, R5**
- **P2** · End-to-end regression proof (no double traceback; never/size/cron-present unaffected) · satisfies **R2, R3, R4**

## Verification

From [`REVIEW.md`](https://github.com/hypershell/hypershell/blob/37e649244367f15ea7146e9c2cd826940996dd7b/spec/croniter-missing-guidance/REVIEW.md) — blind cycle 1, approved:

- `uv run pytest -v tests/test_logging.py` → **42 passed**; `-m unit` → **169 passed** (no regressions).
- **R1/R2** independent repro (croniter injected absent, `@daily`, real CLI in a throwaway site): single `CRITICAL` line naming `croniter` + the `cron` extra, exit 3 — **no** traceback / chained "During handling…" / `ModuleNotFoundError`.
- **R3**: `@daily`/`@midnight`/`0 3 * * *` with croniter present → exit 0. **R4**: `2GB` absent **and** present → exit 0. **`never` edge**: croniter absent → exit 0, no false demand.

## Docs & completions

No CLI/help-text/`share/` completion surface changed (behavior with `croniter` present is unchanged), so the same-commit docs/completions rule does not apply.

*(No linked GitHub issue — the report originated from a local `~/ISSUE.md`; close manually if one exists.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
