### PR TITLE
[refactor] Promote task `part` from a bookkeeping tag to a first-class column

### DIFF
--- a/docs/_include/initdb_desc.rst
+++ b/docs/_include/initdb_desc.rst
@@ -4,5 +4,5 @@ For SQLite this happens automatically.
 See also ``--initdb`` for the ``hs cluster`` command.
 
 The available special actions are mutually exclusive.
-The ``--rotate`` operation migrates completed tasks to the next database partition,
-and applies a special purpose ``part:N`` tag to the new partition and remaining tasks.
+The ``--rotate`` operation migrates completed tasks into the next database partition,
+recording that partition's index in each moved task's ``part`` column.

--- a/docs/_include/task_search_help.rst
+++ b/docs/_include/task_search_help.rst
@@ -31,6 +31,15 @@ Options
 ``-g``, ``--group`` *GROUP*
     Filter results to a single task group.
 
+``--part`` *N*
+    Filter results to a single database partition.
+
+    After ``hs initdb --rotate``, completed tasks are moved into numbered partition files and
+    stamped with that partition's index in their ``part`` column. ``--part`` *N* restricts the
+    listing to a single partition (``--part 0`` is the main database). The filter is a plain
+    column comparison and works on any backend, though only the SQLite provider populates
+    ``part`` via rotation.
+
 ``-s``, ``--order-by`` *FIELD* ``[--desc]``
     Order results by field. Optionally, in descending order.
 

--- a/docs/_include/task_search_usage.rst
+++ b/docs/_include/task_search_usage.rst
@@ -1,5 +1,5 @@
 ``hs`` ``list`` ``[-h]``
-    ``[FIELD [FIELD ...]]`` ``[-w COND [COND ...]]`` ``[-t TAG [TAG...]]`` ``[-g GROUP]``
+    ``[FIELD [FIELD ...]]`` ``[-w COND [COND ...]]`` ``[-t TAG [TAG...]]`` ``[-g GROUP]`` ``[--part N]``
     ``[--order-by FIELD [--desc]]`` ``[--count | --limit NUM]``
     ``[-f FORMAT | --json | --csv]`` ``[-d CHAR]`` ``[-i]``
     ``[--failed | --succeeded | --completed | --remaining]`` ``[--retries]``

--- a/share/bash_completion.d/hs
+++ b/share/bash_completion.d/hs
@@ -374,7 +374,7 @@ function _hs_task_search() {
 	local current="${COMP_WORDS[COMP_CWORD]}"
 	local previous="${COMP_WORDS[COMP_CWORD - 1]}"
 
-	local all_opts="-h --help --all -w --where -t --with-tag -g --group -s --order-by --desc
+	local all_opts="-h --help --all -w --where -t --with-tag -g --group --part -s --order-by --desc
 	-F --failed -C --completed -S --succeeded -R --remaining -X --cancelled --retries --signal
 	-f --format --csv --json -d --delimiter -l --limit -c --count
 	-i --ignore-partitions --fields --tag-keys --tag-values"
@@ -407,6 +407,10 @@ function _hs_task_search() {
 			return
 			;;
 		-g | --group)
+			COMPREPLY=($(compgen -W "0 1 2 3" -- "${current}"))
+			return
+			;;
+		--part)
 			COMPREPLY=($(compgen -W "0 1 2 3" -- "${current}"))
 			return
 			;;

--- a/share/zsh/site-functions/_hs
+++ b/share/zsh/site-functions/_hs
@@ -404,6 +404,7 @@ function _hs_list() {
         '*'{-w,--where}'[Filter on conditional expression]:condition:_hs_fields' \
         '*'{-t,--with-tag}'[Filter by tag]:tag:_hs_tags' \
         '(-g --group)'{-g,--group}'[Filter by group]:group:' \
+        '--part[Filter by partition (0 is the main database)]:partition:' \
         '(-s --order-by)'{-s,--order-by}'[Order output by field]:field:_hs_fields' \
         '--desc[Descending order (requires --order-by)]' \
         '(-F --failed -C --completed -S --succeeded -R --remaining -X --cancelled)'{-F,--failed}'[Alias for -w "exit_status != 0"]' \

--- a/spec/part-tag-to-column/GOAL.md
+++ b/spec/part-tag-to-column/GOAL.md
@@ -18,7 +18,7 @@ the `Task` **`tag` dictionary** rather than as a real column: task creation inje
 into `tag` (`data/model.py:387`), and because that value is not a user annotation it then has to be
 special-cased back out again — excluded from the task fingerprint (`data/model.py:414-423`) and
 extracted with SQLite JSON functions (`json_extract(task.tag, …)`) in the partition/rotation queries
-(`task.py`).
+(`data/__init__.py`).
 
 This conflates two different things in one field. The `tag` dict is meant for **user-supplied
 metadata**; hijacking it to carry an internal partition index makes the user's annotations "dirty,"
@@ -35,9 +35,11 @@ tag was a reasonable-at-the-time shortcut that has aged into a footgun — this 
 the `tag` dictionary field** — and is no longer stored inside `tag`. User annotations in `tag` contain
 only user-supplied metadata again. The database partition/rotation logic reads `part` from the column
 instead of extracting it from tag JSON, which simplifies those queries (no SQLite JSON functions for
-`part`). The column is defined dialect-neutrally so it is usable under both SQLite and PostgreSQL,
-even though the active partition mechanism stays SQLite-only for now. No user-facing CLI behavior
-changes and `part` stays internal — it simply stops appearing among the user's tags. The change
+`part`). The column is defined dialect-neutrally so it is usable under both SQLite and PostgreSQL, even
+though the active partition mechanism stays SQLite-only for now. `part` is a **first-class, visible
+field** (present in the model's column mapping, so it displays and selects like any other column), and
+`hs list` / `hs search` gain a **`--part` option** to filter results to a specific partition — useful
+after a rotate for targeting the tasks that landed in a given database-partition file. The change
 applies to newly created / re-initialized databases; migrating databases that already store `part`
 inside the tag JSON is out of scope.
 
@@ -54,16 +56,23 @@ inside the tag JSON is out of scope.
 - **R4** — WHERE the SQLite database-partition / auto-union logic currently derives `part` from the
   tag JSON, it SHALL instead read the `part` column and SHALL NOT use SQLite JSON functions (e.g.
   `json_extract`) to obtain `part`; the partitioning behavior/outcome SHALL be preserved.
-- **R5** — Behavior that depended on `part` SHALL remain equivalent through the column: `part` SHALL
-  continue to be excluded from the task fingerprint/identity (re-running the same work still yields the
-  same fingerprint), and `part` SHALL NOT appear in user-facing `tag` output.
+- **R5** — `part` SHALL remain excluded from the task fingerprint/identity (re-running the same work
+  still yields the same fingerprint) and SHALL NOT be stored as a user `tag` (it is a column, not a
+  tag).
 - **R6** — WHEN a database is newly created or re-initialized (`hs initdb`), the created schema SHALL
   include the `part` column with its default. Pre-existing databases that store `part` in the tag JSON
   are out of scope (see Non-goals).
 - **R7** — The existing test suite SHALL continue to pass and the docs build SHALL stay clean; the new
   column behavior (set on submit, absent from `tag`, excluded from the fingerprint, read by the
-  partition logic) SHALL be covered by tests, and any documentation that describes `part` as a tag or
-  the JSON-based partition query SHALL be updated to match.
+  partition logic) **and the `--part` filter** SHALL be covered by tests, and any documentation that
+  describes `part` as a tag or the JSON-based partition query SHALL be updated to match.
+- **R8** — `part` SHALL be a **first-class, selectable/displayable field**: it is included in the
+  model's `Task.columns` mapping, so it is available wherever other columns are (e.g. `hs list --all`,
+  field selection / `--fields`, `hs info`), consistent with columns like `group`.
+- **R9** — `hs list` and `hs search` SHALL accept a **`--part N`** option that filters results to tasks
+  whose `part` equals `N` (targeting a specific rotated partition). The affected `docs/_include/*.rst`
+  help snippets and the `share/` shell completions SHALL be updated in the same commit (per the §12
+  same-commit rule).
 
 ## Non-goals (no-gos)
 
@@ -71,9 +80,9 @@ inside the tag JSON is out of scope.
   migration, add-column-on-connect, or migration command. This is forward-only; older databases may
   require re-initialization.
 - **Implementing PostgreSQL partition/rotation** on the new column. The active auto-union mechanism
-  stays SQLite-only; the column merely does not *preclude* future PostgreSQL use.
-- **Surfacing `part` in the CLI** — no new `hs list`/`info`/`search` field, filter, or option for it,
-  and no new completions/help snippets. `part` stays internal.
+  stays SQLite-only; the column merely does not *preclude* future PostgreSQL use. (The `--part` filter,
+  being a plain column filter, works on any backend, but on PostgreSQL `part` is always `0` because no
+  rotation populates it.)
 - The forthcoming **`zone`** concept — this task only clears the way (keeping `tag` clean); `zone` is
   separate future work.
 - Any change to the `group` column, to user-`tag` semantics beyond removing the `part` key, or to
@@ -88,21 +97,25 @@ inside the tag JSON is out of scope.
 - **Q:** `part` is SQLite-only today — what is the PostgreSQL scope? — **A:** Make it a dialect-neutral
   column so PostgreSQL *could* use it later; do **not** build PostgreSQL partition/rotation now
   (resolved 2026-07-31).
-- **Q:** Now that `part` is first-class, should it be visible in the CLI? — **A:** Keep it internal —
-  it just leaves the user tag dict; no new visible column, filter, or option (resolved 2026-07-31).
+- **Q:** Should `part` be visible in the CLI? — **A:** *(Revised 2026-07-31, superseding the earlier
+  "keep internal" answer.)* Yes — `part` SHALL be a first-class, visible field (in `Task.columns`), and
+  `hs list` / `hs search` SHALL gain a `--part N` filter to target a specific rotated partition. (The
+  original shaping answer was "keep internal"; the maintainer changed course after seeing the
+  internal-vs-external trade-off.)
 
 ## Related materials
 
-- `src/hypershell/data/model.py` — the `Task` model (add the `part` column before `tag`); `part`
-  currently injected as `{'part': 0}` (~`:387`) and excluded from the fingerprint (~`:414-423`). Task
-  state/query logic lives here as `Task` classmethods.
-- `src/hypershell/task.py` — SQLite auto-union / partition logic (`attach database … as part_N`,
-  `--ignore-partitions`, ~`:840-856`) and the tag `json_extract` queries (~`:487-489`, `:727`) that
-  touch `part`.
+- `src/hypershell/data/model.py` — the `Task` model (add the `part` column before `tag`; add `'part'`
+  to the `Task.columns` mapping); `part` currently injected as `{'part': 0}` (~`:387`) and excluded
+  from the fingerprint (~`:414-423`). Task state/query logic lives here as `Task` classmethods.
+- `src/hypershell/task.py` — the `list` and `search` apps (add the `--part` option + filter; they
+  already carry `--ignore-partitions`, ~`:148-191` / ~`:596-684`) and the SQLite auto-union / partition
+  logic (`attach database … as part_N`, ~`:840-856`).
+- `src/hypershell/data/__init__.py` — `rotatedb()` (writes/reads `part` via JSON funcs today, ~`:139`,
+  `:147`, `:157`) and `InitDBApp` / schema creation.
 - `src/hypershell/submit.py` — task ingestion / tag-assembly path where `part` currently enters.
-- `src/hypershell/data/core.py` — `InitDBApp` / schema creation, where the new column materializes for
-  fresh databases.
-- `AGENTS.md` — "Task lifecycle contract" (task state is a function of nullable columns; adding a
-  column means touching the model, the relevant queries, and any dialect-variant type handling) and
-  "Data layer specifics"; `data/model.py` is flagged highest-blast-radius.
+- `docs/_include/*.rst` (generated CLI help for `list`/`search`) and `share/` (bash + zsh completions),
+  which the §12 same-commit rule ties to the new `--part` option.
+- `AGENTS.md` — "Task lifecycle contract", "Data layer specifics", and §12 same-commit rules;
+  `data/model.py` is flagged highest-blast-radius.
 - Future context: the planned **`zone`** concept (motivates keeping `tag` for user annotations only).

--- a/spec/part-tag-to-column/GOAL.md
+++ b/spec/part-tag-to-column/GOAL.md
@@ -1,0 +1,108 @@
+# GOAL — Promote `part` from a bookkeeping tag to a first-class column
+
+> **Origin spec.** The *what* and *why* — the locked contract `hs-review` grades against.
+> The *how* lives in [`PLAN.md`](PLAN.md) and [`TECH.md`](TECH.md) (written by `hs-plan`).
+> Keep this at the right altitude: solved and bounded, but not over-specified — leave design
+> freedom for the plan. Edit requirements here; do **not** silently drift them during build.
+
+- **slug:** part-tag-to-column
+- **kind:** refactor
+- **appetite:** small
+
+## Problem
+
+`part` is an internal bookkeeping number used by the SQLite **database-partition** ("auto-union")
+mechanism to record which partition/database-file a task belongs to. It predates the dedicated
+`group` column, and — probably because `group` didn't exist yet — it was implemented as an entry in
+the `Task` **`tag` dictionary** rather than as a real column: task creation injects `{'part': 0}`
+into `tag` (`data/model.py:387`), and because that value is not a user annotation it then has to be
+special-cased back out again — excluded from the task fingerprint (`data/model.py:414-423`) and
+extracted with SQLite JSON functions (`json_extract(task.tag, …)`) in the partition/rotation queries
+(`task.py`).
+
+This conflates two different things in one field. The `tag` dict is meant for **user-supplied
+metadata**; hijacking it to carry an internal partition index makes the user's annotations "dirty,"
+forces the fingerprint and query code to route around the `part` key, and ties `part` to SQLite's
+JSON syntax — which is more complicated than it needs to be and keeps `part` de-facto SQLite-only even
+though a plain column would work under PostgreSQL too. With a new **`zone`** concept coming, we want
+partition/bookkeeping state to be first-class schema and the user's `tag` annotations to stay clean,
+rather than growing a second piece of management state hidden inside `tag`. In short: making `part` a
+tag was a reasonable-at-the-time shortcut that has aged into a footgun — this is the cleanup.
+
+## Outcome / vision
+
+`part` is a first-class column on the `Task` model — placed as the **last column, immediately before
+the `tag` dictionary field** — and is no longer stored inside `tag`. User annotations in `tag` contain
+only user-supplied metadata again. The database partition/rotation logic reads `part` from the column
+instead of extracting it from tag JSON, which simplifies those queries (no SQLite JSON functions for
+`part`). The column is defined dialect-neutrally so it is usable under both SQLite and PostgreSQL,
+even though the active partition mechanism stays SQLite-only for now. No user-facing CLI behavior
+changes and `part` stays internal — it simply stops appearing among the user's tags. The change
+applies to newly created / re-initialized databases; migrating databases that already store `part`
+inside the tag JSON is out of scope.
+
+## Acceptance criteria (the contract)
+
+- **R1** — The `Task` model SHALL define `part` as a first-class column, positioned as the **last
+  column, immediately before the `tag` dictionary field**, carrying the same default the tag form uses
+  today (`0`).
+- **R2** — Task creation SHALL set the `part` **column** and SHALL NOT inject a `part` key into the
+  `tag` dictionary; after this change `tag` SHALL contain only user-supplied annotations (the
+  `data/model.py:387` `{'part': 0}` injection is removed).
+- **R3** — The `part` column SHALL be defined dialect-neutrally so it is usable under both the SQLite
+  and PostgreSQL backends, i.e. it SHALL NOT depend on SQLite-only constructs.
+- **R4** — WHERE the SQLite database-partition / auto-union logic currently derives `part` from the
+  tag JSON, it SHALL instead read the `part` column and SHALL NOT use SQLite JSON functions (e.g.
+  `json_extract`) to obtain `part`; the partitioning behavior/outcome SHALL be preserved.
+- **R5** — Behavior that depended on `part` SHALL remain equivalent through the column: `part` SHALL
+  continue to be excluded from the task fingerprint/identity (re-running the same work still yields the
+  same fingerprint), and `part` SHALL NOT appear in user-facing `tag` output.
+- **R6** — WHEN a database is newly created or re-initialized (`hs initdb`), the created schema SHALL
+  include the `part` column with its default. Pre-existing databases that store `part` in the tag JSON
+  are out of scope (see Non-goals).
+- **R7** — The existing test suite SHALL continue to pass and the docs build SHALL stay clean; the new
+  column behavior (set on submit, absent from `tag`, excluded from the fingerprint, read by the
+  partition logic) SHALL be covered by tests, and any documentation that describes `part` as a tag or
+  the JSON-based partition query SHALL be updated to match.
+
+## Non-goals (no-gos)
+
+- **Migrating pre-existing databases** that already carry `part` inside the tag JSON — no data
+  migration, add-column-on-connect, or migration command. This is forward-only; older databases may
+  require re-initialization.
+- **Implementing PostgreSQL partition/rotation** on the new column. The active auto-union mechanism
+  stays SQLite-only; the column merely does not *preclude* future PostgreSQL use.
+- **Surfacing `part` in the CLI** — no new `hs list`/`info`/`search` field, filter, or option for it,
+  and no new completions/help snippets. `part` stays internal.
+- The forthcoming **`zone`** concept — this task only clears the way (keeping `tag` clean); `zone` is
+  separate future work.
+- Any change to the `group` column, to user-`tag` semantics beyond removing the `part` key, or to
+  unrelated schema; and no broader rewrite of the partition/auto-union mechanism beyond sourcing
+  `part` from the column and simplifying the resulting queries.
+
+## Clarifications
+
+- **Q:** How should existing databases (which store `part` in the tag JSON, with no `part` column) be
+  handled? — **A:** Forward-only: new / re-initialized databases get the column; existing part-in-tag
+  databases are out of scope (may require re-init) (resolved 2026-07-31).
+- **Q:** `part` is SQLite-only today — what is the PostgreSQL scope? — **A:** Make it a dialect-neutral
+  column so PostgreSQL *could* use it later; do **not** build PostgreSQL partition/rotation now
+  (resolved 2026-07-31).
+- **Q:** Now that `part` is first-class, should it be visible in the CLI? — **A:** Keep it internal —
+  it just leaves the user tag dict; no new visible column, filter, or option (resolved 2026-07-31).
+
+## Related materials
+
+- `src/hypershell/data/model.py` — the `Task` model (add the `part` column before `tag`); `part`
+  currently injected as `{'part': 0}` (~`:387`) and excluded from the fingerprint (~`:414-423`). Task
+  state/query logic lives here as `Task` classmethods.
+- `src/hypershell/task.py` — SQLite auto-union / partition logic (`attach database … as part_N`,
+  `--ignore-partitions`, ~`:840-856`) and the tag `json_extract` queries (~`:487-489`, `:727`) that
+  touch `part`.
+- `src/hypershell/submit.py` — task ingestion / tag-assembly path where `part` currently enters.
+- `src/hypershell/data/core.py` — `InitDBApp` / schema creation, where the new column materializes for
+  fresh databases.
+- `AGENTS.md` — "Task lifecycle contract" (task state is a function of nullable columns; adding a
+  column means touching the model, the relevant queries, and any dialect-variant type handling) and
+  "Data layer specifics"; `data/model.py` is flagged highest-blast-radius.
+- Future context: the planned **`zone`** concept (motivates keeping `tag` for user annotations only).

--- a/spec/part-tag-to-column/META.md
+++ b/spec/part-tag-to-column/META.md
@@ -1,0 +1,30 @@
+# META — Promote `part` from a bookkeeping tag to a first-class column
+
+> **Harness feedback log** for this feature — the producer artifact of the factory's self-improvement
+> loop. Written by the lifecycle skills (`hs-feature` / `hs-plan` / `hs-build` / `hs-review`) when the
+> **skillset itself** costs something; read by `hs-publish` (surfaced in the PR) and applied by
+> `/hs-harness`. This file is **orthogonal** to the `GOAL → PLAN → TECH → REVIEW` spine — it is about
+> the *toolchain*, not the feature — and is retained on merge like the rest of `spec/{slug}/`.
+>
+> **Silence is the default.** The bar for a finding is one test: *was this the **skill's** fault — not
+> mine, not the task's?* A merely-hard task, a self-inflicted error, or a one-off content/code issue
+> (that belongs in `GOAL.md` / `REVIEW.md`) is **not** a finding. The blind `hs-review` correctness
+> reviewer never reads this file — it would leak author intent.
+
+- **slug:** part-tag-to-column
+
+## Friction findings
+
+## F1 — Step 7 commit-category rule (`else feature`) contradicts practice and omits `refactor`
+`origin=hs-feature:step7 severity=low category=instruction status=open target=.agents/skills/hs-feature/SKILL.md`
+- **What happened:** Step 7 says `{category} = fix for kind:fix, else feature`, so a `kind: refactor`
+  goal would be committed as `[feature] Shape …`. I used `[refactor]` instead, matching AGENTS.md's
+  category list and the repo's demonstrated convention (git log: `[docs] Shape docs-trim-migrated-sections
+  goal`, i.e. `[{kind}]`).
+- **Skill cause:** the skill's `kind → commit-category` mapping is narrower than AGENTS.md (which blesses
+  `refactor`/`docs`/… and says "coin a category when it fits") and than observed shape commits, which use
+  `[{kind}]`. Same root cause as the docs-trim feature's F1 (kind-taxonomy narrowness at step2) — **seen
+  again**, now at step7's commit line.
+- **Recommended fix:** make Step 7 emit `[{kind}]` (fix|feature|refactor|docs|…), or explicitly map
+  `refactor → refactor`, rather than collapsing everything non-`fix` to `feature`.
+- **Confidence:** high · **Effort:** small

--- a/spec/part-tag-to-column/META.md
+++ b/spec/part-tag-to-column/META.md
@@ -13,18 +13,38 @@
 
 - **slug:** part-tag-to-column
 
+## What worked well
+
+- `hs-plan` Step 3 **parallel research fan-out** (4 read-only agents → briefs) materially de-risked a
+  coupled-core change: it located the real `rotatedb()` mechanism, pinned the exact three R4 expressions,
+  and surfaced the `columns`-dict contradiction that the digest then resolved. Keep it.
+
 ## Friction findings
 
-## F1 — Step 7 commit-category rule (`else feature`) contradicts practice and omits `refactor`
+## F1 — Step 7 commit-category rule (`else feature`) contradicts practice and omits `refactor` · seen again (hs-plan:step8)
 `origin=hs-feature:step7 severity=low category=instruction status=open target=.agents/skills/hs-feature/SKILL.md`
 - **What happened:** Step 7 says `{category} = fix for kind:fix, else feature`, so a `kind: refactor`
   goal would be committed as `[feature] Shape …`. I used `[refactor]` instead, matching AGENTS.md's
   category list and the repo's demonstrated convention (git log: `[docs] Shape docs-trim-migrated-sections
-  goal`, i.e. `[{kind}]`).
-- **Skill cause:** the skill's `kind → commit-category` mapping is narrower than AGENTS.md (which blesses
-  `refactor`/`docs`/… and says "coin a category when it fits") and than observed shape commits, which use
-  `[{kind}]`. Same root cause as the docs-trim feature's F1 (kind-taxonomy narrowness at step2) — **seen
-  again**, now at step7's commit line.
-- **Recommended fix:** make Step 7 emit `[{kind}]` (fix|feature|refactor|docs|…), or explicitly map
-  `refactor → refactor`, rather than collapsing everything non-`fix` to `feature`.
+  goal`, i.e. `[{kind}]`). **Seen again** at `hs-plan` Step 8, whose commit rule is identically
+  `{category} = fix|feature` — I again committed `[refactor]`.
+- **Skill cause:** the `kind → commit-category` mapping in both skills is narrower than AGENTS.md (which
+  blesses `refactor`/`docs`/… and says "coin a category when it fits") and than observed shape/plan
+  commits, which use `[{kind}]`.
+- **Recommended fix:** make both skills' commit lines emit `[{kind}]` (fix|feature|refactor|docs|…), or
+  explicitly map `refactor → refactor`, rather than collapsing everything non-`fix` to `feature`.
+- **Confidence:** high · **Effort:** small
+
+## F2 — Research-depth gate (appetite/kind) ignores blast-radius; would skip needed research
+`origin=hs-plan:step3 severity=low category=missing-guidance status=open target=.agents/skills/hs-plan/SKILL.md`
+- **What happened:** the GOAL is `appetite: small` / `kind: refactor`, so Step 3 instructs skipping the
+  research fan-out. But the change touches `data/model.py` (the `invariants.md` highest-blast-radius file)
+  and a subtle SQLite JSON→column rotation mechanism whose exact shape was unknown; a lean plan would have
+  gotten R4 wrong. I ran the full fan-out anyway on judgment (and it paid off — see "What worked well").
+- **Skill cause:** the research-depth heuristic keys only on `appetite`/`kind`. Its sole exception is
+  "diagnostic fixes," not "small-appetite change to coupled-core / high-blast-radius files." Same root as
+  the docs-trim feature's F2 (the gate misses signals beyond appetite/kind) — **seen again**.
+- **Recommended fix:** extend the Step 3 exception so blast-radius is also a trigger — run the fan-out
+  when the change is expected to touch the coupled core / `invariants.md` high-blast-radius files,
+  regardless of `appetite`.
 - **Confidence:** high · **Effort:** small

--- a/spec/part-tag-to-column/PLAN.md
+++ b/spec/part-tag-to-column/PLAN.md
@@ -1,0 +1,153 @@
+# PLAN — Promote `part` from a bookkeeping tag to a first-class column
+
+> **Status:** Draft for review · **Last updated:** 2026-07-31
+> **Authoritative technical design.** The *how*. Vision/contract is [`GOAL.md`](GOAL.md);
+> the phased executable roadmap is [`TECH.md`](TECH.md). Backing detail is in
+> [`research/`](research/). Every design element traces to a GOAL R-ID.
+
+## 1. Summary
+
+Add `part` as a real integer column on the `Task` model (between `fingerprint` and `tag`, mirroring the
+dialect-neutral integer columns, `default=0`) and stop stuffing it into the `tag` JSON dict. The only
+consumer — the SQLite `rotatedb()` maintenance routine behind `hs initdb --rotate` — is rewritten to
+read/write the column instead of `json_set`/`json_extract` on the tag, which is the promised
+simplification (R4). `part` is kept **internal**: it is a real DB column but is deliberately omitted from
+the `Task.columns` allowlist, so it never reaches the CLI or the wire. This is a small, cohesive,
+coupled-core change (`data/model.py` + `data/__init__.py`) shipped as a single vertical slice with its
+tests and the one same-commit doc/help update.
+
+## 2. Design
+
+### Data model — `src/hypershell/data/model.py`
+
+- **New column (R1, R3):** insert between `fingerprint` (`:299`) and `tag` (`:301`, the current last
+  column):
+  ```python
+  part: Mapped[int] = mapped_column(INTEGER, nullable=False, default=0)  # Partition index (SQLite rotation bookkeeping); internal.
+  ```
+  `INTEGER` (`model.py:96`) maps to `INTEGER` on both SQLite and PostgreSQL, so the column is
+  dialect-neutral with no `with_variant`. `part` is not a reserved word (unlike `group`), so no `quote=`.
+  It is created automatically in a fresh DB by `metadata.create_all` (R6).
+- **Keep it internal (R5, no-CLI-surface non-goal):** do **not** add `'part'` to the `Task.columns` dict
+  (`:303-336`). That dict is the allowlist for `to_dict`/`to_json`/`from_dict`/`repr`/`serialize_tasks`
+  and for CLI field validation / `--fields` / `hs list`. Omitting `part` keeps it off the wire and out of
+  the CLI while it remains a first-class DB column read via the `Task.part` ORM attribute. (This asymmetry
+  is the one deliberate complexity — PLAN §3 deviation table.)
+- **Stop hijacking the tag (R2):** in `Task.new`, change `:387`
+  `tag = {**(tag or {}), **inline_tags, **{'part': 0, }}` → `tag = {**(tag or {}), **inline_tags}`. The
+  `Task(...)` constructor (`:404-406`) needs no explicit `part=` — the column default supplies `0`. The
+  retry builder copies `tag` but not `part`, so retry rows correctly start at `part=0` (a new row lives in
+  `main`).
+- **Fingerprint (R5):** in `compute_fingerprint`, drop the `if key != 'part'` filter at `:423`
+  (→ `'tags': dict(tags or {})`) and update the docstring at `:414`. Byte-identical output, because the
+  tag dict it receives no longer contains `part`.
+
+### Rotation — `src/hypershell/data/__init__.py` (`rotatedb`, R4)
+
+Replace the three JSON expressions with plain column access; behavior is preserved:
+
+| Line | Before | After |
+|------|--------|-------|
+| `:139` (write) | `.update({Task.tag: text("json_set(task.tag, '$.part', :v)")…})` | `.update({Task.part: part_id})` |
+| `:147` (read)  | `Task.tag['part'] == type_coerce(part_id, JSON)` | `Task.part == part_id` |
+| `:157` (read)  | `Task.tag['part'] != type_coerce(part_id, JSON)` | `Task.part != part_id` |
+
+Then remove the now-unused `type_coerce` / `JSON` imports **after grep-confirming** they're unused
+elsewhere in the file (`text` stays — used by the `VACUUM` statements). The `exit_status.isnot(None)`
+filter (`:138`) and `next_rotate_path` (`:163-174`, filesystem-based) are untouched. `auto_union_sqlite`
+(`task.py`) is untouched — its `part_{i+1}` attach alias is a filesystem index unrelated to the column,
+and it never reads `part`.
+
+### Docs / help (R7, §12 same-commit)
+
+`part` is no longer a tag, so update `INITDB_HELP` (`data/__init__.py`, the `--rotate` description that
+says "applies a special purpose `part:N` tag") and regenerate the matching `docs/_include/initdb_desc.rst`
+in the **same commit**; regenerate the `hs` man page if it carries the initdb description. `--ignore-partitions`
+help and `docs/database.rst` reference file numbering (not the tag) and need no change. `share/` completions
+carry no long descriptions → no completion change.
+
+### Requirement → design map
+
+| R-ID | Design element(s) that satisfy it |
+|------|-----------------------------------|
+| R1 | New `part` `mapped_column(INTEGER, nullable=False, default=0)` inserted between `fingerprint` and `tag` in `data/model.py`. |
+| R2 | `Task.new:387` drops the `{'part': 0}` merge; task creation sets the column (via default), `tag` holds only user annotations. |
+| R3 | `INTEGER` type — dialect-neutral (SQLite/PG), no SQLite-only construct. |
+| R4 | `rotatedb` `:139/:147/:157` rewritten to `Task.part` (update / `==` / `!=`); JSON functions & dead imports removed; partition outcome preserved. |
+| R5 | Fingerprint `part`-exclusion removed (byte-identical); `part` omitted from `Task.columns` → absent from tag output, CLI, and wire. |
+| R6 | Column is a mapped column → `metadata.create_all` includes it in fresh `hs initdb` schema. Forward-only (create_all never ALTERs old DBs). |
+| R7 | Update `tests/test_source.py` fingerprint/column tests, fill the `tests/test_initdb.py` `test_rotate` stub with real column-based rotation coverage; update `INITDB_HELP` + `initdb_desc.rst`; full suite + docs build green. |
+
+## 3. Invariant gate (AGENTS.md constitution check)
+
+Checked before research and again after this design (both checkpoints).
+
+- **§1 Task lifecycle (`data/model.py`, highest blast radius)** — `part` is **orthogonal** to the
+  nullable-column state predicates (`schedule_time`/`completion_time`/`exit_status`); it is not added to
+  any state query and does not alter task state. Task-state transition logic stays in `Task` classmethods
+  (we touch only `Task.new`/`compute_fingerprint`/a column). Identity semantics are preserved — removing
+  the `part` fingerprint-exclusion is byte-identical. **Honored.**
+- **§10 Config / data layer** — schema materializes via `metadata.create_all` at `hs initdb`; `create_all`
+  never `ALTER`s, so pre-existing DBs are out of scope (GOAL non-goal, forward-only). No config singleton
+  change. **Honored.**
+- **§12 Project conventions** — the `initdb` help snippet (`docs/_include/initdb_desc.rst`) is updated in
+  the same commit as the behavior change; new tests are `@mark.unit`; no hardcoded version; no dependency
+  floor changes; no new CLI so no completion churn. **Honored.**
+- Sections **§2–§9, §11** (exit_status, retry, server modes, FSM/thread, shutdown, resource, signals,
+  queue/TLS, cluster) — **not touched**; this is a pure data-model + single-query-site change with no
+  server/client/queue/FSM/signal/cluster involvement.
+
+### Deviation justifications
+
+| Deviation | Why needed | Simpler alternative rejected because |
+|-----------|-----------|--------------------------------------|
+| `part` is a real mapped column but is **omitted from the `Task.columns` allowlist** (every other column is listed there). | R5 + the no-CLI-surface non-goal require `part` to stay internal — off the wire, out of `hs list`/`--fields`/tag output. Omitting it from `columns` achieves that while it remains a queryable DB column via `Task.part`. | Adding `part` to `columns` (the "consistent" choice) would expose it on the wire and in the CLI, violating R5 and the non-goal. Mitigated by a test asserting `part` is in the real table but **not** in `Task.columns`. |
+
+## 4. Rabbit holes (resolved)
+
+- **What is "database rotation" and where does `part` flow?** → It's `rotatedb()` behind the manual,
+  SQLite-only `hs initdb --rotate`; `part` is written once by `json_set` and read twice by `json_extract`
+  — exactly three expressions to convert ([`research/01`](research/01-part-lifecycle-and-partition-mechanism.md)).
+- **Does the auto-union depend on the `part` value?** → No; `part_{i+1}` is a filesystem index and the
+  union is `SELECT *` — no change needed, but it is the forward-only column-count hazard
+  ([`research/01`](research/01-part-lifecycle-and-partition-mechanism.md), [`research/03`](research/03-initdb-submit-and-config.md)).
+- **Column placement, type, and dict bookkeeping** → between `fingerprint` and `tag`; `INTEGER` default 0;
+  omit from `columns` ([`research/02`](research/02-task-model-column-and-fingerprint.md), contradiction
+  resolved in [`research/00`](research/00-digest.md)).
+- **Fresh-schema vs existing DBs** → `create_all` auto-includes the column; forward-only is inherent
+  ([`research/03`](research/03-initdb-submit-and-config.md)).
+
+## 5. Risks & open questions
+
+- **Forward-only breakage (documented, accepted):** running new code against an old DB → INSERT/SELECT
+  fail on the missing column, and auto-union of old partition files raises a column-count mismatch until
+  `--ignore-partitions`. This is the GOAL's forward-only non-goal; no migration is built. Worth a one-line
+  note in `docs`/release notes at ship time.
+- **User `-t part:5` now persists as a plain tag** (previously clobbered to 0 by `:387`). This is a
+  deliberate, benign consequence of decoupling — `part`-in-tag is now inert w.r.t. rotation (which reads
+  the column). No key reservation is added. Flag for the human in the hand-off; trivial to add a reserve
+  later if undesired.
+- **`columns`-omission asymmetry:** future code that assumes `Task.columns` enumerates *all* columns could
+  silently skip `part`. Mitigated by the explicit test in R7.
+
+## 6. Verification strategy
+
+Seeds the phase `verify:`. Prefer driving the real CLI in a throwaway site.
+
+- **CLI drive (throwaway site):**
+  `.agents/factory/bin/temp_site.sh sh -c 'uv run hs initdb && printf "echo a\necho b\n" | uv run hs submit && uv run hs initdb --rotate && uv run hs list'`
+  — proves the column code paths (submit → rotate → auto-union list) run without error.
+- **Column + tag-clean assertion (sqlite3 inside the same `sh -c`):** submit a task, then
+  `sqlite3 "$HYPERSHELL_DATABASE_FILE" "select part from task; select count(*) from task where json_extract(tag,'\$.part') is not null"`
+  → expect `part = 0` and count `0`.
+- **Internal-only:** `hs list part` still errors "Invalid field name"; `hs info <id>` no longer prints a
+  `part:` tag.
+- **Tests:** `tests/test_source.py` (fingerprint stable, `part` in table but not in `Task.columns`),
+  `tests/test_initdb.py::test_rotate` (real column-based rotation: completed tasks land in the partition
+  file, `main` keeps the rest), full `uv run pytest -q`.
+- **Docs:** `uv run sphinx-build -E -b html docs docs/_build` builds with only the 2 pre-existing baseline
+  toctree warnings (`docs/cli/task_submit.rst`, `docs/manual.rst`).
+
+---
+
+*Backing research: [`research/00-digest.md`](research/00-digest.md).*

--- a/spec/part-tag-to-column/PLAN.md
+++ b/spec/part-tag-to-column/PLAN.md
@@ -1,6 +1,6 @@
 # PLAN — Promote `part` from a bookkeeping tag to a first-class column
 
-> **Status:** Draft for review · **Last updated:** 2026-07-31
+> **Status:** Draft for review (re-planned 2026-07-31 after GOAL reshape) · **Last updated:** 2026-07-31
 > **Authoritative technical design.** The *how*. Vision/contract is [`GOAL.md`](GOAL.md);
 > the phased executable roadmap is [`TECH.md`](TECH.md). Backing detail is in
 > [`research/`](research/). Every design element traces to a GOAL R-ID.
@@ -8,43 +8,47 @@
 ## 1. Summary
 
 Add `part` as a real integer column on the `Task` model (between `fingerprint` and `tag`, mirroring the
-dialect-neutral integer columns, `default=0`) and stop stuffing it into the `tag` JSON dict. The only
-consumer — the SQLite `rotatedb()` maintenance routine behind `hs initdb --rotate` — is rewritten to
-read/write the column instead of `json_set`/`json_extract` on the tag, which is the promised
-simplification (R4). `part` is kept **internal**: it is a real DB column but is deliberately omitted from
-the `Task.columns` allowlist, so it never reaches the CLI or the wire. This is a small, cohesive,
-coupled-core change (`data/model.py` + `data/__init__.py`) shipped as a single vertical slice with its
-tests and the one same-commit doc/help update.
+dialect-neutral integer columns, `default=0`), add it to the `Task.columns` mapping so it is a visible,
+selectable field like `group`, and stop stuffing it into the `tag` JSON dict. The SQLite `rotatedb()`
+maintenance routine (behind `hs initdb --rotate`) is rewritten to read/write the column instead of
+`json_set`/`json_extract` on the tag (R4). Finally, `hs list`/`hs search` — which are a **single app**
+(`TaskSearchApp`) — gain a `--part N` filter to target a specific rotated partition (R9). Two vertical
+slices: (P1) the data-layer conversion + visible column, (P2) the `--part` CLI filter with its
+same-commit help/completions. This is a small, bounded change; research bought down the two unknowns
+(the rotation mechanism and the CLI/§12 machinery).
+
+> **Scope note:** the GOAL was reshaped on 2026-07-31 — the maintainer reversed the original "keep
+> `part` internal" decision. `part` is now user-visible and gains a `--part` filter (R8, R9). This
+> **reverses** the earlier design's one deviation (omitting `part` from `Task.columns`): it is now a
+> normal column entry, so the deviation table is empty.
 
 ## 2. Design
 
 ### Data model — `src/hypershell/data/model.py`
 
-- **New column (R1, R3):** insert between `fingerprint` (`:299`) and `tag` (`:301`, the current last
-  column):
+- **New column (R1, R3):** insert between `fingerprint` (`:299`) and `tag` (`:301`, current last column):
   ```python
-  part: Mapped[int] = mapped_column(INTEGER, nullable=False, default=0)  # Partition index (SQLite rotation bookkeeping); internal.
+  part: Mapped[int] = mapped_column(INTEGER, nullable=False, default=0)  # Partition index for SQLite database rotation.
   ```
-  `INTEGER` (`model.py:96`) maps to `INTEGER` on both SQLite and PostgreSQL, so the column is
-  dialect-neutral with no `with_variant`. `part` is not a reserved word (unlike `group`), so no `quote=`.
-  It is created automatically in a fresh DB by `metadata.create_all` (R6).
-- **Keep it internal (R5, no-CLI-surface non-goal):** do **not** add `'part'` to the `Task.columns` dict
-  (`:303-336`). That dict is the allowlist for `to_dict`/`to_json`/`from_dict`/`repr`/`serialize_tasks`
-  and for CLI field validation / `--fields` / `hs list`. Omitting `part` keeps it off the wire and out of
-  the CLI while it remains a first-class DB column read via the `Task.part` ORM attribute. (This asymmetry
-  is the one deliberate complexity — PLAN §3 deviation table.)
+  `INTEGER` (`model.py:96`) maps to `INTEGER` on both SQLite and PostgreSQL — dialect-neutral, no
+  `with_variant`. `part` is not a reserved word (unlike `group`), so no `quote=`. Created automatically
+  in a fresh DB by `metadata.create_all` (R6).
+- **Visible field (R8):** add `'part': int` to the `Task.columns` dict (`:303-336`), placed next to the
+  column's model position (after `fingerprint`, before `tag`). This flows `part` through
+  `to_dict`/`to_json`/`from_dict`/`serialize_tasks` and CLI field validation (`task.py:545-549` checks
+  `name in Task.columns`), so `hs list part`, `--fields`/`-x`, `hs list --all`, and `hs info` treat it
+  like any other column — exactly as `group` behaves.
 - **Stop hijacking the tag (R2):** in `Task.new`, change `:387`
   `tag = {**(tag or {}), **inline_tags, **{'part': 0, }}` → `tag = {**(tag or {}), **inline_tags}`. The
-  `Task(...)` constructor (`:404-406`) needs no explicit `part=` — the column default supplies `0`. The
-  retry builder copies `tag` but not `part`, so retry rows correctly start at `part=0` (a new row lives in
-  `main`).
+  `Task(...)` constructor (`:404-406`) needs no explicit `part=` — the column default supplies `0`; the
+  retry builder copies `tag` but not `part`, so retry rows correctly start at `part=0`.
 - **Fingerprint (R5):** in `compute_fingerprint`, drop the `if key != 'part'` filter at `:423`
-  (→ `'tags': dict(tags or {})`) and update the docstring at `:414`. Byte-identical output, because the
-  tag dict it receives no longer contains `part`.
+  (→ `'tags': dict(tags or {})`) and update the docstring at `:414`. Byte-identical, because the tag dict
+  it receives no longer contains `part`. (`part` being *visible* does not make it part of identity.)
 
 ### Rotation — `src/hypershell/data/__init__.py` (`rotatedb`, R4)
 
-Replace the three JSON expressions with plain column access; behavior is preserved:
+Replace the three JSON expressions with plain column access; behavior preserved:
 
 | Line | Before | After |
 |------|--------|-------|
@@ -52,102 +56,131 @@ Replace the three JSON expressions with plain column access; behavior is preserv
 | `:147` (read)  | `Task.tag['part'] == type_coerce(part_id, JSON)` | `Task.part == part_id` |
 | `:157` (read)  | `Task.tag['part'] != type_coerce(part_id, JSON)` | `Task.part != part_id` |
 
-Then remove the now-unused `type_coerce` / `JSON` imports **after grep-confirming** they're unused
+Then remove the now-unused `type_coerce`/`JSON` imports **after grep-confirming** they're unused
 elsewhere in the file (`text` stays — used by the `VACUUM` statements). The `exit_status.isnot(None)`
-filter (`:138`) and `next_rotate_path` (`:163-174`, filesystem-based) are untouched. `auto_union_sqlite`
-(`task.py`) is untouched — its `part_{i+1}` attach alias is a filesystem index unrelated to the column,
-and it never reads `part`.
+filter (`:138`) and `next_rotate_path` (`:163-174`) are untouched.
 
-### Docs / help (R7, §12 same-commit)
+### CLI filter — `src/hypershell/task.py` (`--part`, R9)
 
-`part` is no longer a tag, so update `INITDB_HELP` (`data/__init__.py`, the `--rotate` description that
-says "applies a special purpose `part:N` tag") and regenerate the matching `docs/_include/initdb_desc.rst`
-in the **same commit**; regenerate the `hs` man page if it carries the initdb description. `--ignore-partitions`
-help and `docs/database.rst` reference file numbering (not the tag) and need no change. `share/` completions
-carry no long descriptions → no completion change.
+`hs list` and `hs search` are the **same app**, `TaskSearchApp` (`task.py:601`; registered `list` at
+`__init__.py:130`, `search` at `task.py:1235`), so `--part` is added **once**:
+
+- Add `part_filter: Optional[int] = None` to the `SearchableMixin` and
+  `interface.add_argument('--part', type=int, default=None, dest='part_filter')` to `TaskSearchApp`,
+  mirroring the `-g/--group` option (`:465`).
+- In `__build_filters` (`:513-538`), append `f'part == {self.part_filter}'` when `part_filter is not
+  None` (mirroring the group filter at `:531-532`, `:646-647`). This routes through `WhereClause`, which
+  resolves `getattr(Task, 'part')` — valid now that `part` is a real column. `--part 0` is a legitimate
+  filter (main partition); absent flag ⇒ no filter (`is not None` guard, so `0` is not treated as
+  "unset").
+- **Auto-union composition:** `auto_union_sqlite` builds the temp view in `run()` (`:684-685`) before
+  `build_query()` (`:694`), so `WHERE part = N` over the union correctly returns partition N's rows.
+
+### Docs / help / completions (R7, R9, §12 same-commit)
+
+- **`hs initdb --rotate` help:** `part` is no longer a tag — update `INITDB_HELP` (`data/__init__.py`)
+  and regenerate/hand-edit `docs/_include/initdb_desc.rst`.
+- **`--part` help (hand-maintained, no generator):** update `SEARCH_USAGE`/`SEARCH_HELP` constants
+  (`task.py:554`/`:568`) and the hand-authored `docs/_include/task_search_help.rst` (and
+  `task_search_usage.rst` iff the synopsis line changes) — following the `961fb22 [feature] Add --all`
+  precedent.
+- **Completions:** bash `_hs_task_search` (add `--part` to `all_opts`, ~`:377-380`, + optional value
+  branch); zsh `_hs_list` (add an `_arguments` line mirroring `--ignore-partitions`, ~`:422`).
+  `hsx`/`hs cluster` completions are separate and unaffected.
+- **Man pages / CI:** man pages regenerate at release time only (not same-commit; matches the `--all`
+  precedent). The CI wheel-metadata assertion checks a fixed path list — unaffected by content changes.
 
 ### Requirement → design map
 
 | R-ID | Design element(s) that satisfy it |
 |------|-----------------------------------|
-| R1 | New `part` `mapped_column(INTEGER, nullable=False, default=0)` inserted between `fingerprint` and `tag` in `data/model.py`. |
-| R2 | `Task.new:387` drops the `{'part': 0}` merge; task creation sets the column (via default), `tag` holds only user annotations. |
-| R3 | `INTEGER` type — dialect-neutral (SQLite/PG), no SQLite-only construct. |
-| R4 | `rotatedb` `:139/:147/:157` rewritten to `Task.part` (update / `==` / `!=`); JSON functions & dead imports removed; partition outcome preserved. |
-| R5 | Fingerprint `part`-exclusion removed (byte-identical); `part` omitted from `Task.columns` → absent from tag output, CLI, and wire. |
-| R6 | Column is a mapped column → `metadata.create_all` includes it in fresh `hs initdb` schema. Forward-only (create_all never ALTERs old DBs). |
-| R7 | Update `tests/test_source.py` fingerprint/column tests, fill the `tests/test_initdb.py` `test_rotate` stub with real column-based rotation coverage; update `INITDB_HELP` + `initdb_desc.rst`; full suite + docs build green. |
+| R1 | New `part` `mapped_column(INTEGER, nullable=False, default=0)` between `fingerprint` and `tag`. |
+| R2 | `Task.new:387` drops the `{'part': 0}` merge; creation sets the column (default), `tag` = user annotations only. |
+| R3 | `INTEGER` — dialect-neutral (SQLite/PG); no SQLite-only construct. |
+| R4 | `rotatedb` `:139/:147/:157` rewritten to `Task.part`; JSON funcs & dead imports removed; outcome preserved. |
+| R5 | Fingerprint `part`-exclusion removed (byte-identical); `part` is a column, not a user tag. |
+| R6 | Mapped column → `metadata.create_all` includes it in fresh `hs initdb` schema. Forward-only. |
+| R7 | Update fingerprint/rotate tests, add `--part` tests; update help snippets + completions; full suite + docs build green. |
+| R8 | `'part'` added to `Task.columns` → selectable/displayable via `--fields`, `hs list --all`, `hs info`, like `group`. |
+| R9 | `--part N` option on `TaskSearchApp` (`hs list`/`hs search`) → `part == N` filter over the (possibly unioned) query; help + completions updated same-commit. |
 
 ## 3. Invariant gate (AGENTS.md constitution check)
 
-Checked before research and again after this design (both checkpoints).
+Checked before research and again after this (re-planned) design.
 
-- **§1 Task lifecycle (`data/model.py`, highest blast radius)** — `part` is **orthogonal** to the
-  nullable-column state predicates (`schedule_time`/`completion_time`/`exit_status`); it is not added to
-  any state query and does not alter task state. Task-state transition logic stays in `Task` classmethods
-  (we touch only `Task.new`/`compute_fingerprint`/a column). Identity semantics are preserved — removing
-  the `part` fingerprint-exclusion is byte-identical. **Honored.**
-- **§10 Config / data layer** — schema materializes via `metadata.create_all` at `hs initdb`; `create_all`
-  never `ALTER`s, so pre-existing DBs are out of scope (GOAL non-goal, forward-only). No config singleton
-  change. **Honored.**
-- **§12 Project conventions** — the `initdb` help snippet (`docs/_include/initdb_desc.rst`) is updated in
-  the same commit as the behavior change; new tests are `@mark.unit`; no hardcoded version; no dependency
-  floor changes; no new CLI so no completion churn. **Honored.**
-- Sections **§2–§9, §11** (exit_status, retry, server modes, FSM/thread, shutdown, resource, signals,
-  queue/TLS, cluster) — **not touched**; this is a pure data-model + single-query-site change with no
-  server/client/queue/FSM/signal/cluster involvement.
+- **§1 Task lifecycle (`data/model.py`, highest blast radius)** — `part` is orthogonal to the
+  nullable-column state predicates; it is not added to any state query, and the `--part` filter is an
+  ordinary `WHERE` on a non-state column that composes with (does not alter) existing predicates.
+  Task-state logic stays in `Task` classmethods; identity semantics preserved (fingerprint change is
+  byte-identical). **Honored.**
+- **§10 Config / data layer** — schema via `metadata.create_all` at `hs initdb`; `create_all` never
+  `ALTER`s → pre-existing DBs out of scope (forward-only, GOAL non-goal). No config-singleton change.
+  **Honored.**
+- **§12 Project conventions (same-commit)** — the new `--part` option updates the `task_search_*` help
+  snippets **and** the bash+zsh completions in the same commit; `hs initdb --rotate` help snippet
+  updated with its behavior change; new tests `@mark.unit`; no hardcoded version; no dependency-floor or
+  CI-metadata changes. **Honored.**
+- Sections **§2–§9, §11** — not touched (pure data-model + one query-site + one leaf CLI app; no
+  server/client/queue/FSM/signal/cluster involvement). The wire now carries `part` (it is in `columns`),
+  exactly as it carries `group` today — inert for execution, round-trips like any column.
 
 ### Deviation justifications
 
 | Deviation | Why needed | Simpler alternative rejected because |
 |-----------|-----------|--------------------------------------|
-| `part` is a real mapped column but is **omitted from the `Task.columns` allowlist** (every other column is listed there). | R5 + the no-CLI-surface non-goal require `part` to stay internal — off the wire, out of `hs list`/`--fields`/tag output. Omitting it from `columns` achieves that while it remains a queryable DB column via `Task.part`. | Adding `part` to `columns` (the "consistent" choice) would expose it on the wire and in the CLI, violating R5 and the non-goal. Mitigated by a test asserting `part` is in the real table but **not** in `Task.columns`. |
+| — (none) | — | — |
+
+*(The prior draft's one deviation — omitting `part` from `Task.columns` to keep it internal — is removed
+by the GOAL reshape; `part` is now a normal column entry.)*
 
 ## 4. Rabbit holes (resolved)
 
-- **What is "database rotation" and where does `part` flow?** → It's `rotatedb()` behind the manual,
-  SQLite-only `hs initdb --rotate`; `part` is written once by `json_set` and read twice by `json_extract`
-  — exactly three expressions to convert ([`research/01`](research/01-part-lifecycle-and-partition-mechanism.md)).
-- **Does the auto-union depend on the `part` value?** → No; `part_{i+1}` is a filesystem index and the
-  union is `SELECT *` — no change needed, but it is the forward-only column-count hazard
-  ([`research/01`](research/01-part-lifecycle-and-partition-mechanism.md), [`research/03`](research/03-initdb-submit-and-config.md)).
-- **Column placement, type, and dict bookkeeping** → between `fingerprint` and `tag`; `INTEGER` default 0;
-  omit from `columns` ([`research/02`](research/02-task-model-column-and-fingerprint.md), contradiction
-  resolved in [`research/00`](research/00-digest.md)).
-- **Fresh-schema vs existing DBs** → `create_all` auto-includes the column; forward-only is inherent
-  ([`research/03`](research/03-initdb-submit-and-config.md)).
+- **What is "database rotation" and where does `part` flow?** → `rotatedb()` behind the manual,
+  SQLite-only `hs initdb --rotate`; exactly three JSON expressions to convert
+  ([`research/01`](research/01-part-lifecycle-and-partition-mechanism.md)).
+- **Auto-union & `part`** → the `part_{i+1}` attach alias is a filesystem index unrelated to the value;
+  the union is `SELECT *` (no change), but old partition files lacking the column are the forward-only
+  hazard ([`research/01`](research/01-part-lifecycle-and-partition-mechanism.md),
+  [`research/03`](research/03-initdb-submit-and-config.md)).
+- **Where does `--part` hook in, and is it one app or two?** → one app (`TaskSearchApp`); mirror
+  `-g/--group`; the filter composes over the union view ([`research/05`](research/05-list-search-apps-and-part-filter.md)).
+- **§12 machinery** → help includes are hand-maintained `task_search_*` (no generator); one bash + one
+  zsh completion function; man pages release-time only
+  ([`research/06`](research/06-help-snippets-and-completions.md)).
 
 ## 5. Risks & open questions
 
-- **Forward-only breakage (documented, accepted):** running new code against an old DB → INSERT/SELECT
-  fail on the missing column, and auto-union of old partition files raises a column-count mismatch until
-  `--ignore-partitions`. This is the GOAL's forward-only non-goal; no migration is built. Worth a one-line
-  note in `docs`/release notes at ship time.
-- **User `-t part:5` now persists as a plain tag** (previously clobbered to 0 by `:387`). This is a
-  deliberate, benign consequence of decoupling — `part`-in-tag is now inert w.r.t. rotation (which reads
-  the column). No key reservation is added. Flag for the human in the hand-off; trivial to add a reserve
-  later if undesired.
-- **`columns`-omission asymmetry:** future code that assumes `Task.columns` enumerates *all* columns could
-  silently skip `part`. Mitigated by the explicit test in R7.
+- **Forward-only breakage (documented, accepted):** new code against an old DB → INSERT/SELECT fail on
+  the missing column, and auto-union of old partition files raises a column-count mismatch until
+  `--ignore-partitions`. GOAL non-goal; worth a release-note line.
+- **`part` now on the wire:** adding `part` to `columns` serializes it in task bundles (like `group`).
+  Inert for execution and round-trips like any column; noted for awareness, not a concern in a
+  single-version cluster.
+- **User `-t part:5` now persists as a plain user tag** (previously clobbered to 0). Now that `part` is
+  also a prominent column + filter, a same-named user tag is inert but *potentially confusing*. Default:
+  no key reservation (tags are the user's namespace; the column/`--part` are separate). Flag for the
+  human — trivial to reserve later if undesired.
+- **`--part` on `hs update`?** Out of R9 scope (R9 says list/search). Not added.
 
 ## 6. Verification strategy
 
 Seeds the phase `verify:`. Prefer driving the real CLI in a throwaway site.
 
-- **CLI drive (throwaway site):**
-  `.agents/factory/bin/temp_site.sh sh -c 'uv run hs initdb && printf "echo a\necho b\n" | uv run hs submit && uv run hs initdb --rotate && uv run hs list'`
-  — proves the column code paths (submit → rotate → auto-union list) run without error.
-- **Column + tag-clean assertion (sqlite3 inside the same `sh -c`):** submit a task, then
+- **Column + tag-clean (P1):** submit a task, then
   `sqlite3 "$HYPERSHELL_DATABASE_FILE" "select part from task; select count(*) from task where json_extract(tag,'\$.part') is not null"`
-  → expect `part = 0` and count `0`.
-- **Internal-only:** `hs list part` still errors "Invalid field name"; `hs info <id>` no longer prints a
-  `part:` tag.
-- **Tests:** `tests/test_source.py` (fingerprint stable, `part` in table but not in `Task.columns`),
-  `tests/test_initdb.py::test_rotate` (real column-based rotation: completed tasks land in the partition
-  file, `main` keeps the rest), full `uv run pytest -q`.
-- **Docs:** `uv run sphinx-build -E -b html docs docs/_build` builds with only the 2 pre-existing baseline
-  toctree warnings (`docs/cli/task_submit.rst`, `docs/manual.rst`).
+  → `part = 0`, count `0`. `hs info <id>` shows no `part:` tag; `hs list part` is now a **valid** field
+  (shows `0`).
+- **Rotation (P1):** `hs initdb --rotate` after completing tasks → completed rows carry the right `part`
+  and land in the partition file; `hs list` (auto-union) still works.
+- **`--part` filter (P2):**
+  `.agents/factory/bin/temp_site.sh sh -c '…submit + complete + hs initdb --rotate…; uv run hs list --part 1'`
+  returns only partition-1 rows; `hs list --part 0` returns the main partition; absent ⇒ all.
+- **Tests:** `tests/test_source.py` (fingerprint stable; `part` in `Task.columns` **and** in the real
+  table), `tests/test_initdb.py::test_rotate` (real column-based rotation), `tests/test_list.py` (`--part`
+  filter cases), full `uv run pytest -q`.
+- **Docs/completions:** `uv run sphinx-build -E -b html docs docs/_build` → only the 2 baseline toctree
+  warnings; the updated `task_search_help.rst` renders; `--part` present in bash/zsh completions.
 
 ---
 
-*Backing research: [`research/00-digest.md`](research/00-digest.md).*
+*Backing research: [`research/00-digest.md`](research/00-digest.md) (briefs `01`–`06`).*

--- a/spec/part-tag-to-column/REVIEW.md
+++ b/spec/part-tag-to-column/REVIEW.md
@@ -1,0 +1,92 @@
+# REVIEW — Promote `part` from a bookkeeping tag to a first-class column
+
+> Adversarial QA by `hs-review`, run via a blind fresh-subagent correctness pass. The reviewer graded
+> the branch diff against [`GOAL.md`](GOAL.md) + the AGENTS.md invariants **only** — it did not see
+> `PLAN.md`/`TECH.md`/`research/`/`META.md`. Every finding cites an **executed** command. Findings were
+> sanity-checked against source by the orchestrator before this record was written.
+
+- **Reviewed commit:** a3af539 (`a3af53941279b9e0d79d81cdb522b1274f04933a`)  ·  **Base:** develop  ·  **Date:** 2026-07-31
+- **Verdict:** changes-requested
+- **Cycle:** 1 of ≤3 — mirrors `review.cycle` in `TECH.md`
+
+## Verification run
+
+Commands actually executed (blind reviewer, then orchestrator confirmation):
+
+- `uv run pytest -q` → **422 passed** (~245s). No failures.
+- `uv run pytest -q tests/test_source.py tests/test_initdb.py tests/test_list.py` → **31 passed**.
+- `uv run sphinx-build -E -b html docs docs/_build` → build succeeded, **2 warnings** (both the
+  pre-existing baseline `task_submit.rst`/`manual.rst` toctree warnings; no new warnings).
+- CLI drive in a throwaway site (`.agents/factory/bin/temp_site.sh`): submit 4 → complete 2 →
+  `hs initdb --rotate --yes`. Confirmed completed rows land in `local.1` with `part=1`; incomplete
+  stay in main at `part=0`; `part` never appears in tag JSON in either file
+  (`json_extract(tag,'$.part')` = NULL on all rows); auto-union count 4, `--ignore-partitions` count 2;
+  `--part 1`→partition rows, `--part 0`→main, `--part 99`→empty; `--part` composes with `-t`;
+  `hs list part`, `hs info -x part`, `--json`/`--csv`/table all expose the column; `hs task search --part`
+  identical to `hs list --part`.
+- Orchestrator source confirmation of F1: `NORMAL_MODE_TEMPLATE` (`task.py:1294-1319`) has no `{part}`
+  placeholder while rendering every other `Task.columns` member; `check_output_format` (`task.py:821-828`)
+  routes bare `hs list`/`hs info` to that template.
+
+## Requirement → evidence matrix
+
+| R-ID | Implemented by | Verified how | Status |
+|------|----------------|--------------|--------|
+| R1 | `data/model.py:301` — `part: Mapped[int] = mapped_column(INTEGER, nullable=False, default=0)`, positioned after `fingerprint` (:299), immediately before `tag` (:303) | Read source; schema test | ✅ |
+| R2 | `data/model.py:390` — `tag = {**(tag or {}), **inline_tags}` (the `{'part':0}` injection removed) | `test_new_keeps_part_out_of_tag_and_identity`; CLI: `json_extract(tag,'$.part')`=NULL on all rows | ✅ |
+| R3 | Plain `INTEGER`/`Integer()` column type (`model.py:96,301`); `--part` is a plain column filter | Read source (no SQLite-only construct) | ✅ |
+| R4 | `data/__init__.py:139/147/157` use `Task.part`; `json_set`/`json_extract`/`type_coerce` for part removed (import dropped) | `test_rotate`; CLI rotate drive; `grep` confirms no `json_*`-for-part remains | ✅ |
+| R5 | `compute_fingerprint` hashes `dict(tags or {})` with no part special-casing | `test_new_keeps_part_out_of_tag_and_identity` (fingerprint stable); retry path copies parent fingerprint | ✅ |
+| R6 | `create_all` schema includes `part` | `test_fresh_schema_creates_source_table_columns_and_indices` asserts `part` in task columns; CLI submit on fresh DB → `part=0` | ✅ |
+| R7 | Suite green; docs build clean; `docs/_include/initdb_desc.rst` updated (part→column); new behavior + `--part` covered by tests | pytest 422; docs build; see F2 (man-page artifact lag, non-blocking) | ✅ (see F2) |
+| R8 | `'part': int` in `Task.columns` (`model.py:337`); selectable by name / `--fields` / `--order-by` / table / plain / json / csv / `-x` | CLI: `hs list part`, `hs info -x part`, `--json` all show it — **but** the detailed `NORMAL_MODE_TEMPLATE` (`hs info`, bare `hs list`) omits it | ❌ partial (F1) |
+| R9 | `--part N` on `TaskSearchApp` (`task.py:654`); filter in `SearchableMixin.__build_filters` (`task.py:534-535`); `docs/_include/task_search_{usage,help}.rst` + bash & zsh completions updated same commit | `test_part_filter`; CLI drive on both `hs list` and `hs task search`; `grep` share/ completions | ✅ |
+
+Unmapped changes (possible scope creep): **none**. Every hunk maps to an R-ID (the `test_initdb.py`
+helper swap and `sqlite3` import serve the R7 rotation test; the inert `SearchableMixin.part_filter`
+attribute is shared R9 infrastructure — `TaskUpdateApp` exposes no `--part`, so `hs update` is unchanged).
+
+## Findings
+
+### [HIGH/CONFIRMED] R8 partially unmet — `part` omitted from the detailed task view (`hs info`, bare `hs list`)
+- **Where:** `src/hypershell/task.py:1294-1319` (`NORMAL_MODE_TEMPLATE`)
+- **Failure scenario:** a user runs `hs info <id>` (or bare `hs list`, which `check_output_format` routes
+  to the same normal template) to see which partition a task landed in after a rotate → the value is
+  queried and present in `task.to_dict()` but the template has no `{part}` placeholder, so it is silently
+  dropped. `part` is the **only** `Task.columns` member the template omits — it renders `group`,
+  `fingerprint`, `source`, `previous_id`/`next_id`, all hosts, `waited`, `duration`, etc.
+- **Evidence:** blind CLI drive — full `hs info`/`hs list --all` output shows 24 field lines, none for
+  `part`; `hs info -x part` → `0` proves the data is present but unrendered. Orchestrator source
+  confirmation: template lines 1294-1319 contain `group: {group}` (line 1296) but no `part` line;
+  `Task.columns` (`model.py:337`) does contain `part`.
+- **Touches requirement:** R8 — "available wherever other columns are (e.g. … `hs info`), **consistent
+  with columns like `group`**." `group` appears in the detailed view; `part` does not.
+- **Not a coupled-core finding:** `task.py` is a leaf app (per AGENTS.md), so this does **not** trigger
+  the mandatory high-blast-radius human gate.
+- **Suggested remediation:** add a `part: {part}` line to `NORMAL_MODE_TEMPLATE` (natural home: adjacent
+  to `group`, or immediately before `tags`), and cover it with a test asserting the normal/`hs info`
+  output includes `part`.
+
+### [LOW/PLAUSIBLE — non-blocking] Man-page artifact still describes `part` as a tag
+- **Where:** `share/man/man1/hs.1:1181` (and identical `hsx.1`, `hyper-shell.1`): "applies a special
+  purpose `part:N` tag."
+- **Why non-blocking:** the man pages are **Sphinx-generated artifacts** (`docs/conf.py:153 man_pages`;
+  `/hs-release` rebuilds them via `cp docs/_build/man/hs.1 …`). Their source, `docs/_include/initdb_desc.rst`,
+  **was correctly updated** this branch (now: "recording that partition's index in each moved task's
+  `part` column"). The committed `.1` files are dated Jul 23 (the 2.9.0a1 release) and are simply stale;
+  the next `/hs-release` regeneration will pick up the corrected source. The §12 same-commit rule scopes
+  to `docs/_include/*.rst` + `share/` completions (both correctly updated), not to release-time man pages.
+- **Evidence:** `grep -n part share/man/man1/hs.1` → line 1181 old text; `docs/_include/initdb_desc.rst:7-8`
+  → new column-based text. Surfaced for human awareness; does **not** auto-loop.
+
+## Human-gate triggers
+
+- **None.** The one CONFIRMED finding (F1) is in `task.py` (a leaf app), not the high-blast-radius core,
+  and touches no security/DB-lifecycle invariant. The `data/model.py` and `data/__init__.py` changes
+  themselves reviewed clean (lifecycle predicates, retry chain, CANCEL_STATUS filters, fingerprint all
+  intact). No mandatory human sign-off is required to proceed with the loop.
+
+## Optional completeness sub-pass
+
+- Not run this cycle (plain `/hs-review`; no `completeness` argument). The requirement→evidence matrix
+  above already maps every phase's R-IDs to executed evidence.

--- a/spec/part-tag-to-column/TECH.md
+++ b/spec/part-tag-to-column/TECH.md
@@ -3,7 +3,7 @@ slug: part-tag-to-column
 title: Promote `part` from a bookkeeping tag to a first-class column
 kind: refactor
 appetite: small
-status: in_review
+status: done
 branch: feature/part-tag-to-column
 base: develop
 current_phase: done

--- a/spec/part-tag-to-column/TECH.md
+++ b/spec/part-tag-to-column/TECH.md
@@ -10,10 +10,19 @@ current_phase: P1
 last_updated: "2026-07-31"
 phases:
   - id: P1
-    name: "Convert `part` to a column (model + rotatedb) with same-commit help/doc + tests"
+    name: "Data layer: `part` column (visible) + rotatedb via column + same-commit initdb help"
     status: pending
-    satisfies: [R1, R2, R3, R4, R5, R6, R7]
+    satisfies: [R1, R2, R3, R4, R5, R6, R8]
     depends_on: []
+    parallel: false
+    hammerable: false
+    hill: uphill
+    verify: "uv run pytest -q && uv run sphinx-build -E -b html docs docs/_build"
+  - id: P2
+    name: "CLI: `--part N` filter on hs list/search + same-commit help snippets + completions"
+    status: pending
+    satisfies: [R9, R7]
+    depends_on: [P1]
     parallel: false
     hammerable: false
     hill: uphill
@@ -27,94 +36,116 @@ review:
 
 # TECH.md — Promote `part` from a bookkeeping tag to a first-class column
 
-The **context engine and finite-state machine** for building this feature. The YAML
-frontmatter above is the resume ground-truth (read it with
-`uv run python .agents/factory/bin/next_phase.py spec/part-tag-to-column/TECH.md`); the per-phase
-checklist below is the work.
+The **context engine and finite-state machine** for building this feature. The YAML frontmatter above
+is the resume ground-truth (read it with `uv run python .agents/factory/bin/next_phase.py
+spec/part-tag-to-column/TECH.md`); the per-phase checklists below are the work.
 
-- **Vision / requirements (locked):** [`GOAL.md`](GOAL.md) — R-IDs are the contract.
+- **Vision / requirements (locked):** [`GOAL.md`](GOAL.md) — R-IDs are the contract (reshaped
+  2026-07-31: `part` is now visible + gains `--part`).
 - **Authoritative design:** [`PLAN.md`](PLAN.md).
-- **Backing research:** [`research/00-digest.md`](research/00-digest.md) + briefs `01`–`04`.
+- **Backing research:** [`research/00-digest.md`](research/00-digest.md) + briefs `01`–`06`.
 
 ## Conventions (apply to every phase)
 
 - Invariants and code style come from [`AGENTS.md`](../../AGENTS.md) /
   [`invariants.md`](../../.agents/factory/invariants.md). Touched sections: **§1** (task lifecycle —
   `part` is orthogonal to the state predicates; keep state logic in `Task` classmethods), **§10**
-  (schema via `create_all`; forward-only), **§12** (same-commit help/doc snippet; tag tests
-  `@mark.unit`). The one recorded deviation (a real column deliberately omitted from `Task.columns` to
-  stay internal) is in PLAN §3.
-- One atomic commit containing the code, the docs/help snippet, the tests, **and** the `TECH.md` state
-  change. Subject: `[refactor] Build part-tag-to-column P1: …`.
+  (schema via `create_all`; forward-only), **§12** (same-commit help snippets + completions; tag tests
+  `@mark.unit`). No deviations (PLAN §3).
+- One atomic commit per phase containing the code, the same-commit docs/help/completions, the tests,
+  **and** the `TECH.md` state change. Subjects: `[refactor] Build part-tag-to-column P<n>: …`.
 - **No `Co-Authored-By` trailer** (repo convention).
-- **Coupled core:** `data/model.py` is highest-blast-radius. Change model + `rotatedb` with a single
-  coherent view; do not split them (the model change breaks `rotatedb` until it is updated too).
+- **Coupled core:** `data/model.py` is highest-blast-radius. In P1, change the model + `rotatedb` with a
+  single coherent view (the model change breaks `rotatedb` until it is updated too).
 
 ---
 
-## Phase P1 — Convert `part` to a first-class column
-**Satisfies:** R1, R2, R3, R4, R5, R6 (docs/tests of R7) · **Depends on:** —
-**Goal:** `part` is a real, dialect-neutral `Task` column (created in fresh schema, defaulting to 0),
-no longer stored in the `tag` dict; `rotatedb()` reads/writes the column with no SQLite JSON functions;
-`part` stays internal (off the wire and CLI); the suite and docs build are green. One atomic, end-to-end
-verifiable change.
+## Phase P1 — Data layer: visible `part` column + rotation via the column
+**Satisfies:** R1, R2, R3, R4, R5, R6, R8 (+ data-layer tests/docs of R7) · **Depends on:** —
+**Goal:** `part` is a real, dialect-neutral, **visible** `Task` column (in `Task.columns`, default 0),
+no longer in the `tag` dict; `rotatedb()` reads/writes the column with no SQLite JSON functions; fresh
+`hs initdb` schema includes it; suite + docs build green. End-to-end verifiable without the CLI filter.
 
 ### Model — `src/hypershell/data/model.py`
 - [ ] Add the column between `fingerprint` (`:299`) and `tag` (`:301`):
       `part: Mapped[int] = mapped_column(INTEGER, nullable=False, default=0)` with a one-line declarative
-      comment (partition index / SQLite rotation bookkeeping / internal). `INTEGER` is already
-      dialect-neutral (R1, R3).
-- [ ] **Do NOT** add `'part'` to the `Task.columns` dict (`:303-336`) — keeps `part` off
-      `to_dict`/`to_json`/`serialize_tasks`/`--fields`/`hs list` (R5, no-CLI-surface non-goal). See PLAN
-      §3 deviation.
-- [ ] `Task.new`: change `:387` `tag = {**(tag or {}), **inline_tags, **{'part': 0, }}` →
-      `tag = {**(tag or {}), **inline_tags}`. Leave the `Task(...)` constructor (`:404-406`) as-is — the
-      column `default=0` supplies the value; the retry builder (copies `tag`, not `part`) correctly yields
-      `part=0` (R2).
+      comment (partition index for SQLite database rotation) (R1, R3).
+- [ ] Add `'part': int` to the `Task.columns` dict (`:303-336`) in the matching position (after
+      `fingerprint`, before `tag`) so `part` is selectable/displayable like `group` (R8).
+- [ ] `Task.new`: change `:387` → `tag = {**(tag or {}), **inline_tags}` (drop `**{'part': 0, }`); leave
+      the `Task(...)` constructor as-is (column `default=0` supplies the value; retries → `part=0`) (R2).
 - [ ] `compute_fingerprint`: remove the `if key != 'part'` filter at `:423` (→ `'tags': dict(tags or {})`)
-      and update the docstring at `:414` (`part` is now a column, not an excluded tag). Byte-identical
-      output (R5).
+      and fix the docstring at `:414` (R5).
 
 ### Rotation — `src/hypershell/data/__init__.py` (`rotatedb`)
-- [ ] `:139` write → `.update({Task.part: part_id})` (drop the `json_set` text expression) (R4).
-- [ ] `:147` read → `Task.part == part_id`; `:157` read → `Task.part != part_id` (drop
-      `Task.tag['part']`/`type_coerce`/`JSON`) (R4).
-- [ ] Remove the now-unused `type_coerce` / `JSON` imports **after** grep-confirming they are unused
-      elsewhere in the file (`text` stays — used by `VACUUM`). Leave the `exit_status.isnot(None)` filter
-      (`:138`) and `next_rotate_path` untouched. Do not touch `auto_union_sqlite` in `task.py`.
+- [ ] `:139` write → `.update({Task.part: part_id})`; `:147` → `Task.part == part_id`; `:157` →
+      `Task.part != part_id` (drop the `json_set` / `Task.tag['part']` / `type_coerce` / `JSON`) (R4).
+- [ ] Remove now-unused `type_coerce`/`JSON` imports **after** grep-confirming they're unused elsewhere
+      in the file (`text` stays — used by `VACUUM`). Leave the `exit_status.isnot(None)` filter (`:138`)
+      and `next_rotate_path` untouched; do not touch `auto_union_sqlite`.
 
 ### Docs / help (R7, §12 same-commit)
-- [ ] Update `INITDB_HELP` in `data/__init__.py` (the `--rotate` description that calls `part` a "special
-      purpose `part:N` tag") to reflect that `part` is now an internal column, and regenerate the matching
-      `docs/_include/initdb_desc.rst`. Regenerate the `hs` man page (`share/man/man1/hs.1`) if it carries
-      the initdb description. `--ignore-partitions` help and `docs/database.rst` need no change;
-      completions carry no long descriptions so `share/` completions are unchanged.
+- [ ] Update `INITDB_HELP` (`data/__init__.py`) so the `--rotate` description no longer calls `part` a
+      "special purpose `part:N` tag", and hand-edit the matching `docs/_include/initdb_desc.rst`. (Man
+      page is release-time; completions carry no long description → unchanged.)
 
 ### Tests (R7) — `@mark.unit`
-- [ ] `tests/test_source.py:63-67,:86`: drop the hardcoded `{'part': …}` literals from the
-      `compute_fingerprint` calls (the tag no longer carries `part`); confirm fingerprints stay stable.
-- [ ] `tests/test_source.py:99-116`: assert the real `Task` table **has** a `part` column **and** that
-      `'part'` is **absent** from `Task.columns` (locks the internal-only deviation).
+- [ ] `tests/test_source.py:63-67,:86`: drop the hardcoded `{'part': …}` literals from
+      `compute_fingerprint` calls; confirm fingerprints stay stable.
+- [ ] `tests/test_source.py:99-116`: assert `'part'` **is** in `Task.columns` **and** the real `Task`
+      table has a `part` column.
 - [ ] `tests/test_initdb.py::test_rotate` (currently a stub): make it actually rotate — submit + complete
-      tasks, run `rotatedb()` (or `hs initdb --rotate`), assert completed rows carry the right `part`
-      column value, land in the partition file, and are dropped from `main`; assert the tag never contains
-      `part`.
+      tasks, run `rotatedb()` / `hs initdb --rotate`, assert completed rows carry the right `part` value,
+      land in the partition file, and are dropped from `main`; assert `tag` never contains `part`.
+- [ ] Fix any existing test that asserts an exact column/serialization set now that `part` is in
+      `columns` (grep for surprises; the full-suite verify will surface them).
 
 ### Verify
 - [ ] Frontmatter gate: `uv run pytest -q && uv run sphinx-build -E -b html docs docs/_build` (full suite
       green; docs build with only the 2 pre-existing baseline toctree warnings).
-- [ ] CLI drive (throwaway site):
-      `.agents/factory/bin/temp_site.sh sh -c 'uv run hs initdb && printf "echo a\necho b\n" | uv run hs submit && uv run hs initdb --rotate && uv run hs list'`
-      runs clean.
-- [ ] Column + tag-clean (sqlite3 inside the same `sh -c`):
+- [ ] CLI drive: `.agents/factory/bin/temp_site.sh sh -c 'uv run hs initdb && printf "echo a\necho b\n" | uv run hs submit && uv run hs initdb --rotate && uv run hs list part'` runs clean and `part` shows as a column.
+- [ ] Column + tag-clean (sqlite3 in the same `sh -c`):
       `sqlite3 "$HYPERSHELL_DATABASE_FILE" "select part from task; select count(*) from task where json_extract(tag,'\$.part') is not null"`
       → `part=0`, count `0`.
-- [ ] Internal-only: `hs list part` still errors "Invalid field name"; `hs info <id>` shows no `part:` tag.
 - [ ] Grep: no `json_set`/`json_extract`/`type_coerce` reference to `part` remains in `src/hypershell`.
 
 **Touches:** `src/hypershell/data/model.py`, `src/hypershell/data/__init__.py`,
-`docs/_include/initdb_desc.rst` (+ `INITDB_HELP` source), `tests/test_source.py`,
-`tests/test_initdb.py`, and possibly `share/man/man1/hs.1`.
+`docs/_include/initdb_desc.rst`, `tests/test_source.py`, `tests/test_initdb.py`.
+
+## Phase P2 — CLI: `--part N` filter on `hs list` / `hs search`
+**Satisfies:** R9 (+ CLI tests/docs of R7) · **Depends on:** P1
+**Goal:** `hs list --part N` / `hs search --part N` return only tasks whose `part == N` (targeting a
+rotated partition), with the same-commit help snippets and shell completions updated. End-to-end
+verifiable: rotate, then filter by partition.
+
+### CLI — `src/hypershell/task.py` (single `TaskSearchApp`)
+- [ ] Add `part_filter: Optional[int] = None` to `SearchableMixin` and
+      `interface.add_argument('--part', type=int, default=None, dest='part_filter')` to `TaskSearchApp`,
+      mirroring the `-g/--group` option (`:465`).
+- [ ] In `__build_filters` (`:513-538`), append `f'part == {self.part_filter}'` when `part_filter is not
+      None` (mirroring the group filter at `:531-532`, `:646-647`). `--part 0` is a valid filter (main
+      partition); absent ⇒ no filter. `--part` is added **once** (list and search are the same app).
+
+### Docs / help / completions (R7, R9, §12 same-commit)
+- [ ] Update `SEARCH_USAGE`/`SEARCH_HELP` (`task.py:554`/`:568`) to document `--part`, and hand-edit
+      `docs/_include/task_search_help.rst` (and `task_search_usage.rst` iff the synopsis changes) — per
+      the `961fb22 [feature] Add --all` precedent.
+- [ ] bash completion `_hs_task_search`: add `--part` to the `all_opts` string (~`:377-380`) (+ optional
+      `--part)` value branch). zsh completion `_hs_list`: add an `_arguments` line mirroring
+      `--ignore-partitions` (~`:422`). Do not touch `hsx`/`hs cluster` completions.
+
+### Tests (R7) — `@mark.unit`
+- [ ] `tests/test_list.py`: add `--part` cases mirroring existing filter tests — after a rotate,
+      `--part N` returns only partition-N rows, `--part 0` returns the main partition, and omitting it
+      returns all; an out-of-range `--part` returns nothing.
+
+### Verify
+- [ ] Frontmatter gate: `uv run pytest -q && uv run sphinx-build -E -b html docs docs/_build`.
+- [ ] CLI drive (partition targeting): `.agents/factory/bin/temp_site.sh sh -c "…submit + complete tasks + uv run hs initdb --rotate…; uv run hs list --part 1; uv run hs list --part 0"` returns the right partition subsets.
+- [ ] Completions: `--part` appears in `share/` bash + zsh completions for `hs list`/`hs search`.
+
+**Touches:** `src/hypershell/task.py`, `docs/_include/task_search_help.rst` (± `task_search_usage.rst`),
+`share/` bash + zsh completions, `tests/test_list.py`.
 
 ---
 
@@ -123,8 +154,7 @@ verifiable change.
 1. `next_phase.py` prints the next actionable phase (statuses authoritative).
 2. Pre-flight: clean tree, on `feature/part-tag-to-column`, `develop` reachable.
 3. Execute every `[ ]` in the phase (consult `PLAN.md` / `research/` for detail).
-4. Run the phase's `verify:` — never advance on a checkbox alone; the CLI-drive/sqlite/grep bullets are
-   part of the gate.
-5. Amend this file if reality diverges; STOP and escalate only on a `GOAL.md` contradiction (e.g. a
-   hidden second reader of the `part` tag, or a state-predicate entanglement not seen in research).
-6. Mark P1 `done`, `--touch`; one `[refactor]` commit; stop and report.
+4. Run the phase's `verify:` — never advance on a checkbox alone; the CLI-drive/sqlite/completions
+   bullets are part of the gate.
+5. Amend this file if reality diverges; STOP and escalate only on a `GOAL.md` contradiction.
+6. Mark the phase `done`, advance `current_phase`, `--touch`; one `[refactor]` commit; stop and report.

--- a/spec/part-tag-to-column/TECH.md
+++ b/spec/part-tag-to-column/TECH.md
@@ -1,39 +1,49 @@
 ---
 slug: part-tag-to-column
-title: "Promote `part` from a bookkeeping tag to a first-class column"
+title: Promote `part` from a bookkeeping tag to a first-class column
 kind: refactor
 appetite: small
 status: in_progress
 branch: feature/part-tag-to-column
 base: develop
-current_phase: P1
-last_updated: "2026-07-31"
+current_phase: P2
+last_updated: '2026-07-31'
 phases:
-  - id: P1
-    name: "Data layer: `part` column (visible) + rotatedb via column + same-commit initdb help"
-    status: pending
-    satisfies: [R1, R2, R3, R4, R5, R6, R8]
-    depends_on: []
-    parallel: false
-    hammerable: false
-    hill: uphill
-    verify: "uv run pytest -q && uv run sphinx-build -E -b html docs docs/_build"
-  - id: P2
-    name: "CLI: `--part N` filter on hs list/search + same-commit help snippets + completions"
-    status: pending
-    satisfies: [R9, R7]
-    depends_on: [P1]
-    parallel: false
-    hammerable: false
-    hill: uphill
-    verify: "uv run pytest -q && uv run sphinx-build -E -b html docs docs/_build"
+- id: P1
+  name: 'Data layer: `part` column (visible) + rotatedb via column + same-commit initdb
+    help'
+  status: done
+  satisfies:
+  - R1
+  - R2
+  - R3
+  - R4
+  - R5
+  - R6
+  - R8
+  depends_on: []
+  parallel: false
+  hammerable: false
+  hill: uphill
+  verify: uv run pytest -q && uv run sphinx-build -E -b html docs docs/_build
+- id: P2
+  name: 'CLI: `--part N` filter on hs list/search + same-commit help snippets + completions'
+  status: pending
+  satisfies:
+  - R9
+  - R7
+  depends_on:
+  - P1
+  parallel: false
+  hammerable: false
+  hill: uphill
+  verify: uv run pytest -q && uv run sphinx-build -E -b html docs docs/_build
 review:
-  last_reviewed_commit: ""
+  last_reviewed_commit: ''
   verdict: none
-  blocked_reason: ""
+  blocked_reason: ''
   cycle: 0
 ---
-
 # TECH.md — Promote `part` from a bookkeeping tag to a first-class column
 
 The **context engine and finite-state machine** for building this feature. The YAML frontmatter above
@@ -67,47 +77,51 @@ no longer in the `tag` dict; `rotatedb()` reads/writes the column with no SQLite
 `hs initdb` schema includes it; suite + docs build green. End-to-end verifiable without the CLI filter.
 
 ### Model — `src/hypershell/data/model.py`
-- [ ] Add the column between `fingerprint` (`:299`) and `tag` (`:301`):
+- [x] Add the column between `fingerprint` (`:299`) and `tag` (`:301`):
       `part: Mapped[int] = mapped_column(INTEGER, nullable=False, default=0)` with a one-line declarative
       comment (partition index for SQLite database rotation) (R1, R3).
-- [ ] Add `'part': int` to the `Task.columns` dict (`:303-336`) in the matching position (after
+- [x] Add `'part': int` to the `Task.columns` dict (`:303-336`) in the matching position (after
       `fingerprint`, before `tag`) so `part` is selectable/displayable like `group` (R8).
-- [ ] `Task.new`: change `:387` → `tag = {**(tag or {}), **inline_tags}` (drop `**{'part': 0, }`); leave
+- [x] `Task.new`: change `:387` → `tag = {**(tag or {}), **inline_tags}` (drop `**{'part': 0, }`); leave
       the `Task(...)` constructor as-is (column `default=0` supplies the value; retries → `part=0`) (R2).
-- [ ] `compute_fingerprint`: remove the `if key != 'part'` filter at `:423` (→ `'tags': dict(tags or {})`)
+- [x] `compute_fingerprint`: remove the `if key != 'part'` filter at `:423` (→ `'tags': dict(tags or {})`)
       and fix the docstring at `:414` (R5).
 
 ### Rotation — `src/hypershell/data/__init__.py` (`rotatedb`)
-- [ ] `:139` write → `.update({Task.part: part_id})`; `:147` → `Task.part == part_id`; `:157` →
+- [x] `:139` write → `.update({Task.part: part_id})`; `:147` → `Task.part == part_id`; `:157` →
       `Task.part != part_id` (drop the `json_set` / `Task.tag['part']` / `type_coerce` / `JSON`) (R4).
-- [ ] Remove now-unused `type_coerce`/`JSON` imports **after** grep-confirming they're unused elsewhere
+- [x] Remove now-unused `type_coerce`/`JSON` imports **after** grep-confirming they're unused elsewhere
       in the file (`text` stays — used by `VACUUM`). Leave the `exit_status.isnot(None)` filter (`:138`)
       and `next_rotate_path` untouched; do not touch `auto_union_sqlite`.
 
 ### Docs / help (R7, §12 same-commit)
-- [ ] Update `INITDB_HELP` (`data/__init__.py`) so the `--rotate` description no longer calls `part` a
+- [x] Update `INITDB_HELP` (`data/__init__.py`) so the `--rotate` description no longer calls `part` a
       "special purpose `part:N` tag", and hand-edit the matching `docs/_include/initdb_desc.rst`. (Man
       page is release-time; completions carry no long description → unchanged.)
 
 ### Tests (R7) — `@mark.unit`
-- [ ] `tests/test_source.py:63-67,:86`: drop the hardcoded `{'part': …}` literals from
-      `compute_fingerprint` calls; confirm fingerprints stay stable.
-- [ ] `tests/test_source.py:99-116`: assert `'part'` **is** in `Task.columns` **and** the real `Task`
-      table has a `part` column.
-- [ ] `tests/test_initdb.py::test_rotate` (currently a stub): make it actually rotate — submit + complete
+- [x] `tests/test_source.py:63-67,:86`: drop the hardcoded `{'part': …}` literals from
+      `compute_fingerprint` calls; confirm fingerprints stay stable. (Repurposed the obsolete
+      `excludes_part_tag` test into `test_new_keeps_part_out_of_tag_and_identity`; `:86` → `{}`.)
+- [x] `tests/test_source.py:99-116`: assert `'part'` **is** in `Task.columns` **and** the real `Task`
+      table has a `part` column. (Also added `part` to the raw-insert column list in the index test — a
+      NOT NULL column with only a Python-side default, exactly like `"group"`.)
+- [x] `tests/test_initdb.py::test_rotate` (currently a stub): make it actually rotate — submit + complete
       tasks, run `rotatedb()` / `hs initdb --rotate`, assert completed rows carry the right `part` value,
       land in the partition file, and are dropped from `main`; assert `tag` never contains `part`.
-- [ ] Fix any existing test that asserts an exact column/serialization set now that `part` is in
-      `columns` (grep for surprises; the full-suite verify will surface them).
+- [x] Fix any existing test that asserts an exact column/serialization set now that `part` is in
+      `columns` (grep for surprises; the full-suite verify will surface them). (Only the raw-insert index
+      test needed the NOT NULL column added; full suite 421 passed.)
 
 ### Verify
-- [ ] Frontmatter gate: `uv run pytest -q && uv run sphinx-build -E -b html docs docs/_build` (full suite
-      green; docs build with only the 2 pre-existing baseline toctree warnings).
-- [ ] CLI drive: `.agents/factory/bin/temp_site.sh sh -c 'uv run hs initdb && printf "echo a\necho b\n" | uv run hs submit && uv run hs initdb --rotate && uv run hs list part'` runs clean and `part` shows as a column.
-- [ ] Column + tag-clean (sqlite3 in the same `sh -c`):
-      `sqlite3 "$HYPERSHELL_DATABASE_FILE" "select part from task; select count(*) from task where json_extract(tag,'\$.part') is not null"`
-      → `part=0`, count `0`.
-- [ ] Grep: no `json_set`/`json_extract`/`type_coerce` reference to `part` remains in `src/hypershell`.
+- [x] Frontmatter gate: `uv run pytest -q && uv run sphinx-build -E -b html docs docs/_build` (full suite
+      green — 421 passed; docs build with only the 2 pre-existing baseline toctree warnings).
+- [x] CLI drive: submit tagged tasks, complete two, `hs initdb --rotate --yes`, then `hs list part
+      exit_status args --all` shows `part` as a column (0 in main, 1 in the partition); union count 3,
+      `--ignore-partitions` count 1. (`--rotate` needs `--yes` non-interactively.)
+- [x] Column + tag-clean (sqlite3): `select part from task` → 0 in main, 1 in the partition; no `tag`
+      mentions `part` in either file (count 0).
+- [x] Grep: no `json_set`/`json_extract`/`type_coerce` reference to `part` remains in `src/hypershell`.
 
 **Touches:** `src/hypershell/data/model.py`, `src/hypershell/data/__init__.py`,
 `docs/_include/initdb_desc.rst`, `tests/test_source.py`, `tests/test_initdb.py`.

--- a/spec/part-tag-to-column/TECH.md
+++ b/spec/part-tag-to-column/TECH.md
@@ -3,7 +3,7 @@ slug: part-tag-to-column
 title: Promote `part` from a bookkeeping tag to a first-class column
 kind: refactor
 appetite: small
-status: blocked
+status: in_review
 branch: feature/part-tag-to-column
 base: develop
 current_phase: done
@@ -124,8 +124,22 @@ no longer in the `tag` dict; `rotatedb()` reads/writes the column with no SQLite
       mentions `part` in either file (count 0).
 - [x] Grep: no `json_set`/`json_extract`/`type_coerce` reference to `part` remains in `src/hypershell`.
 
+### F1 remediation (review cycle 1) — R8 display consistency
+Review found R8 only partially met: `part` is in `Task.columns` and selectable by name / `--fields` /
+table / plain / json / csv, but the detailed `NORMAL_MODE_TEMPLATE` (used by `hs info` and bare
+`hs list`) rendered every other column **except** `part`, contradicting R8's "consistent with columns
+like `group`" and its explicit `hs info` example.
+- [x] `src/hypershell/task.py` `NORMAL_MODE_TEMPLATE`: add a `part: {part}` line immediately before the
+      `tags: {tag}` line, mirroring the schema order (`part` is the last column before `tag`). Fixes both
+      `hs info` and the fields-less `hs list` normal view. No new CLI flag → no help-snippet/completion
+      change (`--fields`/`--list-columns` already list `part`).
+- [x] `tests/test_list.py`: add `test_part_in_normal_view` — after a rotate, `hs list --all` (the
+      fields-less normal template; bare `hs list` hits the no-args usage guard) shows `part: 0` for the
+      main row and `part: 1` for the rotated row.
+
 **Touches:** `src/hypershell/data/model.py`, `src/hypershell/data/__init__.py`,
-`docs/_include/initdb_desc.rst`, `tests/test_source.py`, `tests/test_initdb.py`.
+`docs/_include/initdb_desc.rst`, `tests/test_source.py`, `tests/test_initdb.py`,
+`src/hypershell/task.py` (F1), `tests/test_list.py` (F1).
 
 ## Phase P2 — CLI: `--part N` filter on `hs list` / `hs search`
 **Satisfies:** R9 (+ CLI tests/docs of R7) · **Depends on:** P1

--- a/spec/part-tag-to-column/TECH.md
+++ b/spec/part-tag-to-column/TECH.md
@@ -1,0 +1,130 @@
+---
+slug: part-tag-to-column
+title: "Promote `part` from a bookkeeping tag to a first-class column"
+kind: refactor
+appetite: small
+status: in_progress
+branch: feature/part-tag-to-column
+base: develop
+current_phase: P1
+last_updated: "2026-07-31"
+phases:
+  - id: P1
+    name: "Convert `part` to a column (model + rotatedb) with same-commit help/doc + tests"
+    status: pending
+    satisfies: [R1, R2, R3, R4, R5, R6, R7]
+    depends_on: []
+    parallel: false
+    hammerable: false
+    hill: uphill
+    verify: "uv run pytest -q && uv run sphinx-build -E -b html docs docs/_build"
+review:
+  last_reviewed_commit: ""
+  verdict: none
+  blocked_reason: ""
+  cycle: 0
+---
+
+# TECH.md — Promote `part` from a bookkeeping tag to a first-class column
+
+The **context engine and finite-state machine** for building this feature. The YAML
+frontmatter above is the resume ground-truth (read it with
+`uv run python .agents/factory/bin/next_phase.py spec/part-tag-to-column/TECH.md`); the per-phase
+checklist below is the work.
+
+- **Vision / requirements (locked):** [`GOAL.md`](GOAL.md) — R-IDs are the contract.
+- **Authoritative design:** [`PLAN.md`](PLAN.md).
+- **Backing research:** [`research/00-digest.md`](research/00-digest.md) + briefs `01`–`04`.
+
+## Conventions (apply to every phase)
+
+- Invariants and code style come from [`AGENTS.md`](../../AGENTS.md) /
+  [`invariants.md`](../../.agents/factory/invariants.md). Touched sections: **§1** (task lifecycle —
+  `part` is orthogonal to the state predicates; keep state logic in `Task` classmethods), **§10**
+  (schema via `create_all`; forward-only), **§12** (same-commit help/doc snippet; tag tests
+  `@mark.unit`). The one recorded deviation (a real column deliberately omitted from `Task.columns` to
+  stay internal) is in PLAN §3.
+- One atomic commit containing the code, the docs/help snippet, the tests, **and** the `TECH.md` state
+  change. Subject: `[refactor] Build part-tag-to-column P1: …`.
+- **No `Co-Authored-By` trailer** (repo convention).
+- **Coupled core:** `data/model.py` is highest-blast-radius. Change model + `rotatedb` with a single
+  coherent view; do not split them (the model change breaks `rotatedb` until it is updated too).
+
+---
+
+## Phase P1 — Convert `part` to a first-class column
+**Satisfies:** R1, R2, R3, R4, R5, R6 (docs/tests of R7) · **Depends on:** —
+**Goal:** `part` is a real, dialect-neutral `Task` column (created in fresh schema, defaulting to 0),
+no longer stored in the `tag` dict; `rotatedb()` reads/writes the column with no SQLite JSON functions;
+`part` stays internal (off the wire and CLI); the suite and docs build are green. One atomic, end-to-end
+verifiable change.
+
+### Model — `src/hypershell/data/model.py`
+- [ ] Add the column between `fingerprint` (`:299`) and `tag` (`:301`):
+      `part: Mapped[int] = mapped_column(INTEGER, nullable=False, default=0)` with a one-line declarative
+      comment (partition index / SQLite rotation bookkeeping / internal). `INTEGER` is already
+      dialect-neutral (R1, R3).
+- [ ] **Do NOT** add `'part'` to the `Task.columns` dict (`:303-336`) — keeps `part` off
+      `to_dict`/`to_json`/`serialize_tasks`/`--fields`/`hs list` (R5, no-CLI-surface non-goal). See PLAN
+      §3 deviation.
+- [ ] `Task.new`: change `:387` `tag = {**(tag or {}), **inline_tags, **{'part': 0, }}` →
+      `tag = {**(tag or {}), **inline_tags}`. Leave the `Task(...)` constructor (`:404-406`) as-is — the
+      column `default=0` supplies the value; the retry builder (copies `tag`, not `part`) correctly yields
+      `part=0` (R2).
+- [ ] `compute_fingerprint`: remove the `if key != 'part'` filter at `:423` (→ `'tags': dict(tags or {})`)
+      and update the docstring at `:414` (`part` is now a column, not an excluded tag). Byte-identical
+      output (R5).
+
+### Rotation — `src/hypershell/data/__init__.py` (`rotatedb`)
+- [ ] `:139` write → `.update({Task.part: part_id})` (drop the `json_set` text expression) (R4).
+- [ ] `:147` read → `Task.part == part_id`; `:157` read → `Task.part != part_id` (drop
+      `Task.tag['part']`/`type_coerce`/`JSON`) (R4).
+- [ ] Remove the now-unused `type_coerce` / `JSON` imports **after** grep-confirming they are unused
+      elsewhere in the file (`text` stays — used by `VACUUM`). Leave the `exit_status.isnot(None)` filter
+      (`:138`) and `next_rotate_path` untouched. Do not touch `auto_union_sqlite` in `task.py`.
+
+### Docs / help (R7, §12 same-commit)
+- [ ] Update `INITDB_HELP` in `data/__init__.py` (the `--rotate` description that calls `part` a "special
+      purpose `part:N` tag") to reflect that `part` is now an internal column, and regenerate the matching
+      `docs/_include/initdb_desc.rst`. Regenerate the `hs` man page (`share/man/man1/hs.1`) if it carries
+      the initdb description. `--ignore-partitions` help and `docs/database.rst` need no change;
+      completions carry no long descriptions so `share/` completions are unchanged.
+
+### Tests (R7) — `@mark.unit`
+- [ ] `tests/test_source.py:63-67,:86`: drop the hardcoded `{'part': …}` literals from the
+      `compute_fingerprint` calls (the tag no longer carries `part`); confirm fingerprints stay stable.
+- [ ] `tests/test_source.py:99-116`: assert the real `Task` table **has** a `part` column **and** that
+      `'part'` is **absent** from `Task.columns` (locks the internal-only deviation).
+- [ ] `tests/test_initdb.py::test_rotate` (currently a stub): make it actually rotate — submit + complete
+      tasks, run `rotatedb()` (or `hs initdb --rotate`), assert completed rows carry the right `part`
+      column value, land in the partition file, and are dropped from `main`; assert the tag never contains
+      `part`.
+
+### Verify
+- [ ] Frontmatter gate: `uv run pytest -q && uv run sphinx-build -E -b html docs docs/_build` (full suite
+      green; docs build with only the 2 pre-existing baseline toctree warnings).
+- [ ] CLI drive (throwaway site):
+      `.agents/factory/bin/temp_site.sh sh -c 'uv run hs initdb && printf "echo a\necho b\n" | uv run hs submit && uv run hs initdb --rotate && uv run hs list'`
+      runs clean.
+- [ ] Column + tag-clean (sqlite3 inside the same `sh -c`):
+      `sqlite3 "$HYPERSHELL_DATABASE_FILE" "select part from task; select count(*) from task where json_extract(tag,'\$.part') is not null"`
+      → `part=0`, count `0`.
+- [ ] Internal-only: `hs list part` still errors "Invalid field name"; `hs info <id>` shows no `part:` tag.
+- [ ] Grep: no `json_set`/`json_extract`/`type_coerce` reference to `part` remains in `src/hypershell`.
+
+**Touches:** `src/hypershell/data/model.py`, `src/hypershell/data/__init__.py`,
+`docs/_include/initdb_desc.rst` (+ `INITDB_HELP` source), `tests/test_source.py`,
+`tests/test_initdb.py`, and possibly `share/man/man1/hs.1`.
+
+---
+
+## How `hs-build` drives this
+
+1. `next_phase.py` prints the next actionable phase (statuses authoritative).
+2. Pre-flight: clean tree, on `feature/part-tag-to-column`, `develop` reachable.
+3. Execute every `[ ]` in the phase (consult `PLAN.md` / `research/` for detail).
+4. Run the phase's `verify:` — never advance on a checkbox alone; the CLI-drive/sqlite/grep bullets are
+   part of the gate.
+5. Amend this file if reality diverges; STOP and escalate only on a `GOAL.md` contradiction (e.g. a
+   hidden second reader of the `part` tag, or a state-predicate entanglement not seen in research).
+6. Mark P1 `done`, `--touch`; one `[refactor]` commit; stop and report.

--- a/spec/part-tag-to-column/TECH.md
+++ b/spec/part-tag-to-column/TECH.md
@@ -3,7 +3,7 @@ slug: part-tag-to-column
 title: Promote `part` from a bookkeeping tag to a first-class column
 kind: refactor
 appetite: small
-status: in_review
+status: blocked
 branch: feature/part-tag-to-column
 base: develop
 current_phase: done
@@ -39,10 +39,11 @@ phases:
   hill: uphill
   verify: uv run pytest -q && uv run sphinx-build -E -b html docs docs/_build
 review:
-  last_reviewed_commit: ''
-  verdict: none
-  blocked_reason: ''
-  cycle: 0
+  last_reviewed_commit: a3af53941279b9e0d79d81cdb522b1274f04933a
+  verdict: changes-requested
+  blocked_reason: 'R8 partial: part omitted from NORMAL_MODE_TEMPLATE (hs info / bare
+    hs list)'
+  cycle: 1
 ---
 # TECH.md — Promote `part` from a bookkeeping tag to a first-class column
 

--- a/spec/part-tag-to-column/TECH.md
+++ b/spec/part-tag-to-column/TECH.md
@@ -3,10 +3,10 @@ slug: part-tag-to-column
 title: Promote `part` from a bookkeeping tag to a first-class column
 kind: refactor
 appetite: small
-status: in_progress
+status: in_review
 branch: feature/part-tag-to-column
 base: develop
-current_phase: P2
+current_phase: done
 last_updated: '2026-07-31'
 phases:
 - id: P1
@@ -28,7 +28,7 @@ phases:
   verify: uv run pytest -q && uv run sphinx-build -E -b html docs docs/_build
 - id: P2
   name: 'CLI: `--part N` filter on hs list/search + same-commit help snippets + completions'
-  status: pending
+  status: done
   satisfies:
   - R9
   - R7
@@ -133,30 +133,34 @@ rotated partition), with the same-commit help snippets and shell completions upd
 verifiable: rotate, then filter by partition.
 
 ### CLI — `src/hypershell/task.py` (single `TaskSearchApp`)
-- [ ] Add `part_filter: Optional[int] = None` to `SearchableMixin` and
+- [x] Add `part_filter: Optional[int] = None` to `SearchableMixin` and
       `interface.add_argument('--part', type=int, default=None, dest='part_filter')` to `TaskSearchApp`,
-      mirroring the `-g/--group` option (`:465`).
-- [ ] In `__build_filters` (`:513-538`), append `f'part == {self.part_filter}'` when `part_filter is not
-      None` (mirroring the group filter at `:531-532`, `:646-647`). `--part 0` is a valid filter (main
-      partition); absent ⇒ no filter. `--part` is added **once** (list and search are the same app).
+      mirroring the `-g/--group` option. (Added the mixin attr only once; the flag is declared on
+      `TaskSearchApp`, not `TaskUpdateApp` — R9 scopes it to list/search.)
+- [x] In `__build_filters`, append `f'part == {self.part_filter}'` when `part_filter is not
+      None` (mirroring the group filter). `--part 0` is a valid filter (main partition); absent ⇒ no
+      filter. `--part` is added **once** (list and search are the same app).
 
 ### Docs / help / completions (R7, R9, §12 same-commit)
-- [ ] Update `SEARCH_USAGE`/`SEARCH_HELP` (`task.py:554`/`:568`) to document `--part`, and hand-edit
-      `docs/_include/task_search_help.rst` (and `task_search_usage.rst` iff the synopsis changes) — per
-      the `961fb22 [feature] Add --all` precedent.
-- [ ] bash completion `_hs_task_search`: add `--part` to the `all_opts` string (~`:377-380`) (+ optional
-      `--part)` value branch). zsh completion `_hs_list`: add an `_arguments` line mirroring
-      `--ignore-partitions` (~`:422`). Do not touch `hsx`/`hs cluster` completions.
+- [x] Update `SEARCH_USAGE`/`SEARCH_HELP` to document `--part` (synopsis gained `[--part N]`), and
+      hand-edit `docs/_include/task_search_help.rst` **and** `task_search_usage.rst` (synopsis changed).
+- [x] bash completion `_hs_task_search`: added `--part` to `all_opts` + a `--part)` value branch. zsh
+      completion `_hs_list`: added an `_arguments` line after `--group`. Did not touch `hsx`/`hs cluster`.
 
-### Tests (R7) — `@mark.unit`
-- [ ] `tests/test_list.py`: add `--part` cases mirroring existing filter tests — after a rotate,
-      `--part N` returns only partition-N rows, `--part 0` returns the main partition, and omitting it
-      returns all; an out-of-range `--part` returns nothing.
+### Tests (R7)
+- [x] `tests/test_list.py`: added `test_part_filter` — after a rotate, `--part 1` returns partition-1
+      rows, `--part 0` the main partition, omitting it returns all, an out-of-range `--part` returns
+      nothing, `--part` composes with `-t`, and `hs task search --part` behaves identically.
+      (Marked `@mark.integration`, not `@mark.unit` as the P2 header said — the test shells out to the
+      installed CLI/DB, which AGENTS.md §Testing classifies as integration.)
 
 ### Verify
-- [ ] Frontmatter gate: `uv run pytest -q && uv run sphinx-build -E -b html docs docs/_build`.
-- [ ] CLI drive (partition targeting): `.agents/factory/bin/temp_site.sh sh -c "…submit + complete tasks + uv run hs initdb --rotate…; uv run hs list --part 1; uv run hs list --part 0"` returns the right partition subsets.
-- [ ] Completions: `--part` appears in `share/` bash + zsh completions for `hs list`/`hs search`.
+- [x] Frontmatter gate: `uv run pytest -q && uv run sphinx-build -E -b html docs docs/_build` — 422
+      passed; docs build with only the 2 baseline toctree warnings.
+- [x] CLI drive (partition targeting): after rotate, `hs list args --part 1` → partition-1 rows,
+      `--part 0` → main, no `--part` count 4, `--part 1 -t n:0` → one row, `--part 99` → empty,
+      `hs task search --part 1` identical.
+- [x] Completions: `--part` appears in `share/` bash (`all_opts` + value branch) and zsh completions.
 
 **Touches:** `src/hypershell/task.py`, `docs/_include/task_search_help.rst` (± `task_search_usage.rst`),
 `share/` bash + zsh completions, `tests/test_list.py`.

--- a/spec/part-tag-to-column/research/00-digest.md
+++ b/spec/part-tag-to-column/research/00-digest.md
@@ -85,6 +85,41 @@ is the mechanical root of forward-only. `part` never enters via `submit.py` — 
 
 Drive `hs` in a throwaway site via `.agents/factory/bin/temp_site.sh sh -c "…"` (run `sqlite3` inside the
 same `sh -c` — the site is deleted on exit). Prove: (a) submitted task's `part` **column** = 0 and its
-`tag` has no `part`; (b) `hs list part` still "Invalid field name" (internal); (c) `hs initdb --rotate`
-partitions by the column and `hs list` (auto-union) still works; (d) fingerprint unchanged. Docs baseline:
-the 2 pre-existing toctree warnings (`docs/cli/task_submit.rst`, `docs/manual.rst`).
+`tag` has no `part`; (b) `hs initdb --rotate` partitions by the column and `hs list` (auto-union) still
+works; (c) fingerprint unchanged; and (after the reshape) (d) `hs list part` is a valid field and
+`hs list --part N` selects partition N. Docs baseline: the 2 pre-existing toctree warnings
+(`docs/cli/task_submit.rst`, `docs/manual.rst`).
+
+## CLI surface — added after the 2026-07-31 GOAL reshape (briefs 05, 06)
+
+The maintainer reversed the "keep internal" decision: `part` is now a **visible column** (in
+`Task.columns`) and `hs list`/`hs search` gain a `--part` filter (R8, R9).
+
+- **`hs list` and `hs search` are the SAME app** — `TaskSearchApp` (`task.py:601`), registered as `list`
+  (`__init__.py:130`) and `search` (`task.py:1235`). `--part` is added **once**; one help source; one
+  completion function per shell.
+- **Visible field (R8):** field validation checks `name in Task.columns` (`task.py:545-549`); adding
+  `'part'` to `Task.columns` (`model.py:303-336`) makes `hs list part` / `--fields` / `-x` /
+  `hs list --all` treat `part` as a normal column. **This reverses the earlier omit-from-columns
+  deviation** — `part` is now a normal entry, so PLAN's deviation table is empty.
+- **`--part` filter (R9):** add `part_filter: Optional[int] = None` to `SearchableMixin` +
+  `interface.add_argument('--part', type=int, default=None, dest='part_filter')` on `TaskSearchApp`; in
+  `__build_filters` (`task.py:513-538`) append `f'part == {self.part_filter}'` when `part_filter is not
+  None` — mirroring the `-g/--group` filter (`:465`, `:531-532`, `:646-647`). Works because `part` is a
+  real column (`WhereClause.compile` → `getattr(Task,'part')`). `--part 0` is a legitimate filter (the
+  main partition); absent flag = no filter (`is not None` guard).
+- **Auto-union composition:** the union temp view is created in `run()` (`:684-685`) **before**
+  `build_query()` (`:694`), so `WHERE part = N` over the view correctly selects partition N's rows. No
+  ordering issue.
+- **Docs (§12) — hand-maintained, NO generator:** help originates from `SEARCH_USAGE`/`SEARCH_HELP`
+  constants (`task.py:554`/`:568`); the RST includes `docs/_include/task_search_{usage,desc,help}.rst`
+  are hand-authored (there is **no** `list_*` include). Precedent: `961fb22 [feature] Add --all to task
+  list` hand-edited `task_search_desc.rst` + `task_search_help.rst`. Edit by hand.
+- **Completions (§12):** bash `_hs_task_search` (add `--part` to the `all_opts` string, ~`:377-380`, +
+  optional `--part)` value branch); zsh `_hs_list` (add an `_arguments` line mirroring
+  `--ignore-partitions`, ~`:422`). `hsx`/`hs cluster` completions are separate and unaffected.
+- **Man pages / CI:** man pages are regenerated at **release time only** (`sphinx-build -b man`; the
+  `--all` precedent did not touch `share/man/` in the feature commit) — **not** a same-commit
+  obligation. The CI wheel-metadata assertion (`tests.yml:95-113`) checks a fixed path list; adding an
+  option changes file *contents*, not the list, so it stays green.
+- **Tests:** mirror `tests/test_list.py` invocation/assertion patterns for the `--part` cases.

--- a/spec/part-tag-to-column/research/00-digest.md
+++ b/spec/part-tag-to-column/research/00-digest.md
@@ -1,0 +1,90 @@
+# 00 — Research digest (consolidated decisions)
+
+Synthesis of briefs `01`–`04`. Each decision below is the single recommendation the design commits to;
+where briefs disagreed, the resolution is called out.
+
+## What `part` actually is (briefs 01, 02)
+
+- Born as `0` on **every** task via `data/model.py:387` (`{'part': 0}` merged into the `tag` JSON dict).
+- Set non-zero **only** by `rotatedb()` (`data/__init__.py:130-160`), invoked by **`hs initdb --rotate`**
+  — a **manual, SQLite-only** maintenance command. There is **no config-driven / automatic** DB
+  rotation (the `rotate` config key is for *log* files only, brief 03).
+- `part_id` for a rotation = highest existing `main.N` partition **filename** suffix + 1
+  (`next_rotate_path`, `:163-174`) — derived from the filesystem, never from a stored value.
+
+## The R4 targets — exactly three expressions (brief 01, ground-truthed)
+
+In `rotatedb()`:
+- **write** `:139` — `.update({Task.tag: text("json_set(task.tag, '$.part', :v)") …})` → `.update({Task.part: part_id})`
+- **read** `:147` — `Task.tag['part'] == type_coerce(part_id, JSON)` → `Task.part == part_id`
+- **read** `:157` — `Task.tag['part'] != type_coerce(part_id, JSON)` → `Task.part != part_id`
+
+After these, `type_coerce` / `JSON` become unused **in `data/__init__.py`** (grep-confirm before removing;
+`text` stays — used by the `VACUUM` statements at `:146,:153,:159`). The `exit_status.isnot(None)` filter
+(`:138`) is preserved verbatim — not part of this change.
+
+## The auto-union is NOT a target (brief 01) — but it is the forward-only hazard (brief 03)
+
+`auto_union_sqlite` (`task.py:839-859`) attaches partition files as `part_{i+1}` (a **positional
+filesystem index, unrelated to the `part` value**) and does `SELECT * … UNION ALL SELECT *`. It never
+reads `part`, so **no change needed**. But `SELECT *` is column-count-sensitive: a new-schema `main`
+(with the `part` column) unioned against an **old** partition file (created before this change, lacking
+the column) raises a column-count mismatch → `hs list/search/info` break until `--ignore-partitions`.
+This is the concrete meaning of "forward-only / may require re-init" (already a GOAL non-goal). New
+rotations are self-consistent: `VACUUM INTO` copies the current schema, so post-change `main.N` files
+carry the column.
+
+## Model change (briefs 02, 04, ground-truthed)
+
+- **Insertion point (R1):** between `fingerprint` (`model.py:299`) and `tag` (`:301`, the current last
+  column, `# kept last (export/print order)`).
+- **Definition (R1, R3):** `part: Mapped[int] = mapped_column(INTEGER, nullable=False, default=0)`.
+  `INTEGER` (`model.py:96`) is already dialect-neutral (SQLite/PG `INTEGER`); no `with_variant`. `part`
+  is not a SQL reserved word, so (unlike `group`) it needs no `quote=`.
+- **`Task.new` (R2):** delete `**{'part': 0, }` from the `:387` merge → `tag = {**(tag or {}), **inline_tags}`.
+  The `Task(...)` constructor (`:404-406`) needs no `part=` — the column `default=0` supplies it, and the
+  retry builder (copies `tag`, not `part`) correctly yields `part=0` for new retry rows.
+- **Fingerprint (R5):** delete `if key != 'part'` at `:423` (→ `'tags': dict(tags or {})`) and fix the
+  docstring at `:414`. Byte-identical, since `part` no longer exists in the tag dict the function
+  receives.
+
+### Contradiction resolved — the `columns` dict (brief 02 vs brief 04)
+
+Brief 02 said add `'part': int` to the parallel `columns` dict (`model.py:303-336`); brief 04 said **do
+not**. **Resolution: DO NOT add it.** That dict is the allowlist driving `to_dict`/`to_json`/`from_dict`/
+`repr`/`serialize_tasks` **and** CLI field validation / `--fields` / `hs list`. Adding `part` there would
+expose it on the wire and in the CLI — violating **R5** ("not in user-facing output") and the **no-CLI-
+surface non-goal**. So `part` is a real mapped column (→ real DB column, R1/R6) that is **deliberately
+absent** from `columns` (→ internal-only). `rotatedb` reads it via the ORM attribute `Task.part`,
+independent of that dict. This asymmetry is the one deliberate complexity — recorded in PLAN §3.
+
+## Schema / forward-only (brief 03)
+
+`initdb()` = `Entity.metadata.create_all(engine)` (`data/__init__.py:65`); adding the mapped column makes
+it appear in a **fresh** DB with zero extra work (R6). `create_all(checkfirst=True)` never `ALTER`s, which
+is the mechanical root of forward-only. `part` never enters via `submit.py` — only via `Task.new`.
+
+## Tests & docs (brief 04)
+
+- **Will break, must update:** `tests/test_source.py:63-67,:86` hardcode `{'part': …}` into
+  `compute_fingerprint` calls. `tests/test_source.py:99-116` (column subset check) is where to assert the
+  real table has `part` **and** that `part` is absent from `Task.columns`.
+- **Stub to fill:** `tests/test_initdb.py:67-82` `test_rotate` currently submits 4 tasks and never
+  rotates — the natural home for real column-based rotation coverage (R4).
+- **Docs (§12 same-commit):** `docs/_include/initdb_desc.rst:7-8` ("applies a special purpose `part:N`
+  **tag**") is generated from `INITDB_HELP` (`data/__init__.py:~190`). Edit both together; `part` is no
+  longer a tag. `--ignore-partitions` help and `docs/database.rst` reference file numbering, not the tag →
+  no change. Completions don't carry the description → no `share/` completion change; regenerate the man
+  page if it carries the initdb text.
+- **Behavioral note (deliberate, document in PLAN):** removing the `:387` clobber means a user
+  `-t part:5` would now persist as an ordinary user tag (previously it was silently overwritten to 0).
+  This is consistent with "tags are user annotations again" — `part`-in-tag is now inert w.r.t. rotation,
+  which reads the column. No special reservation added.
+
+## Verification (brief 04)
+
+Drive `hs` in a throwaway site via `.agents/factory/bin/temp_site.sh sh -c "…"` (run `sqlite3` inside the
+same `sh -c` — the site is deleted on exit). Prove: (a) submitted task's `part` **column** = 0 and its
+`tag` has no `part`; (b) `hs list part` still "Invalid field name" (internal); (c) `hs initdb --rotate`
+partitions by the column and `hs list` (auto-union) still works; (d) fingerprint unchanged. Docs baseline:
+the 2 pre-existing toctree warnings (`docs/cli/task_submit.rst`, `docs/manual.rst`).

--- a/spec/part-tag-to-column/research/01-part-lifecycle-and-partition-mechanism.md
+++ b/spec/part-tag-to-column/research/01-part-lifecycle-and-partition-mechanism.md
@@ -1,0 +1,168 @@
+# `part` lifecycle & the SQLite partition / rotation mechanism
+
+## Summary
+
+`part` is a **bookkeeping integer** that tracks which "database partition" a completed
+task belongs to. It is born as `0` on every task and only becomes non-zero during the
+**manual, SQLite-only** `hs initdb --rotate` operation, which splits completed tasks out
+into a sibling file (`main.db` → `main.1`, `main.2`, …). The `hs list` / `hs search`
+commands then transparently re-union those partition files at read time
+(`auto_union_sqlite`). Today `part` lives *inside* the `Task.tag` JSON dict, so both the
+write (`json_set`) and the two reads (`Task.tag['part']` → SQLite `json_extract`) go
+through SQLite JSON functions. Converting `part` to a real column collapses all of that
+to plain column reads/writes. **`part` has exactly one writer of non-zero values
+(`rotatedb`) and exactly two readers (both in `rotatedb`); the auto-union does NOT read
+`part` at all.** On PostgreSQL `part` is pure dead weight — written but never read.
+
+---
+
+## Write sites
+
+1. **Birth (always `0`)** — `data/model.py:387`, in `Task.new`:
+   ```python
+   tag = {**(tag or {}), **inline_tags, **{'part': 0, }}
+   ```
+   Every task created gets `part: 0` merged into its tag dict. This is the *only* place
+   `part` enters normal task creation. It is never set to anything but `0` here.
+
+2. **Rotation stamp (non-zero)** — `data/__init__.py:139`, in `rotatedb()`:
+   ```python
+   (Session.query(Task)
+        .filter(Task.exit_status.isnot(None))
+        .update({Task.tag: text('json_set(task.tag, :k, :v)').params({'k': '$.part', 'v': part_id})}))
+   ```
+   All **completed** tasks (`exit_status IS NOT NULL`) are stamped with the next
+   partition id `part_id` (an integer from `next_rotate_path`, `data/__init__.py:130`,
+   `:163-174`). This is the *only* incrementer — `part_id` is derived from the highest
+   existing `main.N` file suffix + 1, **not** from any stored `part` value.
+
+No other write sites exist (verified across `server.py`, `submit.py`, `client.py`, `task.py`).
+
+## Read sites
+
+Both live inside `rotatedb()` (`data/__init__.py`) and both go through SQLite JSON indexing:
+
+- `data/__init__.py:147`
+  ```python
+  count_deleted = Session.query(Task).filter(Task.tag['part'] == type_coerce(part_id, JSON)).delete()
+  ```
+  Drops the just-stamped completed tasks from the **main** DB.
+
+- `data/__init__.py:157` (on the freshly-cloned partition file, via a separate engine/session)
+  ```python
+  count_deleted = external_session.query(Task).filter(Task.tag['part'] != type_coerce(part_id, JSON)).delete()
+  ```
+  Drops everything that *doesn't* belong to this partition from the **new** file.
+
+`Task.tag['part']` compiles, on SQLite, to a `json_extract(task.tag, '$.part')`
+expression (SQLAlchemy also wraps tag-key lookups in `json_quote`, per the explicit NOTE
+at `task.py:487-489`). This is the exact "complicated SQLite JSON syntax" the change targets.
+
+**Fingerprint exclusions (read of the key name, not a query):** `data/model.py:414` and
+`:423` deliberately drop `'part'` from the tag dict before hashing:
+```python
+'tags': {key: value for key, value in (tags or {}).items() if key != 'part'}
+```
+Once `part` is a column and no longer injected into `tag`, this `!= 'part'` guard becomes
+dead (harmless) code — a candidate cleanup, not required by R4.
+
+## The partition / rotation mechanism explained
+
+There are **two halves**, both SQLite-only, with **no automatic driver** (no config knob;
+the only `rotate` config key, `core/config.py:109`, is the *logging* file-rotation policy — unrelated).
+
+**(A) Split — `rotatedb()` (`data/__init__.py:124-160`), invoked by `hs initdb --rotate`**
+(`InitDBApp.run`, `data/__init__.py:239-242`; guarded to SQLite at `:127-128` and `:260-261`):
+1. `next_rotate_path()` (`:163-174`) enumerates the DB directory and picks the next integer
+   suffix: `main.db` → `main.1`, `main.2`, … The returned `n` **is** the new `part_id`.
+2. Stamp all completed tasks with `part = n` (write site above).
+3. `VACUUM INTO :path` (`:146`) clones the *entire* DB to `main.n`.
+4. Delete the stamped rows from main (`:147`); `VACUUM` main (`:153`).
+5. Open `main.n` with a fresh engine (`:156`) and delete every row whose `part != n`
+   (`:157`), then `VACUUM` it. Net result: `main.n` holds exactly the completed tasks with
+   `part == n`; main keeps everything else (all still `part == 0`).
+
+So **each partition file contains rows that all share one `part` value equal to the file's
+numeric suffix.** The `part` column is what makes the two delete steps precise (avoiding a
+race where tasks complete between the clone and the drop — see the comment at `:133-135`).
+
+**(B) Re-union at read time — `auto_union_sqlite()` (`task.py:839-867`)**, called by
+`hs list` (`TaskListApp`, `task.py:191-192`) and `hs search` (`task.py:684-685`) unless
+`-i/--ignore-partitions` is passed (`task.py:148,178-179`; `:596,672-673`):
+```python
+parts = sorted([... for filename in os.listdir(dirname)
+                if re.match(f'^{basename}.[0-9]+$', filename)],
+               key=(lambda fn: int(fn.split('.')[-1])))
+...
+Session.execute(text(f"attach database '{path}' as 'part_{i+1}'"))
+...
+SQLITE_UNION_PART + '\n'.join([f'union all\nselect * from part_{i+1}.task' ...])
+```
+where `SQLITE_UNION_PART` (`task.py:864-867`) is `create temp view 'task' as select * from main.task`.
+
+**Key finding — the attach alias `part_{i+1}` is unrelated to the `part` tag/column value.**
+Partitions are discovered purely by **filesystem** globbing (`main.N` regex), sorted by
+suffix; `part_{i+1}` is just a positional ATTACH alias (1-based enumeration index), *not*
+the stored `part` number, and the union does **not filter or reference `part` at all** —
+it blindly `union all`s every partition's `task` table into a temp view. Because
+`select *` is used, adding a `part` column is transparent: all files share the schema, so
+the union keeps working unchanged after the migration.
+
+## Exact simplification opportunities for R4
+
+R4: read/compare `part` from the **column**, drop SQLite JSON functions for `part`,
+preserve behavior. Three concrete edits:
+
+1. **`data/model.py:387`** — stop injecting into tag; set the column instead. The
+   `{'part': 0}` merge is removed and `part` becomes a `mapped_column(..., default=0,
+   nullable=False)` placed **after `fingerprint` (`:299`) and before `tag` (`:301`)**, and
+   added to the `columns` dict **before `'tag'`** (`:335`) so serialization/print order is
+   preserved (`to_dict`/`to_json` iterate `columns`, `data/model.py:130-134`).
+
+2. **`data/__init__.py:139`** (write) —
+   `... .update({Task.tag: text('json_set(task.tag, :k, :v)')...})`
+   becomes plainly `... .update({Task.part: part_id})`. No `json_set`.
+
+3. **`data/__init__.py:147` and `:157`** (reads) —
+   `Task.tag['part'] == type_coerce(part_id, JSON)` → `Task.part == part_id`
+   `Task.tag['part'] != type_coerce(part_id, JSON)` → `Task.part != part_id`
+   No `json_extract`/`json_quote`, no `type_coerce`/`JSON` import needed for these lines.
+
+`auto_union_sqlite` (`task.py:839+`) needs **no change** — it neither reads nor writes
+`part` (it relies on `select *` + filesystem discovery). Same for `--ignore-partitions`.
+
+## Dialect notes
+
+- `tag` is `JSON = JSON_TEXT().with_variant(JSON_BYTES(), 'postgresql')` (`data/model.py:101`)
+  — i.e. **TEXT-backed JSON on SQLite, JSONB on PostgreSQL**. That is why the current reads
+  need `json_extract` (SQLite) vs the `Task.tag[name]` operator SQLAlchemy would emit for
+  JSONB — see the parallel dialect split at `task.py:486-495`, `:709-717`, `:724-733`,
+  `:1113-1128`.
+- **The entire rotation/partition feature is SQLite-only.** `rotatedb` raises for non-SQLite
+  (`data/__init__.py:127-128`), `InitDBApp.check_arguments` rejects `--rotate` on non-SQLite
+  (`:260-261`), and `auto_union_sqlite` early-returns unless SQLite (`task.py:841-842`).
+- Consequence: on **PostgreSQL, `part` is written (`part:0` in JSONB) but never read** — it
+  is dead payload today. Promoting it to a column is a small storage/clarity win there and a
+  correctness/simplicity win on SQLite; a real `SMALL_INTEGER`/`INTEGER` column works
+  identically on both dialects.
+
+## Open questions / risks
+
+- **Column type & nullability:** current values are only ever `0` or a small positive
+  suffix — `SMALL_INTEGER` (as used for `attempt`/`exit_status`, `data/model.py:283,289`)
+  with `default=0, nullable=False` matches the existing "always present" semantics. Confirm
+  `default=0` covers rows created by `serialize_tasks`/queue round-trips (JSON-sourced tasks
+  go through `Task.new`, so they get the default).
+- **Migration of existing DBs:** existing SQLite files (main + any `main.N` partitions) have
+  `part` only inside `tag` JSON and **no `part` column**. `initdb` uses
+  `create_all` (`data/__init__.py:65`) which does **not** ALTER existing tables — there is no
+  migration framework here. After the change, an old partition file attached by
+  `auto_union_sqlite` would lack the `part` column, so `select * ... union all` would fail on
+  a column-count mismatch. This is the main behavioral risk and likely needs either an
+  ADD COLUMN step or an accepted "fresh DB only" boundary — flag for the plan.
+- **`type_coerce(..., JSON)` import:** if `:147/:157` are the last JSON uses in
+  `data/__init__.py`, the `type_coerce`/`JSON` imports (`data/__init__.py:20,31`) may become
+  removable (verify against `vacuumdb`/others — they don't use them).
+- **Print/export order:** R-goal says "immediately before `tag`". Verify the man pages,
+  `docs/_include/*.rst`, and shell completions under `share/` that enumerate task fields are
+  updated in lockstep (AGENTS.md same-commit rule).

--- a/spec/part-tag-to-column/research/02-task-model-column-and-fingerprint.md
+++ b/spec/part-tag-to-column/research/02-task-model-column-and-fingerprint.md
@@ -1,0 +1,146 @@
+# Research 02 — `Task` model: `part` column, placement, and fingerprint
+
+**Scope:** `src/hypershell/data/model.py` (Task ORM, `Task.new`, fingerprint) + `data/core.py`
+type/dialect handling. Covers R1, R2, R3, R5. Read-only; no files edited.
+
+## Summary
+
+`part` today is injected into every task's `tag` dict as `{'part': 0}` in `Task.new`
+(`model.py:387`) and filtered back out of the identity fingerprint (`model.py:423`). Promoting
+it to a column is mechanically small and low-risk **inside the model**: add one integer column
+between `fingerprint` and `tag`, add one entry to the `columns` dict, drop the `{'part': 0}`
+merge, and drop the `key != 'part'` filter (which then becomes a no-op). Serialization,
+`to_dict`/`to_json`/`from_dict`, and `repr` all key off the `columns` dict, so they flow through
+automatically once that dict is updated. The fingerprint value is unchanged. The heavy
+downstream coupling is **not** in the model — it is the SQLite rotation logic in
+`data/__init__.py` (`rotatedb`, R4), which is a separate research item.
+
+## Ordered `Task` column list + insertion point
+
+Columns are declared `model.py:259-301`, in this order:
+`id, group, args, submit_id, submit_time, submit_host, cores, memory, cores_max, memory_max,
+timeout, server_id, server_host, schedule_time, client_id, client_host, command, start_time,
+completion_time, exit_status, outpath, errpath, csvpath, attempt, retried, waited, duration,
+previous_id, next_id, source, fingerprint, tag`.
+
+The **current last column is `tag`** (`model.py:301`):
+
+```python
+tag: Mapped[dict] = mapped_column(JSON, nullable=False, default={})  # kept last (export/print order)
+```
+
+The column immediately before it is `fingerprint` (`model.py:299`). **Insertion point: a new
+`part` line between `fingerprint` (`:299`) and `tag` (`:301`)** — i.e. `part` becomes the last
+column *before* `tag`, satisfying R1.
+
+The parallel `columns` dict (`model.py:303-336`) mirrors this order and ends
+`... 'source': str, 'fingerprint': str, 'tag': dict`. A `'part': int` entry must be inserted
+between `'fingerprint'` and `'tag'` — this is the one **manual** list that does not update itself.
+
+## Dialect-neutral type + recommended `part` column
+
+Pre-defined types (`model.py:93-101`):
+
+```python
+INTEGER = Integer()
+SMALL_INTEGER = Integer().with_variant(SMALLINT, 'postgresql')
+JSON = JSON_TEXT().with_variant(JSON_BYTES(), 'postgresql')   # the tag column's type
+```
+
+`tag` uses `JSON` (`Column(JSON)`), which is `sqlalchemy JSON` on SQLite and `JSONB` on
+PostgreSQL via `with_variant`. `with_variant` is the repo's dialect-neutrality pattern, but for a
+plain integer no variant is even needed: `INTEGER = Integer()` already maps to SQLite `INTEGER`
+and PostgreSQL `INTEGER` — fully dialect-neutral, no SQLite-only construct (R3 met trivially).
+
+The closest analogue is `group` (`model.py:260`), the other partition/bookkeeping index, which is
+`INTEGER, nullable=False, default=DEFAULT_TASK_GROUP`. (`group` additionally carries
+`quote=True, name='group'` **only** because `group` is a SQL reserved word — `part` is not
+reserved in SQLite or PostgreSQL, so no quoting is needed.) `attempt`/`exit_status`/`cores` use
+`SMALL_INTEGER`; either type is dialect-neutral.
+
+**Recommended definition** (matches `group`, immutable default, non-null):
+
+```python
+part: Mapped[int] = mapped_column(INTEGER, nullable=False, default=0)  # kept last before `tag`
+```
+
+Optional polish consistent with `DEFAULT_TASK_GROUP` (`model.py:46`): add
+`DEFAULT_TASK_PART: Final[int] = 0` and use it as the default, avoiding a magic literal. A
+Python-side `default=` (not `server_default=`) matches every other column and is sufficient —
+`Task.new` always sets `part`, and the schema is forward-only (R6; no migration).
+
+## `Task.new` / tag-assembly change (`model.py:357-406`)
+
+Current merge (`model.py:387`):
+
+```python
+tag = {**(tag or {}), **inline_tags, **{'part': 0, }}
+```
+
+Change to drop the injection:
+
+```python
+tag = {**(tag or {}), **inline_tags}
+```
+
+and set `part` at construction (`model.py:404-406`), either via a new `part: int = 0` kwarg or by
+relying on the column default. The constructor becomes `Task(id=uuid(), ..., tag=tag,
+part=part, **other)`. Because `part` has a column default of `0`, simply omitting it also yields
+`0`; an explicit `part=0` kwarg is clearer and lets the retry path forward it.
+
+**Callers of `Task.new`** (all pass `tag=`, none pass `part`): `submit.py:351, 382, 1363`;
+`task.py:101, 425`; and the retry builder `__schedule_next_failed_tasks` (`model.py:620-627`),
+which copies `tag=task.tag, ...` but not part. With the injection removed, `task.tag` no longer
+carries part, so the retry needs no part forwarding — a retried (failed, uncompleted) row in the
+main DB always has `part=0` (rotation drops rotated rows out of main), so `default=0` preserves
+today's behavior. No signature change is forced on callers.
+
+## Fingerprint change (`model.py:408-426`)
+
+The exclusion lives in `compute_fingerprint` (`model.py:420-424`):
+
+```python
+payload = json.dumps(
+    {'args': raw_command,
+     'group': group,
+     'tags': {key: value for key, value in (tags or {}).items() if key != 'part'}},
+    sort_keys=True, separators=(',', ':'), ensure_ascii=False,
+)
+```
+
+Once `part` is no longer merged into `tag`, the `tags` dict passed here never contains `part`, so
+`{... if key != 'part'}` is equivalent to `{... for ...}`. **Removing the filter yields byte-
+identical payloads and hashes** (R5 preserved). `compute_fingerprint`'s signature stays the same
+— `part` must **not** become a parameter (it deliberately does not participate in identity).
+
+## Serialization / dict / schema-reflecting touchpoints
+
+`to_tuple`/`to_dict`/`to_json`/`__repr__` (`model.py:119-134`) all iterate `self.columns`;
+`from_dict`/`from_json` (`:137-144`) call `cls(**data)`; `serialize_tasks`/`deserialize_tasks`
+(`:237-245`) go through `to_json`/`from_json`. **All of these pick up `part` automatically once
+it is added to the `columns` dict** — no per-method edits. `part` will then appear in the JSON
+wire payload sent to clients, which is harmless (a column, not a user tag). The only manual
+serialization edit is the `columns` dict entry.
+
+## Lifecycle orthogonality (§1 invariant)
+
+`part` is independent of the state predicates (`schedule_time`, `completion_time`, `exit_status`)
+and appears in **no** state/selection query in `model.py` — only in rotation. It does not belong
+in `select_new`/`select_failed`/`next`/`revert_*`/`increment_group` etc. Confirmed orthogonal.
+
+## Open questions / cross-references (outside this brief's scope)
+
+- **R4 (separate item):** `data/__init__.py rotatedb` is the real consumer — it *writes* part
+  into tag JSON via `json_set(task.tag, '$.part', part_id)` (`data/__init__.py:139`) and *reads*
+  it via `Task.tag['part'] == type_coerce(part_id, JSON)` (`:147`) and `!=` (`:157`). These must
+  move to the `part` **column** (plain `Task.part == part_id`), dropping the JSON functions.
+- **R5 user-facing output:** the tag search/list paths in `task.py` (`:487-495`, `:720-733`)
+  read arbitrary tag keys via `json_extract`/`Task.tag[name]`. They need **no change** — with
+  part gone from `tag`, they simply stop matching/listing `part`, which is the desired outcome.
+- **R7 tests:** `tests/test_source.py:64-66` and `:86` pass `{'part': 0}`/`{'part': 7}` into
+  `compute_fingerprint` to assert part-in-tag doesn't shift identity. After the filter is
+  removed, passing `part` in the tag dict *would* alter the hash — those tests must be rewritten
+  to reflect that part no longer lives in `tag` (and new coverage: part-column set on submit,
+  absent from `tag`, excluded from fingerprint).
+- Naming: consider `DEFAULT_TASK_PART` constant for parity with `DEFAULT_TASK_GROUP`. `part` is
+  not a reserved word, so no `quote=True`/`name=` needed (unlike `group`).

--- a/spec/part-tag-to-column/research/03-initdb-submit-and-config.md
+++ b/spec/part-tag-to-column/research/03-initdb-submit-and-config.md
@@ -1,0 +1,158 @@
+# Research 03 — Schema creation, submit/ingest path, config, and the forward-only boundary
+
+**Scope:** how a fresh DB gets its schema, how `part` enters on submit today, what config knobs
+touch partitioning, and precisely what breaks when new (`part`-column) code meets an old
+(`part`-in-tag) SQLite DB. Read-only; no migration is designed here (out of scope per GOAL).
+
+## Summary
+
+Adding a `Column` to the `Task` model is **all that is required** for a fresh DB to get the
+`part` column — `initdb()` just calls `Entity.metadata.create_all(engine)`, which reflects the
+model. `part` does **not** enter through `submit.py` at all: the submit/loader path only carries
+user `tag`/`cores`/`memory`/`group`; the `{'part': 0}` injection happens solely inside
+`Task.new` (`data/model.py:387`). There are **no config knobs** for `part`/DB-partitioning
+(the `rotate` key in config is for *log* files). Forward-only means: run new code against an old
+SQLite DB and the first `INSERT`/`SELECT` touching `part` raises `OperationalError` — and the
+auto-union will break with a column-count mismatch when a new-schema `main` is unioned with
+old-schema partition files.
+
+## Schema creation / `InitDBApp` (`data/core.py`, `data/__init__.py`)
+
+Engine + session are built **at import** in `data/core.py:266-269`:
+
+```python
+engine = get_engine()
+factory = sessionmaker(bind=engine)
+Session = scoped_session(factory)
+```
+
+SQLite `check_same_thread=False` is injected at `data/core.py:213-214`:
+
+```python
+if 'check_same_thread' not in connect_args:
+    connect_args['check_same_thread'] = False
+```
+
+Table creation is entirely reflective — `data/__init__.py:63-65`:
+
+```python
+def initdb(optimize: bool = False) -> None:
+    """Initialize database tables."""
+    Entity.metadata.create_all(engine)
+```
+
+`truncatedb()` (`:76-78`) does `drop_all` then `create_all`. **Adding a `Column` to `Task`
+appears automatically in any fresh DB with no extra work** — `create_all` emits `CREATE TABLE`
+from the declarative metadata. Crucially, `create_all` defaults to `checkfirst=True`: it creates
+only *absent* tables and **never `ALTER`s an existing table to add a column**. So re-running
+`hs initdb` on a DB that already has a `task` table is a no-op for that table — this is the
+mechanical root of "forward-only." `checkdb()` (`:82-85`) only asserts the `task` table exists,
+not its columns. `InitDBApp.run` (`:246-252`) auto-inits for SQLite and prompts otherwise.
+
+Column type note (R3): the model already uses dialect-neutral `.with_variant` types (e.g.
+`SMALL_INTEGER`, `data/model.py:97`); a `part` column should follow that pattern, e.g.
+`mapped_column(SMALL_INTEGER, nullable=False, default=0)`, matching `group` at
+`data/model.py:260`.
+
+## Submit / ingest path — `part` enters only in `Task.new`
+
+The loader builds every task via `Task.new` (`submit.py:351-353` for line tasks, `382-384` for
+JSON records) passing only `args/raw_args/source/cores/memory/timeout/group/tag`. `SubmitApp`
+single-task path is the same (`submit.py:1363-1364`). **No submit-path code writes `part`.**
+
+`part` is injected inside the model, `data/model.py:387`:
+
+```python
+tag = {**(tag or {}), **inline_tags, **{'part': 0, }}
+```
+
+and then excluded from the fingerprint, `data/model.py:423`:
+
+```python
+'tags': {key: value for key, value in (tags or {}).items() if key != 'part'}},
+```
+
+**Can `part` be user-supplied via `-t/--tag`?** In DB mode tags are parsed by
+`Task.ensure_valid_tag` (`submit.py:1378-1384`) with no `part` reservation — a user *could* pass
+`-t part:5`, but line 387's `**{'part': 0}` unconditionally overwrites it, so it is always
+clobbered to `0`. After this change (R2/R5) `part` must move to the column and the `{'part': 0}`
+merge is removed; a stray user `part:` tag would then survive in `tag` unless separately guarded
+(the GOAL keeps `part` internal — worth flagging in TECH whether to strip/reject a user `part`
+key). Inline `# HYPERSHELL:` tags are parsed by `Task.split_argline` (`data/model.py:428-444`)
+and merged the same way. Per AGENTS.md, **submit queue-mode silently ignores `-t/--tag`** (group
+stays `None`); tag/`part` resolution happens entirely in `Task.new`, confirming the column change
+lives in the model, not the submit plumbing.
+
+## Config knobs
+
+**None for `part` / DB partitioning.** `default['database']` is just `{'provider': 'sqlite'}`
+(`core/config.py:91-93`). The only `rotate` knob is for **logging** file rotation
+(`core/config.py:109`: `'rotate': 'never'`), unrelated to `rotatedb()`. DB rotation is a manual
+action (`hs initdb --rotate`, `data/__init__.py:239-242`) with no size/threshold config — so no
+config defaults need touching for this feature.
+
+## Forward-only failure-mode analysis (informs the non-goal)
+
+Given an **old** SQLite DB whose `task` table has no `part` column, running new code:
+
+1. **`hs initdb` does not fix it.** `create_all(checkfirst=True)` leaves the existing `task`
+   table untouched — no column is added. (`data/__init__.py:65`.)
+2. **INSERT fails.** `Task.new` will populate the new `part` column, so `Task.add`/`add_all`
+   (`data/model.py:173-191`) emits `INSERT INTO task (..., part, ...) VALUES(...)` →
+   SQLite `OperationalError: table task has no column named part`. First submit fails.
+3. **SELECT fails.** Any query referencing the column — the rewritten partition/rotation logic
+   (currently `Task.tag['part']` at `data/__init__.py:147,157`; after R4 a `Task.part` filter),
+   or a `SELECT *`/ORM load that maps `part` — raises `OperationalError: no such column:
+   task.part` at query time.
+
+This is exactly "may require re-initialization": the DB must be recreated (`initdb` on a fresh
+file, or `--truncate`) to gain the column. No auto-add is in scope.
+
+### Auto-union column-count mismatch (the subtle one)
+
+`auto_union_sqlite()` (`task.py:839-860`) attaches every `main.N` partition file and builds a
+temp view:
+
+```python
+Session.execute(text(f'attach database \'{path}\' as \'part_{i+1}\''))
+...
+SQLITE_UNION_PART + '\n'.join([f'union all\nselect * from part_{i+1}.task' ...])
+```
+
+with `SQLITE_UNION_PART = "create temp view 'task' as \nselect * from main.task\n"`
+(`task.py:864-867`). This is `SELECT * FROM main.task UNION ALL SELECT * FROM part_i.task`.
+**`UNION ALL` requires identical column counts.** If `main` is re-initialized to the new schema
+(has `part`) but pre-existing partition files were produced by `--rotate` under the old schema
+(no `part` column), the branches differ by one column →
+`OperationalError: SELECTs to the left and right of UNION ALL do not have the same number of
+result columns`, and `hs list`/`hs search`/`hs info` (which call `auto_union_sqlite`,
+`task.py:191-192,684-685`) break until `--ignore-partitions` is passed. `rotatedb`
+(`data/__init__.py:124-160`) clones `main` via `VACUUM INTO`, so *new* partitions inherit the new
+schema and are consistent — the mismatch is strictly a legacy-partition-file problem. This is the
+concrete edge that makes the forward-only boundary "old partition files may need re-rotation or
+`--ignore-partitions`," and it is why `SELECT *` here is fragile to column changes.
+
+## Tests affected (fixtures constructing tasks/DBs)
+
+- `tests/test_source.py:100-134` — `test_fresh_schema_creates_source_table_columns_and_indices`
+  asserts `insp.get_columns('task')`; a new `part` column changes the column set (currently only
+  checks `{'source','fingerprint'} <= task_columns`, so likely still passes, but a new R7 test
+  should assert `part` is present). `:64-66` asserts `part` is fingerprint-neutral (must stay
+  green). `:83-86` builds the expected fingerprint with `{'part': 0}` — **will need updating**
+  once `part` leaves the tag dict (the fingerprint payload no longer contains `part`).
+- `tests/test_initdb.py:67-83` — `test_rotate` (integration) exercises `initdb`→`submit`→rotate;
+  covers the partition path end-to-end and must stay green after R4 rewrites the queries.
+- `tests/test_submit.py:230-238`, `tests/test_client.py:32-40` — construct via `Task.new`;
+  benign but exercise the injection site.
+- `tests/__init__.py:59-76` (`create_taskfile_echo`, etc.) and `conftest.py:49 temp_site` are the
+  standard fixtures; no `part` assumptions.
+
+## Open questions for TECH
+
+1. With `{'part': 0}` removed, should a user-supplied `-t part:...` / inline `part:` tag be
+   stripped or rejected to keep `part` internal (R2/R5)? Today it is silently clobbered.
+2. Default form: `SMALL_INTEGER, nullable=False, default=0` (mirroring `group`) vs. nullable —
+   `default=0` best preserves current semantics and keeps `part` a non-null bookkeeping value.
+3. Confirm whether any `to_json`/serialization consumer relies on `part` living in `tag` (the
+   remote-queue task JSON round-trips `columns`, `data/model.py:303-336`; adding `part` to
+   `columns` puts it in the wire payload — verify server/client tolerate the extra key).

--- a/spec/part-tag-to-column/research/04-tests-docs-and-verification.md
+++ b/spec/part-tag-to-column/research/04-tests-docs-and-verification.md
@@ -1,0 +1,150 @@
+# Research 04 — Tests, Docs & Verification for `part` tag→column
+
+## Summary
+
+Promoting `part` from a `Task.tag` JSON entry (`{'part': 0}`, `src/hypershell/data/model.py:387`)
+to a first-class nullable-default-0 column touches a small, well-bounded surface:
+
+- **Model/source of truth**: `src/hypershell/data/model.py` (tag injection at :387, fingerprint
+  exclusion at :414/:423), and the SQLite rotation/partition logic in
+  `src/hypershell/data/__init__.py:133-159` (`rotatedb` uses `json_set(tag,'$.part',N)` + filters
+  `Task.tag['part'] == N`). Auto-union in `src/hypershell/task.py:839-866` does **not** read `part`
+  — it unions all partition *files* by numeric filename suffix, so it needs no change (verify only).
+- **Design tension (flag to impl brief 03)**: `Task.columns` (`data/model.py:303-338`) drives
+  `to_dict`/`to_json`/`serialize_tasks` (`data/model.py:128-157,237`), the CLI field validators
+  (`task.py:434,548,1003,1160`), `--fields` (`task.py:605`), `-x/--extract` (`task.py:169`),
+  `--order-by` (`task.py:946`), and default `hs list --all` output. To keep `part` **INTERNAL
+  (no new CLI surface)**, add it as a `mapped_column` but **do NOT add it to the `columns` dict**;
+  `rotatedb` reads it via the ORM attribute `Task.part`. Adding it to `columns` would leak it into
+  `hs list --all`, `hs info`, `--fields`, and wire serialization.
+
+## Tests to touch
+
+**Will break / must update:**
+- `tests/test_source.py:63-67` `test_fingerprint_excludes_part_tag` — passes `{'k':'1','part':N}`
+  into `compute_fingerprint`. Behavior is preserved only if the `part`-exclusion filter stays in
+  `compute_fingerprint` (`data/model.py:423`). Decide: keep filter as defensive dead-code (test
+  passes unchanged) or drop filter + rewrite this test to assert the **column** doesn't affect
+  identity (e.g. two `Task.new(...)` with different `part` attrs → same fingerprint).
+- `tests/test_source.py:86` `test_new_stamps_source_and_falls_back_to_args_without_raw` — asserts
+  `fallback.fingerprint == Task.compute_fingerprint('echo x', 0, {'part': 0})`. After removal, the
+  natural RHS is `compute_fingerprint('echo x', 0, {})` (or `None`). Update the literal.
+
+**Guards behavior we must preserve (verify still green, likely no edit):**
+- `tests/test_source.py:99-116` `test_fresh_schema_creates_source_table_columns_and_indices` — uses
+  subset `{'source','fingerprint'} <= task_columns`, so it won't break. **Best place to ADD** a new
+  assertion `'part' in task_columns` to cover column existence.
+- `tests/test_source.py:30-59,72-94` other fingerprint tests — order-independence, resource-knob
+  exclusion, supplied-fingerprint — unaffected; re-run to confirm.
+- `tests/test_initdb.py:67-82` `test_rotate` — **currently a stub**: it submits 4 tasks and stops;
+  it never calls `hs initdb --rotate` nor asserts partition/union results. This is the natural home
+  for **new column-based rotation coverage** (rotate → part column set on migrated rows, dropped from
+  main, auto-union re-attaches). Extend it.
+- `tests/data/test_model.py:20-45` `test_split_argline` — asserts exact `(args, tag)` tuples;
+  `split_argline` never injects `part`, so unaffected (confirm).
+- `tests/test_submit.py:221-238` inline/`tag=` resource-tag tests, `tests/test_list.py:91-92`
+  tag-filter color test, `tests/test_update.py`, `tests/test_submit_json.py`, `tests/test_restart.py`
+  — exercise tags/fingerprint but not `part`; re-run as regression.
+
+**Helpers/fixtures (no change needed, use them):** `tests/__init__.py` — `main`/`main_lines`
+(rc,stdout,stderr), `assert_output(pattern,output,count,groups)`, `create_taskfile_echo(temp_site,
+count,tags=)`. `tests/conftest.py` — `temp_site` (sets `HYPERSHELL_SITE`,
+`HYPERSHELL_DATABASE_FILE=<site>/local.db`, `LOGGING_LEVEL=DEBUG`), autouse `clean_env`.
+Tag new tests `@mark.unit` / `@mark.integration` only (strict-markers).
+
+## Docs to touch
+
+- **`docs/_include/initdb_desc.rst:7-8`** — "applies a special purpose ``part:N`` **tag** to the new
+  partition and remaining tasks." This is generated from the source string
+  **`src/hypershell/data/__init__.py:190-191`** (`INITDB_HELP`). Per AGENTS.md, edit the source
+  string AND regenerate/hand-sync the snippet in the **same commit**. Reword to describe the internal
+  `part` column (or drop "tag").
+- **`docs/_include/task_info_help.rst:34-38`** and **`docs/_include/task_search_help.rst:95-99`**
+  (`--ignore-partitions` help; source = `task.py:148,596`) — these describe the "**numbering
+  pattern**" of database *files*, not the part tag. Accurate as-is; **verify no change needed**.
+- **`docs/manual.rst:104-108`** includes the initdb snippets (and `:25` the usage line) — rebuilds
+  automatically once `_include/initdb_desc.rst` is fixed.
+- **`docs/database.rst`** (+ `docs/_include/database.rst`) — contains **no** part/partition/rotate/tag
+  prose today (grep clean); nothing to change.
+- No other `docs/_include/*.rst` generated CLI help mentions `part` — confirmed. Because `part`
+  stays internal (not added to `Task.columns`), `--fields`/`hs list` help need no change.
+
+## Verification recipe (copy-paste; seed per-phase `verify:` gates)
+
+Wrapper: `.agents/factory/bin/temp_site.sh` mirrors the pytest `temp_site` isolation and sets
+`HYPERSHELL_DATABASE_FILE=$site/task.db`. **The site is deleted on exit**, so all `sqlite3`
+inspection MUST run inside the same `sh -c "..."`. `sqlite3` is present (`/usr/bin/sqlite3`, 3.51).
+
+**Baseline (current, pre-change) — for contrast:** 32-col task table with NO `part` column; a
+submitted row has `tag = {"part": 0}`; `hs info <id>` prints `tags: part:0`; `hs list tag -f json`
+shows `{"tag": {"part": 0}}`; `hs list part` → `CRITICAL Invalid field name "part"`.
+
+**(a) `part` is a real COLUMN, default 0, set on submit:**
+```
+.agents/factory/bin/temp_site.sh sh -c 'printf "echo one\necho two\n" > t.in; uv run hs submit t.in >/dev/null 2>&1;
+  sqlite3 "$HYPERSHELL_DATABASE_FILE" "PRAGMA table_info(task);" | grep -iw part;
+  sqlite3 "$HYPERSHELL_DATABASE_FILE" "SELECT DISTINCT part FROM task;"'
+```
+PASS: `table_info` shows a `part|INTEGER` row (with default 0); `SELECT DISTINCT part` prints `0`.
+
+**(b) `part` is GONE from the tag dict / tag output:**
+```
+.agents/factory/bin/temp_site.sh sh -c 'printf "echo one\n" > t.in; uv run hs submit t.in >/dev/null 2>&1;
+  echo "col:"; sqlite3 "$HYPERSHELL_DATABASE_FILE" "SELECT tag FROM task LIMIT 1;";
+  id=$(uv run hs list id -f plain | head -1);
+  echo "info:"; uv run hs info "$id" 2>/dev/null | grep -i "tag";
+  echo "json:"; uv run hs list tag -f json 2>/dev/null | tr -d " \n"'
+```
+PASS: DB `tag` = `{}`; `hs info` tags line is empty (`tags:`), no `part:0`; JSON shows `{"tag":{}}`.
+(Add a user tag to prove real tags still flow: `printf "echo x  # HYPERSHELL: color:red\n"` → tag
+`{"color":"red"}`, still no `part`.)
+
+**(b2) `part` stays INTERNAL (no CLI surface):**
+```
+.agents/factory/bin/temp_site.sh sh -c 'uv run hs list --fields 2>&1 | tr " " "\n" | grep -w part && echo LEAK || echo internal-ok'
+```
+PASS: prints `internal-ok` (no `part` in `--fields`); `uv run hs list part` still errors
+`Invalid field name "part"`. (If `part` appears, it was wrongly added to `Task.columns`.)
+
+**(c) SQLite rotate + auto-union still works, driven by the column:**
+```
+.agents/factory/bin/temp_site.sh sh -c 'set -e; printf "echo a\necho b\necho c\n" > t.in;
+  uv run hs submit t.in >/dev/null 2>&1;
+  uv run hs update exit_status=0 completion_time=now --completed --no-confirm >/dev/null 2>&1 || \
+    sqlite3 "$HYPERSHELL_DATABASE_FILE" "UPDATE task SET exit_status=0, completion_time=CURRENT_TIMESTAMP;";
+  uv run hs initdb --rotate --yes 2>&1 | tail -2;
+  echo "partition files:"; ls "$(dirname "$HYPERSHELL_DATABASE_FILE")" | grep -E "task\.[0-9]+$";
+  echo "part col in partition:"; sqlite3 "$(dirname "$HYPERSHELL_DATABASE_FILE")/task.1" "SELECT DISTINCT part FROM task;";
+  echo "union count:"; uv run hs list --count -f plain'
+```
+PASS: a `task.1` partition file exists; migrated rows in it carry `part = 1`; `hs list --count`
+(auto-union across main + `task.1`) equals the full history count. NOTE: the completed-task setup
+step above (marking `completion_time`/`exit_status`) is what makes `rotatedb` migrate rows — confirm
+the exact "mark completed" idiom against `rotatedb` (`data/__init__.py:133-138`) during build.
+
+**(d) Fingerprint/identity unchanged (unit-level, fastest signal):**
+```
+uv run pytest -v tests/test_source.py -k "fingerprint or part or schema"
+uv run pytest -v tests/test_initdb.py -k rotate
+uv run pytest -v -m unit
+uv run pytest -v            # full suite (integration needs `uv sync` first)
+```
+PASS: all green. Spot-identity check across the change: `compute_fingerprint('echo a',0,{})` before
+and after must be byte-identical (the md5 payload must not gain/lose a `part` key).
+
+**Docs build gate:**
+```
+uv run sphinx-build -q docs docs/_build
+```
+PASS: **exactly the pre-existing baseline** and no new warnings — one `pkg_resources`
+DeprecationWarning (environmental) + two "document isn't included in any toctree" warnings for
+**`docs/cli/task_submit.rst`** and **`docs/manual.rst`**. Any new warning (esp. from
+`_include/initdb_desc.rst`) is a regression.
+
+## Inspecting the DB column directly
+
+Because the temp site is torn down on exit, inspect inside the same `sh -c`:
+- `sqlite3 "$HYPERSHELL_DATABASE_FILE" "PRAGMA table_info(task);"` — confirms `part` is a real
+  column (name/type/default); baseline task table is 32 cols, post-change 33.
+- `sqlite3 "$HYPERSHELL_DATABASE_FILE" "SELECT part, tag FROM task;"` — column populated, tag clean.
+- Partition file: `sqlite3 "<dir>/task.1" "SELECT DISTINCT part FROM task;"` after `--rotate`.

--- a/spec/part-tag-to-column/research/05-list-search-apps-and-part-filter.md
+++ b/spec/part-tag-to-column/research/05-list-search-apps-and-part-filter.md
@@ -1,0 +1,123 @@
+# Research 05 — list & search CLI apps and the `--part` filter
+
+## Summary
+
+There is **one** application class, `TaskSearchApp` (`src/hypershell/task.py:601`), that
+serves **both** `hs list` (top-level, `__init__.py:130`) and `hs task search`
+(`task.py:1235`). "list" and "search" are the same app — so `--part` is added **once**.
+Its query machinery lives in the shared `SearchableMixin` (`task.py:447`), which is also
+mixed into `TaskUpdateApp`. `part` is currently a tag entry only (`model.py:387`,
+`tag = {**(tag or {}), **inline_tags, **{'part': 0,}}`) and is **not** in `Task.columns`
+(`model.py:303-336`), which is why `hs list part` errors "Invalid field name". Promoting
+`part` to a real column + adding it to `Task.columns` makes it selectable/displayable, and
+a `--part N` flag mirroring the existing `-g/--group` filter injects `Task.part == N` into
+the query. Auto-union composes correctly because the temp view is created *before* the query
+runs and SQLite has no schema qualifier (`schema = None`).
+
+## 1. The app + argument style (mirror `-g/--group`)
+
+`TaskSearchApp` declares filters as class attrs bound to `interface.add_argument`. The
+model to copy is the group filter — an int option feeding a `*_filter` dest:
+
+```python
+# task.py:646-647
+group_filter: Optional[int] = None
+interface.add_argument('-g', '--group', type=int, default=None, dest='group_filter')
+```
+
+Existing `-i/--ignore-partitions` (house style for the partition toggle):
+
+```python
+# task.py:672-673
+ignore_partitions: bool = False
+interface.add_argument('-i', '--ignore-partitions', action='store_true', dest='ignore_partitions')
+```
+
+`--fields` version string is `' '.join(Task.columns)` (`task.py:605`); the `field_names`
+positional defaults to `ALL_FIELDS = list(Task.columns)` (`task.py:434`, `:607-608`).
+`ALLOW_INTERSPERSE` is not set on any of these apps (cmdkit default). `-x/--extract` on
+`TaskInfoApp` uses `choices=Task.columns` (`task.py:169`).
+
+## 2. Where the WHERE clause is applied — shared, add once
+
+`SearchableMixin.build_query` (`task.py:469-475`) is the single query builder; both
+`TaskSearchApp` and `TaskUpdateApp` call it. Filters flow through `__build_filters`
+(`task.py:513-538`), which appends **string** predicates to `self.where_clauses` and then
+converts each via `WhereClause.from_cmdline`. The group filter is the exact template:
+
+```python
+# task.py:531-532
+if self.group_filter is not None:
+    self.where_clauses.append(f'group == {self.group_filter}')
+```
+
+`WhereClause.compile` (`task.py:1259-1262`) does `op_call(getattr(Task, self.field), value)`,
+so `'part == N'` becomes `Task.part == N` — this **requires `part` to be a real mapped
+column** (which the refactor provides). `from_cmdline` (`task.py:1264-1284`) coerces the RHS
+via `smart_coerce` for non-`str` columns, so `part` (int) coerces cleanly.
+
+**Recommended change (once):** add `part_filter: Optional[int] = None` to `SearchableMixin`
+(beside `group_filter` at `task.py:465`); append `if self.part_filter is not None:
+self.where_clauses.append(f'part == {self.part_filter}')` in `__build_filters`; and add
+`interface.add_argument('--part', type=int, default=None, dest='part_filter')` to
+`TaskSearchApp` (R9 scopes this to list/search). Adding the attr to the mixin is safe for
+`TaskUpdateApp` — it defaults to `None`, so no filter unless that app also declares the flag.
+
+## 3. Field selection / display — adding `part` to `columns` is sufficient
+
+`check_field_names` (`task.py:545-549`) is the validator:
+
+```python
+for name in self.field_names:
+    if name not in Task.columns:
+        raise ArgumentError(f'Invalid field name "{name}"')
+```
+
+`fields` (`task.py:540-543`, and the color-aware override `:757-763`) does
+`getattr(Task, name)`. So once `'part'` is in `Task.columns` **and** is a real attribute,
+`hs list part` validates, selects, and displays. It also auto-appears in `--fields`,
+`--list-columns` (`task.py:1227`), the default `ALL_FIELDS` view, and `-x/--extract`
+choices. Order in `Task.columns` = column order in normal/default output (place it per the
+model brief, e.g. right after `group`).
+
+## 4. Auto-union composition — confirmed correct
+
+`auto_union_sqlite` (`task.py:839-860`) attaches partition files and builds a temp view via
+`SQLITE_UNION_PART` (`task.py:864-867`): `create temp view 'task' as select * from main.task
+union all select * from part_N.task ...`. It runs in `run()` at `task.py:684-685`, **before**
+`build_query()` at `:694`. Because SQLite resolves unqualified `task` to the temp schema
+first, and `schema = config.pop('schema', None)` is `None` for SQLite (`data/core.py:199`),
+SQLAlchemy emits `SELECT ... FROM task WHERE task.part = ?` against the **view**. `select *`
+propagates each partition's own `part` value through the `union all`, so `WHERE part = N`
+selects exactly partition N's rows. **No ordering issue** — the filter is part of the query
+executed after the view exists. (Caveat for the migration brief: every partition file's
+`task` table must carry the `part` column, or `union all`'s column counts mismatch.)
+
+## 5. Type / coercion & "no filter"
+
+Mirror `-g/--group`: `type=int, default=None`. Absent → `part_filter is None` → **no
+filter** (this is why the guard must be `is not None`, not truthiness). `--part 0` is a
+**legitimate** filter (part 0 = main partition) and works precisely because `0 is not None`.
+Int limits use the same idiom (`-l/--limit` `type=int, default=None`, `task.py:629`).
+
+## 6. Tests to mirror
+
+`tests/test_list.py` is the pattern source. `test_signal_filter` (`:193-219`) and
+`test_sighup_cancel_equivalence` (`:222-235`) are the closest analogs for a filter option:
+submit via `create_taskfile`, mutate with `hs update ... --no-confirm`, then assert with
+`main_lines(['hs', 'list', <field>, '--part', 'N'])`. Helpers: `main`/`main_lines`
+(`tests/__init__.py:28,38`), `create_taskfile` (`:59`). Mark `@mark.integration`. Suggested
+cases: `--part 0` returns main rows; `--part N` selects a rotated partition (needs an
+`initdb --rotate` fixture — see the initdb brief); absent flag = unfiltered; `--part`
+combines with `-t`/`-w`; `hs task search --part` behaves identically (same class).
+
+## Open questions
+
+- **`--part 0` semantics**: confirmed a valid filter (main partition). Keep the `is not
+  None` guard so it is not swallowed as falsy.
+- **`hs update --part`?** R9 names only list/search. The mixin change makes adding it to
+  `TaskUpdateApp` trivial later, but out of scope now.
+- **Short flag**: `-g` is taken by group; `-p` is free but unclaimed elsewhere — recommend
+  long-only `--part` unless the plan wants a short alias.
+- **Non-SQLite (Postgres)**: no auto-union; `--part` is a plain `WHERE part = N` and works
+  identically. No partition semantics there, but the column filter is still valid.

--- a/spec/part-tag-to-column/research/06-help-snippets-and-completions.md
+++ b/spec/part-tag-to-column/research/06-help-snippets-and-completions.md
@@ -1,0 +1,142 @@
+# 06 — Help snippets & completions: the §12 same-commit machinery
+
+## Summary
+
+`hs list` and `hs search` are **the same app** — `TaskSearchApp` (`src/hypershell/task.py:601`),
+registered twice: as `'list'` in the top-level command dict (`src/hypershell/__init__.py:130`) and as
+`'search'` under the `task` group (`src/hypershell/task.py:1235`). So there is **one** help-text source,
+**one** docs include set, and **one** completion function per shell to touch — editing them covers both
+subcommands.
+
+The §12 same-commit rule (invariants.md:137–138) covers exactly two artifact families: the
+`docs/_include/*.rst` help snippets and the `share/` shell completions. **Man pages are NOT part of the
+same-commit rule** — they are regenerated at release time by `/hs-release`. This is confirmed by the
+closest precedent, `961fb22 [feature] Add --all to task list`, whose entire file list was:
+`docs/_include/task_search_desc.rst`, `docs/_include/task_search_help.rst`, `share/bash_completion.d/hs`,
+`share/zsh/site-functions/_hs`, `src/hypershell/task.py` — **no man pages**.
+
+## 1. `docs/_include/*.rst` — HAND-MAINTAINED (no generator)
+
+There is **no generator** — no script under `.agents/`, `tools/`, no Makefile/noxfile/pyproject task, no
+Sphinx argparse/autoprogram hook. The include files are hand-authored RST that mirror (but are not
+byte-identical to) the plain-text help constants in `task.py`. The help text originates from string
+constants:
+
+- `SEARCH_PROGRAM = 'hs list'` — `task.py:552`
+- `SEARCH_SYNOPSIS` — `task.py:553`
+- `SEARCH_USAGE` (usage block) — `task.py:554`
+- `SEARCH_HELP` (`SEARCH_USAGE` + Arguments/Options) — `task.py:568`, wired via
+  `interface = Interface(SEARCH_PROGRAM, SEARCH_USAGE, SEARCH_HELP)` (`task.py:604`).
+
+The **exact include files** for both `list` and `search` (there is **no** `list_*`/`task_list_*` file —
+`hs list` reuses these):
+
+- `docs/_include/task_search_usage.rst` — synopsis (RST backtick-wrapped)
+- `docs/_include/task_search_desc.rst` — description prose
+- `docs/_include/task_search_help.rst` — Arguments + Options reference
+
+Consumers: `docs/cli/task_search.rst` (page titled "List", `.. include:: ../_include/task_search_*`) and
+`docs/manual.rst:141–148`.
+
+**Regen command: NONE — edit by hand** to match the updated `SEARCH_HELP` text. Add the new `--part`
+option under the `Options` section of `task_search_help.rst`; update `task_search_usage.rst` **only if**
+the synopsis line changes; touch `task_search_desc.rst` only if adding narrative (the `--all` commit did,
+to explain the guard). Build/verify: `uv run sphinx-build docs docs/_build` (expect no new warnings; the
+pre-existing `task_submit.rst`/`manual.rst` "not in any toctree" warnings are fine).
+
+## 2. `share/` completions — one edit point per shell
+
+Both shells route `list` and `search` to a **single** function, so `--part` is added once per shell.
+
+### bash — `share/bash_completion.d/hs`, function `_hs_task_search` (defined at line 373)
+Dispatch: `list) _hs_task_search ;;` (line 90) and `search) _hs_task_search ; return ;;` (line 259).
+Options live in one whitespace-joined string, `all_opts` (lines 377–380):
+```
+	local all_opts="-h --help --all -w --where -t --with-tag -g --group -s --order-by --desc
+	-F --failed -C --completed -S --succeeded -R --remaining -X --cancelled --retries --signal
+	-f --format --csv --json -d --delimiter -l --limit -c --count
+	-i --ignore-partitions --fields --tag-keys --tag-values"
+```
+**Add `--part`** to this string (e.g. append to the `-g --group` group or the last line). For value
+completion, add a branch to the `case "${previous}"` block, mirroring `--signal`/`-l --limit`
+(lines 425–432), e.g.:
+```
+		--part)
+			COMPREPLY=($(compgen -W "0 1 2 3" -- "${current}"))
+			return
+			;;
+```
+
+### zsh — `share/zsh/site-functions/_hs`, function `_hs_list` (defined at line 400)
+Dispatch: `list) _hs_list ;;` (line 179) and `search) _hs_list ;;` (line 332). Options are `_arguments`
+lines. Model on the existing `--ignore-partitions` line (line 422):
+```
+        '(-i --ignore-partitions)'{-i,--ignore-partitions}'[Suppress auto-union feature (SQLite only)]' \
+```
+and `--signal` (line 415, shows value-completion syntax):
+```
+        '--signal[Match tasks killed by signal NAME]:signal:(HUP INT QUIT ABRT KILL TERM)' \
+```
+**Add** a line like `'--part[Filter by partition N]:partition:' \` alongside these (before the trailing
+`'*:field:_hs_fields'`).
+
+### hsx / hs cluster — NOT affected
+`hsx`/`hs cluster` completions are separate functions (`_hs_cluster`); `list`/`search` do not touch them.
+The bash `hsx` completion is a **symlink** `share/bash_completion.d/hsx -> hs`, and the wheel installs the
+`hs` file under both names — so editing the single `hs` file covers both binaries.
+
+## 3. Man pages — release-time regen, not this commit
+
+`share/man/man1/{hs,hsx,hyper-shell}.1` are generated from `docs/manual.rst` via the `man_pages` table in
+`docs/conf.py:153` (source doc `manual` → `hyper-shell.1` and `hs.1`; there is no `hsx` entry). Because
+`docs/manual.rst:141–148` `.. include::`s the `task_search_*.rst` files, the new `--part` text **will**
+flow into `hs.1` when the man pages are next rebuilt — the roff already contains the list/search help
+(grep `hs.1` for "killed by signal" → 5 hits; note hyphens are roff-escaped as `\-`, so
+"ignore-partitions" won't match literally).
+
+Rebuild command (per `/hs-release` Step 4, `.agents/skills/hs-release/SKILL.md:157`):
+`uv run sphinx-build -b man docs docs/_build/man`, then
+`cp docs/_build/man/hs.1 share/man/man1/hs.1`, `cp docs/_build/man/hyper-shell.1 share/man/man1/hyper-shell.1`,
+and `cp share/man/man1/hs.1 share/man/man1/hsx.1` (`hsx.1` is a byte-copy of `hs.1`).
+
+**Do NOT rebuild man pages in the feature commit** — git history shows `share/man/man1/` is touched only
+by `[release]`/`Rebuild manual pages` commits, never by feature commits. `/hs-release` owns this. (Minor
+caveat: the release skill's Step-4 "verify only the `.TH` line changed" check assumes CLI content is
+already current; after this feature it will legitimately also show the `--part` addition — expected, not
+an error.)
+
+## 4. CI metadata assertion — file LIST is unchanged, so it stays green
+
+`.github/workflows/tests.yml:95–113` ("Assert completions & man pages ship in the wheel") checks a
+**fixed** list of six wheel paths exists in `dist/*.whl`:
+```
+"share/bash-completion/completions/hs",
+"share/bash-completion/completions/hsx",
+"share/zsh/site-functions/_hs",
+"share/man/man1/hs.1",
+"share/man/man1/hsx.1",
+"share/man/man1/hyper-shell.1",
+```
+The source→wheel remap lives in `pyproject.toml:119–125` (`[tool.hatch.build.targets.wheel.shared-data]`),
+e.g. `"share/bash_completion.d/hs" = "share/bash-completion/completions/hs"`. Adding a `--part` option
+changes only file **contents**, adds/removes **no** files, so both the shared-data map and the CI
+assertion are **unaffected** — do not edit either. (Separately, `README.rst` must still pass
+`twine check --strict`, but a CLI option does not touch it.)
+
+## 5. Ordered same-commit checklist for adding `--part`
+
+1. **`src/hypershell/task.py`** — add the `--part` argument to `TaskSearchApp.interface`
+   (`interface.add_argument(...)`, ~line 672 near `--ignore-partitions`) and edit the `SEARCH_HELP`
+   Options block (`task.py:568`); update `SEARCH_USAGE`/`SEARCH_SYNOPSIS` (`task.py:553–566`) **only if**
+   the synopsis gains `--part`.
+2. **`docs/_include/task_search_help.rst`** — hand-add a `--part` entry under `Options` mirroring the
+   `--ignore-partitions`/`--signal` entries. Edit `task_search_usage.rst` iff the synopsis changed;
+   `task_search_desc.rst` iff narrative is warranted.
+3. **`share/bash_completion.d/hs`** — add `--part` to `_hs_task_search`'s `all_opts` (lines 377–380) and,
+   for value completion, a `--part)` branch in the `case "${previous}"` block.
+4. **`share/zsh/site-functions/_hs`** — add a `--part` `_arguments` line in `_hs_list` (near line 415/422).
+5. **Do NOT touch** `share/man/man1/*.1` (release owns it) or the CI list / shared-data map.
+6. **Verify:** `uv run hs list --help` and `uv run hs search --help` render the option;
+   `uv run sphinx-build docs docs/_build` builds with no new warnings; optionally dry-run
+   `uv run sphinx-build -b man docs docs/_build/man` to confirm it renders (but do not commit the `.1`
+   output). Stage exactly the 5 files above (matching the `961fb22` precedent).

--- a/src/hypershell/data/__init__.py
+++ b/src/hypershell/data/__init__.py
@@ -17,7 +17,7 @@ import functools
 from cmdkit.app import Application, exit_status
 from cmdkit.cli import Interface, ArgumentError
 from cmdkit.config import ConfigurationError
-from sqlalchemy import inspect, text, type_coerce
+from sqlalchemy import inspect, text
 from sqlalchemy.orm import close_all_sessions, sessionmaker, Session as SessionType
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.engine import create_engine
@@ -28,7 +28,7 @@ from hypershell.core.config import config
 from hypershell.core.exceptions import handle_exception, DatabaseUninitialized, get_shared_exception_mapping
 from hypershell.core.pretty_print import format_bytes
 from hypershell.data.core import Session, engine, in_memory, schema, providers
-from hypershell.data.model import Entity, Task, JSON
+from hypershell.data.model import Entity, Task
 
 # Public interface
 __all__ = [
@@ -130,13 +130,13 @@ def rotatedb() -> None:
     part_id, part_path = next_rotate_path()
     log.info(f'Rotating database {DATABASE_SITE} into {part_path}')
 
-    # Mark completed tasks as having part:N
+    # Stamp completed tasks with this partition's index in the `part` column.
     # We cannot simply drop completed tasks naively as more tasks may be updated in the
     # time between vacuuming to the new partition and the drop step
     (
         Session.query(Task)
             .filter(Task.exit_status.isnot(None))
-            .update({Task.tag: text('json_set(task.tag, :k, :v)').params({'k': '$.part', 'v': part_id})})
+            .update({Task.part: part_id})
     )
     Session.commit()
 
@@ -144,7 +144,7 @@ def rotatedb() -> None:
     # Previously marked tasks as part:N can then be dropped from main database
     log.debug(f'Vacuuming into {part_path}')
     Session.execute(text(f'VACUUM INTO :path'), params={'path': part_path})
-    count_deleted = Session.query(Task).filter(Task.tag['part'] == type_coerce(part_id, JSON)).delete()
+    count_deleted = Session.query(Task).filter(Task.part == part_id).delete()
     Session.commit()
     log.debug(f'Dropped {count_deleted} completed tasks from main ({DATABASE_SITE})')
 
@@ -154,7 +154,7 @@ def rotatedb() -> None:
 
     # Now we can drop anything in the new partition not belonging to part:N
     with sessionmaker(bind=create_engine(f'{providers[DATABASE_PROVIDER]}:///{part_path}'))() as external_session:
-        count_deleted = external_session.query(Task).filter(Task.tag['part'] != type_coerce(part_id, JSON)).delete()
+        count_deleted = external_session.query(Task).filter(Task.part != part_id).delete()
         external_session.commit()
         external_session.execute(text('VACUUM'))
         log.debug(f'Dropped {count_deleted} remaining tasks from partition ({part_path})')
@@ -188,8 +188,8 @@ INITDB_HELP = f"""\
   See also --initdb for the `hs cluster` command.
 
   The available special actions are mutually exclusive.
-  The --rotate operation migrates completed tasks to the next database partition,
-  and applies a special purpose `part:N` tag to the new partition and remaining tasks.
+  The --rotate operation migrates completed tasks into the next database partition,
+  recording that partition's index in each moved task's `part` column.
 
 Actions:
   -v, --vacuum             Vacuum an existing database.

--- a/src/hypershell/data/model.py
+++ b/src/hypershell/data/model.py
@@ -298,6 +298,8 @@ class Task(Entity):
     source: Mapped[Optional[str]] = mapped_column(UUID, nullable=True)  # Source.id or reserved-const id
     fingerprint: Mapped[Optional[str]] = mapped_column(TEXT, nullable=True)  # Stable identity hash (args + group + tags).
 
+    part: Mapped[int] = mapped_column(INTEGER, nullable=False, default=0)  # Partition index for SQLite database rotation.
+
     tag: Mapped[dict] = mapped_column(JSON, nullable=False, default={})  # kept last (export/print order)
 
     columns = {
@@ -332,6 +334,7 @@ class Task(Entity):
         'next_id': str,
         'source': str,
         'fingerprint': str,
+        'part': int,
         'tag': dict,
     }
 
@@ -384,7 +387,7 @@ class Task(Entity):
             args, inline_tags = cls.split_argline(args)
         else:
             args, inline_tags = str(args).strip(), {}
-        tag = {**(tag or {}), **inline_tags, **{'part': 0, }}
+        tag = {**(tag or {}), **inline_tags}
         other['group'] = tag.pop('group', group)
         other['cores'] = tag.pop('cores', other.get('cores', None))
         # A memory value may arrive as a unit-bearing string ('2GB') from an inline
@@ -411,16 +414,17 @@ class Task(Entity):
         """Stable, order-independent identity fingerprint.
 
         An md5 over canonical JSON of the pre-template ``raw_command``, the task
-        ``group``, and user ``tags`` (the bookkeeping ``part`` tag excluded; resource
-        knobs are already popped from the tag dict before this is called). The uuid,
-        attempt/retry counters, timing, exit status, and execution template deliberately
-        do not participate — re-running the same work under a different template yields
-        the same fingerprint. MD5 matches the SOURCE content fingerprint and is stdlib.
+        ``group``, and user ``tags`` (resource knobs are already popped from the tag
+        dict before this is called; the bookkeeping ``part`` is a column, never a tag).
+        The uuid, attempt/retry counters, timing, exit status, and execution template
+        deliberately do not participate — re-running the same work under a different
+        template yields the same fingerprint. MD5 matches the SOURCE content fingerprint
+        and is stdlib.
         """
         payload = json.dumps(
             {'args': raw_command,
              'group': group,
-             'tags': {key: value for key, value in (tags or {}).items() if key != 'part'}},
+             'tags': dict(tags or {})},
             sort_keys=True, separators=(',', ':'), ensure_ascii=False,
         )
         return hashlib.md5(payload.encode()).hexdigest()

--- a/src/hypershell/task.py
+++ b/src/hypershell/task.py
@@ -1315,6 +1315,7 @@ NORMAL_MODE_TEMPLATE: Final[str] = """\
      csvpath: {csvpath}
  previous_id: {previous_id}
      next_id: {next_id}
+        part: {part}
         tags: {tag}
 """
 

--- a/src/hypershell/task.py
+++ b/src/hypershell/task.py
@@ -463,6 +463,7 @@ class SearchableMixin:
     show_cancelled: bool = False
 
     group_filter: Optional[int] = None
+    part_filter: Optional[int] = None
     retry_filter: bool = False
     signal_filter: Optional[str] = None
 
@@ -530,6 +531,8 @@ class SearchableMixin:
             self.where_clauses.append(f'exit_status == {signal_status}')
         if self.group_filter is not None:
             self.where_clauses.append(f'group == {self.group_filter}')
+        if self.part_filter is not None:
+            self.where_clauses.append(f'part == {self.part_filter}')  # 0 is valid (main partition)
         if self.retry_filter:
             self.where_clauses.append('attempt > 1')
         if not self.where_clauses:
@@ -553,7 +556,7 @@ SEARCH_PROGRAM = 'hs list'
 SEARCH_SYNOPSIS = f'{SEARCH_PROGRAM} [-h] [FIELD [FIELD ...]] [-w COND [COND ...]] [-t TAG [TAG...]] ...'
 SEARCH_USAGE = f"""\
 Usage:
-  hs list [-h] [FIELD [FIELD ...]] [-w COND [COND ...]] [-t TAG [TAG...]] [-g GROUP]
+  hs list [-h] [FIELD [FIELD ...]] [-w COND [COND ...]] [-t TAG [TAG...]] [-g GROUP] [--part N]
           [--failed | --succeeded | --completed | --remaining | --cancelled] [--retries]
           [--signal NAME] [--order-by FIELD [--desc]] [--all | --count | --limit LIMIT]
           [-f FORMAT | --json | --csv]  [-d CHAR] [-i]
@@ -575,6 +578,7 @@ Options:
   -w, --where       COND...  Filter on conditional expression.
   -t, --with-tag    TAG...   Filter by tag.
   -g, --group       GROUP    Filter by group.
+      --part        N        Filter by partition (0 is the main database).
   -s, --order-by    FIELD    Order output by field.
       --desc                 Descending order (requires --order-by).
   -F, --failed               Alias for `-w exit_status != 0`.
@@ -645,6 +649,9 @@ class TaskSearchApp(Application, SearchableMixin):
 
     group_filter: Optional[int] = None
     interface.add_argument('-g', '--group', type=int, default=None, dest='group_filter')
+
+    part_filter: Optional[int] = None
+    interface.add_argument('--part', type=int, default=None, dest='part_filter')
 
     retry_filter: bool = False
     interface.add_argument('--retries', action='store_true', dest='retry_filter')

--- a/tests/test_initdb.py
+++ b/tests/test_initdb.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 # Standard libs
+import sqlite3
 from pathlib import Path
 
 # External libs
@@ -15,7 +16,7 @@ from pytest import mark
 from cmdkit.app import exit_status
 
 # Internal libs
-from tests import main, main_lines, NO_OUTPUT, create_taskfile_echo, assert_output
+from tests import main, main_lines, NO_OUTPUT, create_taskfile
 
 
 @mark.integration
@@ -63,20 +64,43 @@ def test_vacuum(temp_site: Path) -> None:
     ])
 
 
+def _task_parts(path: Path) -> list[tuple[int, object]]:
+    """Read each task's `part` column and its `part` tag-JSON key from a SQLite file."""
+    conn = sqlite3.connect(str(path))
+    try:
+        return conn.execute("select part, json_extract(tag, '$.part') from task").fetchall()
+    finally:
+        conn.close()
+
+
 @mark.integration
 def test_rotate(temp_site: Path) -> None:
-    """Rotate database."""
-    assert main_lines(['hs', 'initdb', '--yes']) == (
-        exit_status.success, NO_OUTPUT, [
-        f'INFO [hypershell.data] SQLite database initialized automatically',
-        f'INFO [hypershell.data] Optimizing database {temp_site / "local.db"}'
-    ])
-    taskfile = create_taskfile_echo(temp_site, count=4)
-    rc, stdout, stderr = main(['hs', 'submit', taskfile])
-    assert rc == exit_status.success
-    assert stdout == ''
-    assert_output(r'DEBUG .* Submitted from (?P<file>.*) \(implicit - not executable\)$',
-                  stderr, 1, groups={'file': str(taskfile)})
-    assert_output(r'DEBUG .* Submitted 1 tasks$', stderr, 4)
-    assert_output(r'DEBUG .* Done$', stderr, 1)
-    assert_output(r'INFO .* Submitted 4 tasks$', stderr, 1)
+    """Rotation moves completed tasks into the next partition via the `part` column.
+
+    Completed tasks (exit_status set) are stamped with the new partition's index in the
+    `part` **column** — never the tag — cloned into the partition file, and dropped from
+    main; incomplete tasks stay behind at part 0. Auto-union re-joins both files at read
+    time; `--ignore-partitions` sees only main.
+    """
+    main_db = temp_site / 'local.db'
+    partition = temp_site / 'local.1'
+
+    # Four tasks; complete two (n:0, n:1), leave two (n:2, n:3) unscheduled.
+    taskfile = create_taskfile(temp_site, [f'echo {n}  # HYPERSHELL: n:{n}' for n in range(4)])
+    assert main(['hs', 'submit', str(taskfile)])[0] == exit_status.success
+    assert main(['hs', 'update', 'exit_status=0', '-t', 'n:0', '--no-confirm'])[0] == exit_status.success
+    assert main(['hs', 'update', 'exit_status=0', '-t', 'n:1', '--no-confirm'])[0] == exit_status.success
+
+    # Rotate: completed -> local.1 at part 1, main keeps the two incomplete at part 0.
+    assert main(['hs', 'initdb', '--rotate', '--yes'])[0] == exit_status.success
+    assert partition.exists()
+
+    main_rows = _task_parts(main_db)
+    part_rows = _task_parts(partition)
+    assert sorted(part for part, _ in main_rows) == [0, 0]       # incomplete tasks stay at part 0
+    assert sorted(part for part, _ in part_rows) == [1, 1]       # completed tasks carry the partition index
+    assert all(tag_part is None for _, tag_part in main_rows + part_rows)   # `part` never leaks into tag JSON
+
+    # Auto-union re-joins both files; --ignore-partitions restricts to main.
+    assert main_lines(['hs', 'list', '--count'])[1] == ['4']
+    assert main_lines(['hs', 'list', '--count', '--ignore-partitions'])[1] == ['2']

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -233,3 +233,31 @@ def test_sighup_cancel_equivalence(temp_site: Path) -> None:
     by_cancelled = main_lines(['hs', 'list', 'exit_status', '-t', 'n:0', '--cancelled'])[1]
     assert by_signal == ['-1']
     assert by_cancelled == ['-1']
+
+
+@mark.integration
+def test_part_filter(temp_site: Path) -> None:
+    """`--part N` restricts the listing to one rotated partition; auto-union keeps all visible."""
+    taskfile = create_taskfile(temp_site, [f'echo {n}  # HYPERSHELL: n:{n}' for n in range(4)])
+    assert main(['hs', 'submit', str(taskfile)])[0] == cli_status.success
+
+    # Complete n:0 and n:1 so they rotate into partition 1; n:2 and n:3 stay in main (part 0).
+    assert main(['hs', 'update', 'exit_status=0', '-t', 'n:0', '--no-confirm'])[0] == cli_status.success
+    assert main(['hs', 'update', 'exit_status=0', '-t', 'n:1', '--no-confirm'])[0] == cli_status.success
+    assert main(['hs', 'initdb', '--rotate', '--yes'])[0] == cli_status.success
+
+    # --part 1 targets the rotated partition; --part 0 the main database.
+    assert sorted(main_lines(['hs', 'list', 'args', '--part', '1'])[1]) == ['echo 0', 'echo 1']
+    assert sorted(main_lines(['hs', 'list', 'args', '--part', '0'])[1]) == ['echo 2', 'echo 3']
+
+    # Omitting --part lists everything (auto-union across both files).
+    assert main_lines(['hs', 'list', '--count'])[1] == ['4']
+
+    # --part composes with a tag filter, and 0 is a legitimate filter (not treated as "unset").
+    assert main_lines(['hs', 'list', 'args', '--part', '1', '-t', 'n:0'])[1] == ['echo 0']
+
+    # An out-of-range partition returns nothing.
+    assert main_lines(['hs', 'list', 'args', '--part', '99'])[1] == ['']
+
+    # `hs task search` is the same app -> identical filtering.
+    assert sorted(main_lines(['hs', 'task', 'search', 'args', '--part', '1'])[1]) == ['echo 0', 'echo 1']

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -261,3 +261,19 @@ def test_part_filter(temp_site: Path) -> None:
 
     # `hs task search` is the same app -> identical filtering.
     assert sorted(main_lines(['hs', 'task', 'search', 'args', '--part', '1'])[1]) == ['echo 0', 'echo 1']
+
+
+@mark.integration
+def test_part_in_normal_view(temp_site: Path) -> None:
+    """The detailed (normal / `hs info`) view renders the `part` column, consistent with `group`."""
+    taskfile = create_taskfile(temp_site, [f'echo {n}  # HYPERSHELL: n:{n}' for n in range(2)])
+    assert main(['hs', 'submit', str(taskfile)])[0] == cli_status.success
+
+    # Complete n:0 so it rotates into partition 1; n:1 stays in main (part 0).
+    assert main(['hs', 'update', 'exit_status=0', '-t', 'n:0', '--no-confirm'])[0] == cli_status.success
+    assert main(['hs', 'initdb', '--rotate', '--yes'])[0] == cli_status.success
+
+    # `hs list --all` (no explicit fields) renders the detailed normal template; `part` must appear
+    # there, consistent with `group` — not only via `hs list part` / `-x part` / `--json`.
+    lines = [strip_ansi(line).strip() for line in main_lines(['hs', 'list', '--all'])[1]]
+    assert sorted(line for line in lines if line.startswith('part:')) == ['part: 0', 'part: 1']

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -60,12 +60,12 @@ def test_fingerprint_differs_on_args_group_or_tag_change() -> None:
 
 
 @mark.unit
-def test_fingerprint_excludes_part_tag() -> None:
-    """The bookkeeping ``part`` tag (rewritten on rotation) must not affect identity."""
-    a = Task.compute_fingerprint('echo a', 0, {'k': '1', 'part': 0})
-    b = Task.compute_fingerprint('echo a', 0, {'k': '1', 'part': 7})
-    c = Task.compute_fingerprint('echo a', 0, {'k': '1'})
-    assert a == b == c
+def test_new_keeps_part_out_of_tag_and_identity() -> None:
+    """``part`` is a column now, not a tag: creation leaves ``tag`` user-only and identity is
+    computed over the user tags directly (no more routing around a bookkeeping ``part`` key)."""
+    task = Task.new(args='echo a', raw_args='a', tag={'k': '1'})
+    assert task.tag == {'k': '1'}                                    # no bookkeeping 'part' key
+    assert task.fingerprint == Task.compute_fingerprint('a', 0, {'k': '1'})
 
 
 @mark.unit
@@ -83,7 +83,7 @@ def test_new_stamps_source_and_falls_back_to_args_without_raw() -> None:
     stamped = Task.new(args='echo x', raw_args='x', source=DIRECT_SOURCE_ID)
     assert stamped.source == DIRECT_SOURCE_ID
     fallback = Task.new(args='echo x')            # no raw_args -> uses expanded args
-    assert fallback.fingerprint == Task.compute_fingerprint('echo x', 0, {'part': 0})
+    assert fallback.fingerprint == Task.compute_fingerprint('echo x', 0, {})
 
 
 @mark.unit
@@ -108,7 +108,8 @@ def test_fresh_schema_creates_source_table_columns_and_indices() -> None:
     assert source_columns == {'id', 'path', 'fingerprint', 'task_count', 'created'}
 
     task_columns = {col['name'] for col in insp.get_columns('task')}
-    assert {'source', 'fingerprint'} <= task_columns
+    assert {'source', 'fingerprint', 'part'} <= task_columns
+    assert 'part' in Task.columns          # first-class, selectable/displayable like `group`
 
     source_indices = {ix['name'] for ix in insp.get_indexes('source')}
     task_indices = {ix['name'] for ix in insp.get_indexes('task')}
@@ -147,10 +148,10 @@ def test_source_lookups_use_the_index_not_a_full_scan() -> None:
     Entity.metadata.create_all(engine)
     real = 'aaaaaaaa-0000-7000-8000-000000000000'
     columns = ('id', '"group"', 'args', 'submit_id', 'submit_time', 'attempt', 'retried', 'tag',
-               'source', 'fingerprint')
-    rows = ([(f'{i:036d}', 1, 'echo', 'sub', '2026-01-01', 1, 0, '{}', real, f'fp{i % 5}')
+               'source', 'fingerprint', 'part')
+    rows = ([(f'{i:036d}', 1, 'echo', 'sub', '2026-01-01', 1, 0, '{}', real, f'fp{i % 5}', 0)
              for i in range(30)] +
-            [(f'r{i:035d}', 1, 'echo', 'sub', '2026-01-01', 1, 0, '{}', DIRECT_SOURCE_ID, None)
+            [(f'r{i:035d}', 1, 'echo', 'sub', '2026-01-01', 1, 0, '{}', DIRECT_SOURCE_ID, None, 0)
              for i in range(2000)])   # bulk reserved rows -> a scan would be far costlier than the index
     with engine.begin() as conn:
         conn.exec_driver_sql(f'INSERT INTO task ({", ".join(columns)}) VALUES ({", ".join(["?"] * len(columns))})', rows)


### PR DESCRIPTION
## Summary

`part` — the internal SQLite database-partition index used by the auto-union / rotation mechanism — was stored inside the `Task.tag` dictionary (`{'part': 0}`), which dirtied user annotations, forced the fingerprint and rotation queries to special-case it, and tied it to SQLite JSON functions. This promotes `part` to a first-class `Task` column (dialect-neutral, positioned last before `tag`, default `0`), removes it from `tag`, rewrites rotation to read/write the column (no `json_extract`/`json_set`), and surfaces it as a visible, selectable field with a new `hs list` / `hs search --part N` partition filter. Forward-only; pre-existing part-in-tag databases are out of scope.

## Goal

[`GOAL.md`](https://github.com/hypershell/hypershell/blob/a5c9ce98386aa7e87c572915916770a6c58544c7/spec/part-tag-to-column/GOAL.md) — R1–R9 (the locked contract; reshaped 2026-07-31 to surface `part` + add `--part`).

## Design

[`PLAN.md`](https://github.com/hypershell/hypershell/blob/a5c9ce98386aa7e87c572915916770a6c58544c7/spec/part-tag-to-column/PLAN.md) (historical design record).

## Research

[`research/00-digest.md`](https://github.com/hypershell/hypershell/blob/a5c9ce98386aa7e87c572915916770a6c58544c7/spec/part-tag-to-column/research/00-digest.md) + [briefs 01–06](https://github.com/hypershell/hypershell/tree/a5c9ce98386aa7e87c572915916770a6c58544c7/spec/part-tag-to-column/research) (historical).

## Phases completed

- **P1** · Data layer: visible `part` column + `rotatedb` via the column + same-commit initdb help · satisfies R1–R6, R8 (+ data-layer R7)
- **P2** · CLI: `--part N` filter on `hs list` / `hs search` + same-commit help snippets + completions · satisfies R9, R7

## Verification

From [`REVIEW.md`](https://github.com/hypershell/hypershell/blob/a5c9ce98386aa7e87c572915916770a6c58544c7/spec/part-tag-to-column/REVIEW.md) (cycle 1) + the remediation build:

- `uv run pytest -q` → **423 passed**, no failures (new coverage: column presence, rotation via the column, the `--part` filter, and normal-view rendering).
- `uv run sphinx-build -E -b html docs docs/_build` → build succeeded, only the 2 pre-existing baseline toctree warnings.
- CLI drive (throwaway site): submit → complete → `hs initdb --rotate --yes` → completed rows land in the partition file at `part=1`, main stays `part=0`, `tag` never contains `part`; `hs list` / `hs search --part N` targets a partition; `hs info` and `hs list --all` render `part` alongside `group`.

## Docs & completions

Same-commit rule honored: `docs/_include/initdb_desc.rst` (part→column), `docs/_include/task_search_{usage,help}.rst` (`--part`), and `share/` bash + zsh completions were all updated in-branch. (Man pages regenerate at `/hs-release`.)

## ⚠️ Review status — shipped on human override

Cycle-1 `/hs-review` returned **changes-requested** for one HIGH finding (F1: `part` was absent from the `NORMAL_MODE_TEMPLATE` detailed view — R8). It was remediated in `e595cbe` (a one-line template addition + `test_part_in_normal_view`) and verified green. Per the maintainer's explicit decision, the **second review cycle was skipped** — the remediation is confined to the presentation layer of normal-mode printing (no logic/core change; the data-layer core passed cycle 1 clean). `TECH.md` `review.verdict` therefore still reads `changes-requested`; this PR ships on that recorded override.

## 🔧 Harness feedback

Open toolchain findings from this feature's `META.md` (process-only; for `/hs-harness`):

- **F1 · low** · commit-category rule (`else feature`) omits `refactor` — `hs-feature`/`hs-plan` should emit `[{kind}]` (seen again).
- **F2 · low** · research-depth gate keys only on appetite/kind, ignoring blast-radius — would have skipped needed research on this coupled-core change.
- *Worked well:* `hs-plan` parallel research fan-out materially de-risked the coupled-core change (pinned the exact rotation expressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
