### PR TITLE
[feature] Add rich per-task "card" view for hs list / search / info

### DIFF
--- a/docs/_include/task_info_help.rst
+++ b/docs/_include/task_info_help.rst
@@ -8,7 +8,8 @@ Options
 ^^^^^^^
 
 ``-f``, ``--format`` *FORMAT*
-    Format task info ([normal], json, yaml).
+    Format task info ([normal], card, json, yaml). The ``card`` format renders the task as a
+    richly-formatted, bordered panel with a color-coded status badge (see ``task search``).
 
 ``--json``
     Format metadata output as JSON.

--- a/docs/_include/task_search_help.rst
+++ b/docs/_include/task_search_help.rst
@@ -72,11 +72,13 @@ Options
     (see ``--cancelled``).
 
 ``-f``, ``--format`` *FORMAT*
-    Specify output format (either ``normal``, ``plain``, ``table``, ``csv``, ``json``).
+    Specify output format (either ``normal``, ``card``, ``plain``, ``table``, ``csv``, ``json``).
 
     Default is ``normal`` for whole-task output. If any *FIELD* names are given, output is
     formatted in simple ``plain`` text; use ``csv`` for compliant output. The pretty-printed
-    ``table`` formatting is good for presentation on wide screens.
+    ``table`` formatting is good for presentation on wide screens. The ``card`` format renders
+    each task as a richly-formatted, bordered panel that adapts to the terminal width and shows a
+    color-coded status badge; like ``normal`` it needs the whole task (not a subset of *FIELD* s).
 
     See ``--csv``, ``--json``, and ``--delimiter``.
 

--- a/docs/_include/task_wait_help.rst
+++ b/docs/_include/task_wait_help.rst
@@ -16,7 +16,7 @@ Options
     See ``task info`` command.
 
 ``-f``, ``--format`` *FORMAT*
-    Format task info ([normal], json, yaml).
+    Format task info ([normal], card, json, yaml).
 
 ``--json``
     Format metadata output as JSON.

--- a/share/bash_completion.d/hs
+++ b/share/bash_completion.d/hs
@@ -294,7 +294,7 @@ function _hs_task_info() {
 
 	case "${previous}" in
 		-f | --format)
-			COMPREPLY=($(compgen -W "normal json yaml" -- "${current}"))
+			COMPREPLY=($(compgen -W "normal card json yaml" -- "${current}"))
 			return
 			;;
 		-x | --extract)
@@ -324,7 +324,7 @@ function _hs_task_wait() {
 			return
 			;;
 		-f | --format)
-			COMPREPLY=($(compgen -W "normal json yaml" -- "${current}"))
+			COMPREPLY=($(compgen -W "normal card json yaml" -- "${current}"))
 			return
 			;;
 	esac

--- a/share/bash_completion.d/hs
+++ b/share/bash_completion.d/hs
@@ -415,7 +415,7 @@ function _hs_task_search() {
 			return
 			;;
 		-f | --format)
-			COMPREPLY=($(compgen -W "normal plain table csv json" -- "${current}"))
+			COMPREPLY=($(compgen -W "normal card plain table csv json" -- "${current}"))
 			return
 			;;
 		-d | --delimiter)

--- a/share/zsh/site-functions/_hs
+++ b/share/zsh/site-functions/_hs
@@ -414,7 +414,7 @@ function _hs_list() {
         '(-F --failed -C --completed -S --succeeded -R --remaining -X --cancelled)'{-X,--cancelled}'[Alias for -w "exit_status == -1"]' \
         '--retries[Alias for -w "attempt > 1"]' \
         '--signal[Match tasks killed by signal NAME]:signal:(HUP INT QUIT ABRT KILL TERM)' \
-        '(-f --format --json --csv)'{-f,--format}'[Format output]:format:(normal plain table csv json)' \
+        '(-f --format --json --csv)'{-f,--format}'[Format output]:format:(normal card plain table csv json)' \
         '(-f --format --json --csv)--json[Format output as JSON]' \
         '(-f --format --json --csv)--csv[Format output as CSV]' \
         '(-d --delimiter)'{-d,--delimiter}'[Field separator for plain/csv formats]:delimiter:(, \; \|)' \

--- a/share/zsh/site-functions/_hs
+++ b/share/zsh/site-functions/_hs
@@ -352,7 +352,7 @@ function _hs_task_submit() {
 function _hs_info() {
     _arguments -s \
         '(-h --help)'{-h,--help}'[Show this message and exit]' \
-        '(-f --format --json --yaml)'{-f,--format}'[Format task info]:format:(normal json yaml)' \
+        '(-f --format --json --yaml)'{-f,--format}'[Format task info]:format:(normal card json yaml)' \
         '(-f --format --json --yaml)--json[Format task metadata as JSON]' \
         '(-f --format --json --yaml)--yaml[Format task metadata as YAML]' \
         '(--stdout --stderr --perf -x --extract)'{-x,--extract}'[Print a single field]:field:_hs_fields' \
@@ -374,7 +374,7 @@ function _hs_wait() {
         '(-i --info -s --status -r --return)'{-i,--info}'[Print info on task]' \
         '(-i --info -s --status -r --return)'{-s,--status}'[Print exit status for task]' \
         '(-i --info -s --status -r --return)'{-r,--return}'[Use exit status from task]' \
-        '(-f --format --json --yaml)'{-f,--format}'[Format task info]:format:(normal json yaml)' \
+        '(-f --format --json --yaml)'{-f,--format}'[Format task info]:format:(normal card json yaml)' \
         '(-f --format --json --yaml)--json[Format info as JSON]' \
         '(-f --format --json --yaml)--yaml[Format info as YAML]' \
         '1:task UUID:_hs_task_ids'

--- a/spec/task-card-view/GOAL.md
+++ b/spec/task-card-view/GOAL.md
@@ -1,0 +1,126 @@
+# GOAL — Rich "card" view for tasks
+
+> **Origin spec.** The *what* and *why* — the locked contract `hs-review` grades against.
+> The *how* lives in [`PLAN.md`](PLAN.md) and [`TECH.md`](TECH.md) (written by `hs-plan`).
+> Keep this at the right altitude: solved and bounded, but not over-specified — leave design
+> freedom for the plan. Edit requirements here; do **not** silently drift them during build.
+
+- **slug:** task-card-view
+- **kind:** feature
+- **appetite:** big
+
+## Problem
+
+`hs list` / `hs search` (and single-task `hs info`) default to **`normal`** mode: a vertical
+block per task built from `NORMAL_MODE_TEMPLATE`, ~30 fields deep, `---`-separated, some fields
+compressed parenthetically, with a single **flat** color applied to the whole block from the
+task's exit status. It reads well and the recent color-coding gives quick at-a-glance state
+feedback — but it is **running out of vertical room**. We keep adding columns to `Task`
+(`fingerprint`, `part`, …) and a **`zone`** field is coming next, so each task now costs a tall
+scroll and the flat coloring can only say "green/red/yellow", not *what* the state actually is.
+
+We don't want to lose `normal` mode — it's good for dense mental-compression scanning. Instead we
+want a **new, opt-in display mode** that trades vertical stacking for horizontal layout: a richly
+formatted, bordered **"card"** (baseball-card metaphor) per task that uses the `rich` package's
+layout capabilities to spread metadata across the width of the terminal, group related fields into
+labeled regions, and surface an explicit, *labeled* status badge instead of a flat wash of color.
+
+## Outcome / vision
+
+A user runs `hs list --format=card` (and `hs info --format=card`) and, instead of a tall flat
+block, sees each task as a **self-contained bordered card** that:
+
+- puts the identity fields (**id**, **fingerprint**, **group**, **part**, and — once it exists —
+  **zone**) horizontally along the **top**;
+- groups the rest of the metadata (submission/provenance, scheduling & timing, resources, output
+  artifacts, retry chain, tags) into **logical, labeled regions** using color and emphasis for
+  meaning rather than one flat field list;
+- shows a virtual **`status: <STATUS>`** badge in the **lower-right** — `OK` in bold green,
+  `FAILED` in bold red, `CANCELLED` in yellow, and so on for the rest of the lifecycle — replacing
+  normal mode's flat whole-block coloring;
+- **adapts to the terminal width**, choosing among *narrow / normal / wide* layouts between a
+  **minimum of 60** and **maximum of 160** columns, so it looks right on a laptop split-pane and
+  takes advantage of a full-width terminal.
+
+Illustrative sketch only — **non-binding**; exact layout, glyphs, and region grouping are
+`/hs-plan`'s job:
+
+```
+┌ task ─────────────────────────────────────────────────────────────────────┐
+│ id 3f2a…9c1   fp 8b0e…   group 4   part 0                                   │
+│                                                                            │
+│ command   echo hello world              submitted  2026-07-31 10:12:04     │
+│ source    tasks.txt (a1b2…)             started    2026-07-31 10:12:07     │
+│ resources 1 core · 512 MB               completed  2026-07-31 10:12:09     │
+│ output    out: …/3f2a.out  err: …/…     duration   00:00:02                │
+│ tags      priority=high, phase=warmup                                      │
+│                                                            status: OK      │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Acceptance criteria (the contract)
+
+- **R1** — WHEN the user passes `-f/--format=card` to `hs list` / `hs search` **or** `hs info`,
+  the CLI SHALL render each matched task as a card; `normal` SHALL remain the default and the
+  existing `normal` / `plain` / `table` / `json` / `csv` outputs SHALL be unchanged (card is
+  purely additive).
+- **R2** — The card SHALL be a self-contained unit with an **outer border** built from a custom
+  `rich` layout (not the existing `table` format), presenting **id, fingerprint, group, part**
+  laid out **horizontally across the top** and leaving room for a future **`zone`** field in that
+  header.
+- **R3** — The remaining task metadata SHALL be organized into **labeled logical regions** (e.g.
+  submission/provenance, scheduling & timing, resources, output artifacts, retry chain, tags)
+  rather than one flat field list, using color/emphasis to aid scanning.
+- **R4** — The card SHALL display a virtual **`status: <STATUS>`** indicator in the
+  **lower-right** region, where `<STATUS>` is a human-readable label **derived from the task
+  lifecycle** (not a stored column). It SHALL distinguish at least: **OK** (bold green), **FAILED**
+  (bold red), **CANCELLED** (yellow), **RUNNING** (in-flight), **WAITING** (unscheduled), and an
+  **abnormal** state (signal-kill / never-ran sentinels such as template/resource errors). This
+  replaces normal mode's flat whole-block coloring.
+- **R5** — WHILE the output width varies, the card SHALL **auto-select** among **narrow / normal /
+  wide** layouts from the detected terminal width, clamped to a **minimum of 60** and a
+  **maximum of 160** columns.
+- **R6** — IF stdout is not a TTY or color is disabled (piped output, `NO_COLOR`, `COLOR_STDOUT`
+  false), THEN the card SHALL still render legibly and the status SHALL remain readable as plain
+  text.
+- **R7** — `hs info --format=card` SHALL render a single task's card **consistent** with how
+  `hs list --format=card` renders that same task (shared renderer).
+- **R8** — The affected `docs/_include/*.rst` help snippets and the `share/` shell completions
+  SHALL list `card` as a valid format value, updated in the **same commit** (repo convention).
+
+## Non-goals (no-gos)
+
+- **Not** removing, replacing, or restyling `normal` mode — it stays the default and unchanged.
+- **Not** adding the `zone` column/field itself — that is separate upcoming work; here we only
+  reserve a place for it in the header layout so the card is forward-compatible.
+- **Not** an interactive/pager TUI — output stays line-oriented (cards printed in sequence), just
+  as `normal` does today.
+- **Not** applying the card treatment to `plain` / `table` / `json` / `csv`.
+- **Not** adding a manual layout-override flag (e.g. `--width narrow|normal|wide`) — layout is
+  auto-selected from terminal width. (Deferred; can be a follow-up if demand appears.)
+
+## Clarifications
+
+- **Q:** Which commands get the card view? — **A:** Both `hs list` / `hs search` **and**
+  `hs info` (a card is inherently a single-task view; the renderer is shared) (resolved
+  2026-07-31).
+- **Q:** How is narrow/normal/wide chosen? — **A:** Auto-detected from terminal width, clamped
+  60–160 cols; **no** manual override flag in this unit of work (resolved 2026-07-31).
+- **Q:** Which states get a labeled status badge? — **A:** The full lifecycle set (OK / FAILED /
+  CANCELLED / RUNNING / WAITING / abnormal), derived from the nullable-column lifecycle, not just
+  `exit_status` (resolved 2026-07-31).
+- **Q:** What is the mode named? — **A:** `card` (resolved 2026-07-31).
+
+## Related materials
+
+- Current `normal` renderer & color logic — `src/hypershell/task.py`: `NORMAL_MODE_TEMPLATE`
+  (~L1294), `print_normal` (~L1382), `select_color` / `select_style` / `SPECIAL_TASK_COLORS`
+  (~L1328–1360), `TaskSearchApp` output-format wiring (~L605–845), `TaskInfoApp` (~L160–360).
+- Task fields & lifecycle contract — `src/hypershell/data/model.py`: `Task.columns` (~L305),
+  `CANCEL_STATUS` (L49), and the "Task lifecycle contract" / `exit_status` reserved ranges in
+  `AGENTS.md` (source of truth for what "status" means: unscheduled / in-flight / done /
+  cancelled, and the `-1..-64` signal + `<-1000` never-ran sentinels).
+- Docs & completions to update — `docs/_include/*.rst` (list help), `share/` (bash+zsh
+  completions).
+- Dependency — `rich` is already a runtime dependency (used by `table` / `json` rendering via
+  `rich.Console` / `rich.Table` / `rich.Syntax`).

--- a/spec/task-card-view/PLAN.md
+++ b/spec/task-card-view/PLAN.md
@@ -1,0 +1,166 @@
+# PLAN — Rich "card" view for tasks
+
+> **Status:** Draft for review · **Last updated:** 2026-08-01
+> **Authoritative technical design.** The *how*. Vision/contract is [`GOAL.md`](GOAL.md);
+> the phased executable roadmap is [`TECH.md`](TECH.md). Backing detail is in
+> [`research/`](research/). Every design element traces to a GOAL R-ID.
+
+## 1. Summary
+
+Add an opt-in **`card`** output format to `hs list`/`hs search` and `hs info` (plus `hs wait --info`
+for parity). Each task renders as a `rich` **`Panel`** (rounded border, `title="task"`) whose body is
+a horizontal identity **header** (id · fingerprint · group · part · reserved zone) over **labeled
+regions** of the remaining metadata, with a virtual **`status: <STATUS>`** badge pinned to the
+lower-right **via the Panel subtitle**. Layout is **responsive** — the effective width is clamped to
+[60, 160] and selects narrow/normal/wide. The status label is derived from the task lifecycle by a
+new read-only **`Task.status_label`** property (model-side, per invariant §1); the label→color map is
+presentation-side. No schema change, no new dependency, no touch to server/client/queue.
+
+## 2. Design
+
+**Status derivation (`data/model.py`).** New read-only property `Task.status_label -> str` on the
+`Task` model, implementing the order-critical ladder (WAITING → RUNNING → OK → CANCELLED → ERROR →
+KILLED → FAILED → UNKNOWN; see [`research/02`](research/02-status-lifecycle-derivation.md) and the
+digest). It re-derives the same nullable-column predicates the model already uses
+(`schedule_time`/`completion_time`/`exit_status == CANCEL_STATUS`), so it belongs with the model, not
+scattered into `task.py`. Never-ran sentinels are classified by the **documented `exit_status <=
+-1000` range** — we do **not** import `TASK_TEMPLATE_ERROR`/`TASK_RESOURCE_ERROR` from `client.py`
+(circular + heavy import). Pure function of already-loaded columns; adds no query and changes no
+state.
+
+**Label → style (`task.py`).** A `STATUS_STYLES: Dict[str, str]` beside the existing
+`select_style`/`SPECIAL_TASK_STYLES`, mapping OK→`bold green`, FAILED→`bold red`, CANCELLED→`yellow`,
+RUNNING→`cyan`, WAITING→`dim`, ERROR/KILLED/UNKNOWN→`magenta`. The card uses this one map for both the
+badge text and the Panel border color. CANCELLED=`yellow` is a **deliberate card-specific palette**
+(GOAL-fixed) that intentionally differs from `select_style`'s exit-status-only `dim`; the two coloring
+systems coexist (normal/plain/table keep `select_color`/`select_style` unchanged).
+
+**Renderer (`task.py`).** `render_card(task, width, source_map=None) -> Panel` — a pure function
+returning the rich renderable for a given clamped width. It reuses `print_normal`'s field-prep
+(waited/duration/timeout→`timedelta`, memory→`format_bytes`, cores, source→`resolve_source`,
+tags→`format_tag`) and composes: `Panel(Group(header_grid, "", regions), title="task",
+title_align="left", box=box.ROUNDED, width=width, padding=(0,1), subtitle=f"status:
+{task.status_label}", subtitle_align="right", border_style=STATUS_STYLES[...])`. Regions group the
+NORMAL_MODE_TEMPLATE fields logically — **command**, **timing** (submitted/scheduled/started/
+completed + waited/duration/timeout), **resources** (cores/memory req vs used), **execution hosts**
+(submit/server/client host+id), **output** (out/err/csv paths), **retry** (attempt/retried/
+previous/next), **source**, **tags** — as `Table.grid` label:value blocks, side-by-side via `Columns`
+in normal/wide and stacked in narrow. **The id is never truncated** (it's actionable); the fingerprint
+may abbreviate in narrow. Exact narrow composition is a build detail within R5.
+
+**Width & color (`task.py`).** One `Console()`; `W = max(60, min(160, console.size.width))`;
+thresholds `<90` narrow / `90–129` normal / `>=130` wide. Non-TTY yields width 80 → narrow, rich
+auto-strips ANSI, and the status is always literal text in the subtitle — so R6 holds on one code
+path. `BrokenPipeError` stays handled by the existing `handle_broken_pipe` mapping.
+
+**CLI wiring.** `TaskSearchApp`: add `'card'` to `output_formats`; add `print_card(self, results)`
+(mirrors the static `print_normal`: rebuild `Task` objects, `Source.paths_for_ids` batch, one
+`Console()`, loop `console.print(render_card(task, W, source_map))`); extend the subset-rejection
+guard in `check_output_format` from `== 'normal'` to `in ('normal','card')`. `TaskInfoApp`: add
+`'card'` to `output_formats` and branch `run()` to `render_card` the single task. `TaskWaitApp`: add
+`'card'` to its forwarded `output_formats` for parity. No conflict with the `--json`/`--csv`/`--yaml`
+mutually-exclusive const groups (card has no alias; it's accepted purely via `choices`).
+
+**Docs/completions (same PR).** Help strings (`SEARCH_HELP`/`INFO_HELP`/`WAIT_HELP`), argparse
+`choices`, `docs/_include/task_{search,info,wait}_help.rst`, `share/bash_completion.d/hs`,
+`share/zsh/site-functions/_hs`, and regenerated `share/man/man1/*.1`. Exact file:line list in
+[`research/05`](research/05-docs-completions.md).
+
+### Requirement → design map
+
+| R-ID | Design element(s) that satisfy it |
+|------|-----------------------------------|
+| R1 | `'card'` added to `output_formats` on `TaskSearchApp`/`TaskInfoApp`(/`TaskWaitApp`); `print_card` dispatch; `normal` stays default; other formats untouched |
+| R2 | `render_card` → `Panel(box.ROUNDED)` with a `Table.grid` header row for id·fingerprint·group·part·(zone) |
+| R3 | `Group(header, "", regions)` with `Table.grid` label:value region blocks (command/timing/resources/hosts/output/retry/source/tags) |
+| R4 | `Task.status_label` ladder (model) + `STATUS_STYLES` (presentation) rendered as the lower-right Panel `subtitle` |
+| R5 | `W = clamp(console.size.width, 60, 160)`; `<90/90–129/>=130` → narrow/normal/wide region layout |
+| R6 | Single code path: rich strips ANSI on non-TTY, status always literal text; `BrokenPipeError` handled |
+| R7 | `hs info --format=card` and `hs list --format=card` both call the same `render_card` |
+| R8 | Help strings + `docs/_include/*` + bash/zsh completions + regenerated man pages, in-PR |
+
+## 3. Invariant gate (AGENTS.md constitution check)
+
+Checked against [`invariants.md`](../../.agents/factory/invariants.md) before research and again after
+this design.
+
+- **§1 Task lifecycle** — `Task.status_label` reproduces the exact nullable-column predicates
+  (unscheduled/in-flight/done/cancelled) and lives as a read-only `Task` property (state-query logic
+  on the model, not in FSM/driver code). It adds **no query** and performs **no state transition** —
+  display only.
+- **§2 exit_status overloading** — the ladder honors every reserved range: `0` OK, `>0` FAILED,
+  `CANCEL_STATUS(−1)` CANCELLED (checked before other negatives), `−2..−64` KILLED, `<=−1000` ERROR
+  (never-ran). No failure/retry/count query is added, so the "`!= 0 AND != CANCEL_STATUS`" rule can't
+  be violated — nothing here can resurrect a cancelled task.
+- **§12 conventions** — docs/_include help + bash/zsh completions land in the same PR as the CLI
+  change; man pages regenerated (generated asset); no new return codes (card reuses existing
+  success/`ArgumentError` paths and `cmdkit.app.exit_status`); idiomatic Python with real-equivalence
+  care.
+
+Not touched: §3 retry model (card displays `attempt`/`retried`/chain but changes no retry logic),
+§4–§11 (no server/client/queue/FSM/signal/config/cluster changes).
+
+### Deviation justifications
+
+| Deviation | Why needed | Simpler alternative rejected because |
+|-----------|-----------|--------------------------------------|
+| —         | —         | — |
+
+*(CANCELLED=yellow vs `select_style`'s `dim` is a GOAL-specified presentation choice on a new
+palette, not an invariant bend — `select_style` and normal/table coloring are unchanged.)*
+
+## 4. Rabbit holes (resolved)
+
+- **Can rich pin a badge to the lower-right corner without a custom layout?** → Yes: Panel
+  `subtitle=..., subtitle_align="right"` renders it flush in the bottom border; live-verified at
+  w=70 and w=120 ([`research/01`](research/01-rich-card-layout.md)).
+- **Where does status derivation belong, given it needs the whole row (not just exit_status)?** →
+  A read-only `Task.status_label` property on the model; existing `select_color`/`select_style` stay
+  (exit_status-only) for the other formats ([`research/02`](research/02-status-lifecycle-derivation.md)).
+- **How to classify never-ran tasks without a circular import?** → By the documented `exit_status
+  <= -1000` range, not by importing the `client.py` sentinels ([`research/02`](research/02-status-lifecycle-derivation.md)).
+- **How to get a clamped, testable width incl. the piped case?** → `console.size.width` (free 80-col
+  pipe fallback + `COLUMNS` honored), clamped to [60,160]; tests force width via a constructed
+  `Console` ([`research/04`](research/04-tty-width-color.md)).
+- **Shared renderer without an import cycle?** → Keep `render_card` in `task.py` next to
+  `print_normal`; do not move to `core/pretty_print.py` ([`research/03`](research/03-output-wiring.md)).
+
+## 5. Risks & open questions
+
+- **Man-page regeneration noise.** `sphinx-build -b man` may emit a date/line diff beyond the `card`
+  additions. *Mitigation:* regenerate in the final phase and inspect; if the diff is only `card` (±a
+  date line) keep it, otherwise **defer man to the next `/hs-release`** — the bash/zsh completions and
+  `docs/_include` snippets are the hard §12 requirement and are done with their CLI phases regardless.
+- **`hs wait --info -f card` parity** is included (small, adjacent) to avoid a spurious rejection;
+  it's technically beyond the GOAL's stated `list`+`info` scope. Flag for sign-off — trivial to drop
+  if unwanted.
+- **Narrow-mode header at 60 cols.** Full 36-char id + 32-char fingerprint can't sit horizontally;
+  the header stacks the id on its own line in narrow. Exact composition is a build decision inside R5;
+  the invariant is *never truncate the id*.
+- **Status badge in the border subtitle** is elegant but modest; if it reads as too subtle at narrow
+  widths, the fallback is a right-justified bottom body cell (`Table.grid(expand=True)`), same map —
+  no contract change.
+
+## 6. Verification strategy
+
+- **Unit** (`tests/`, `@mark.unit`):
+  - `status_label` ladder — construct `Task` objects covering each branch (unscheduled; scheduled but
+    incomplete; exit 0; `CANCEL_STATUS`; `-1001`; `-9`; `>0`; completed-with-null-exit) and assert the
+    label.
+  - `render_card` — render real `Task` objects through a **width-forced `Console`** (capture to a
+    buffer) at 60/70/120/150; assert the id appears in full, region labels present, `status: <LABEL>`
+    text present, and the panel honors the clamp; assert a non-TTY/no-color render still contains the
+    border + literal status text.
+  - `check_output_format` rejects `--format=card` with a field subset (parity with `normal`).
+- **Integration** (`@mark.integration`, shells out to the installed CLI): submit a handful of tasks in
+  a throwaway site and drive `hs list --format=card` and `hs info <id> --format=card`; grep the output
+  for a border glyph and `status:`.
+- **CLI eyeball** during build:
+  `.agents/factory/bin/temp_site.sh sh -c "seq 20 | uv run hsx -t 'echo {}' -N4 && uv run hs list --format=card"`,
+  repeated under `COLUMNS=70` and `COLUMNS=140` to see narrow/wide.
+- **Docs:** `uv run sphinx-build docs docs/_build` clean (no new warnings); grep completions + man for
+  `card`.
+
+---
+
+*Backing research: [`research/00-digest.md`](research/00-digest.md).*

--- a/spec/task-card-view/REVIEW.md
+++ b/spec/task-card-view/REVIEW.md
@@ -174,3 +174,31 @@ R3's submission/provenance region.
 additions this cycle were re-verified read-only with no finding. Verdict routed to
 `changes-requested` per the rubric (any CONFIRMED finding loops to `/hs-build`); the fix is small and
 localized to the two call sites.
+
+---
+
+## Review cycle 3 — approved (2026-08-01)
+
+- **Reviewed commit:** b3fd5b79e2d5ac578225d33b692558c9e5ae0a74  ·  **Base:** develop
+- **Mode:** **scoped remediation-verification** of cycle-2 finding **C2-1** (not a fresh full blind
+  pass — the remediation delta since `dbfe83b` is only `task.py` +20/−4 and `test_card_render.py`
+  +16/−1; no `data/model.py`/coupled-core change). Delegated to a fresh blind subagent to keep the
+  executed-evidence spine; denied PLAN/TECH/research/META/prior-REVIEW.
+
+### C2-1 — CLOSED
+
+The fix adds a shared `card_console()` (`task.py:1485`) = `Console(width=card_width(Console().size.
+width))`, and routes both card call sites (`TaskInfoApp.run` `task.py:207`, `TaskSearchApp.print_card`
+`task.py:805`) through it, so the **console** — not just the Panel — carries the clamped width. A
+wider-than-terminal Panel is no longer clipped.
+
+- Executed at `COLUMNS=30` (throwaway site): `hs list --format=card` and `hs info <id> --format=card`
+  both contain the **full task id** (`LIST_OK` / `INFO_OK`) — no truncation.
+- **R5** closed (unit `test_card_console_clamps_terminal_width`: 30→60, 9999→160, 100→100).
+- **R6** non-regressed: piped + `NO_COLOR=1` emits **zero ANSI**, `status:` literal (fixing `width`
+  leaves `is_terminal` detection intact).
+- **R1** non-regressed: default (~80) card renders; `normal`/`json`/`csv` unchanged; `normal` default.
+- Card suite `-k "card or status_label"` → **38 passed**. Tree clean on hand-back.
+
+**New findings:** none. **Human-gate triggers:** none (fix is in `task.py`, not a high-blast-radius
+core file or security/DB invariant). Verdict: **approved** → `/hs-publish`.

--- a/spec/task-card-view/REVIEW.md
+++ b/spec/task-card-view/REVIEW.md
@@ -86,3 +86,91 @@ invariant was weakened. No human sign-off gate is forced by this cycle.
 Not run this cycle (invoked as plain `/hs-review`). All five planned phases (P1–P5) are marked `done`
 in `TECH.md` and the requirement→evidence matrix shows full R1–R8 coverage; scope stayed within the
 `big` appetite with no unmapped changes.
+
+---
+
+## Review cycle 2 — changes-requested (2026-08-01)
+
+- **Reviewed commit:** dbfe83b93ab04c59cdabda8bec987eb1d22bef75  ·  **Base:** develop
+- **Trigger:** cycle 1 approved at `232b277`, then two commits landed after it — `b67d827`
+  (*Refine: submission region + source fingerprint*, re-touching `data/model.py`) and `dbfe83b`
+  (*docstring reformat*). `last_reviewed_commit` was stale, so this is a **fresh full blind pass**
+  over `git diff develop...HEAD -- . ':(exclude)spec/'` (not a scoped remediation pass — cycle 1
+  had no findings to remediate).
+- **Mode:** single blind `general-purpose` reviewer (curated inputs: `GOAL.md` inline,
+  spec-excluded diff, `invariants.md`, `review-rubric.md`; denied `PLAN.md`/`TECH.md`/`research/`/
+  `META.md`/prior `REVIEW.md`). Orchestrator second-pass sanity check by code inspection.
+
+### Verification run (executed, not asserted)
+
+- `uv run pytest -q -m unit -k "card or status_label"`, `uv run pytest -q -k card`, and the full
+  `uv run pytest -q` suite — **459 passed**; the only failure (`test_groups.py::
+  test_group_hard_failure_halts`) is a **pre-existing timing-flaky** server group-gating test that
+  passes in isolation and lies on a path this diff does not touch.
+- Real CLI in a throwaway site (`.agents/factory/bin/temp_site.sh`, never the developer's DB):
+  OK/FAILED/WAITING badges correct; shell-metachar commands (`sed 's/x/[/]/'`,
+  `echo '[bold]hi[/bold]'`) render verbatim (rich-markup safety holds); piped non-TTY + `NO_COLOR=1`
+  emit zero ANSI with border + literal `status:` intact (**R6**); `hs info … --format=card` matches
+  `hs list` for the same id (**R7**); `json`/`csv`/`table`/`plain`/`normal` unchanged (**R1**).
+- Width sweep `COLUMNS` 30/60/100/150/200 → rendered widths 30/60/100/150/**160**: the **max** clamp
+  holds; the **min-60** clamp does **not** (finding C2-1 below).
+- Non-goal proof: the `format_task_fields` extraction is behavior-preserving — full suite (incl.
+  existing `normal` tests) green; the only textual delta (`int(format_json(x))`→`int(x)` for the
+  INTEGER `waited`/`duration` columns) is a verified identity.
+- `git status --porcelain` empty at reviewer hand-back (tree left clean); orchestrator re-verified
+  the `data/model.py` additions are read-only (`Task.status_label` property + `Source.
+  fingerprints_for_ids` batched query mirroring `paths_for_ids`) — no query/state-transition or
+  `exit_status`-range logic altered (§1/§2 clean).
+
+### Findings
+
+**C2-1 — MEDIUM · CONFIRMED · R5 (partial).** The min-60 width clamp is **inert below 60 columns**,
+so the card renders narrower than the contracted floor and the identity header (full UUID +
+fingerprint) is truncated with an ellipsis.
+
+- **Where:** `render_card`/`card_width` (`src/hypershell/task.py:1480`, `1516`) are correct in
+  isolation, but both call sites — `TaskInfoApp.run` (`task.py:207-208`) and
+  `TaskSearchApp.print_card` (`task.py:805-810`) — print into a **bare `Console()`** sized to the
+  real terminal while passing the clamped width only to the `Panel`. Rich clips a Panel wider than
+  its Console to the console width, defeating the min-60 floor.
+- **Failure scenario:** `COLUMNS=30 hs list --format=card` →
+  `id 019fbe23-7da9-7b11-9801-0…` (UUID truncated, uncopyable); `fp 5ebb0a127fb5bd6… g… …`
+  (fingerprint + group/part truncated). Contradicts R5's explicit "minimum of 60" and the
+  renderer's own docstring guarantee ("the id … never truncated"). `normal` mode preserves the full
+  id at the same width.
+- **Severity rationale:** edge path (default piped width 80; typical TTYs ≥ 80), and clipping is a
+  *defensible* fallback — hence MEDIUM, not HIGH. But it is a real, reproducible gap against a stated
+  acceptance criterion.
+- **Fix direction:** size the console to the clamped width at both call sites —
+  `Console(width=card_width(console.size.width))` — so a sub-60 terminal renders a structurally
+  60-wide card (id on its own line, intact; terminal soft-wraps/scrolls the overflow, matching how
+  `normal` mode's long lines already behave) instead of truncating. Add a render-through-a-narrow-
+  console regression test (the existing `test_id_never_truncated_even_at_min_width` forces the width
+  directly and so does not exercise the call-site console-sizing path).
+
+No other correctness bugs, invariant violations, or scope creep survived the refutation protocol.
+
+### Requirement → evidence matrix (cycle 2)
+
+| R-ID | Verified how | Status |
+|------|--------------|--------|
+| R1 — additive; other formats unchanged | full suite + live normal/plain/json/csv/table; `format_task_fields` equivalence proof | ✅ |
+| R2 — bordered custom layout; id/fp/group/part horizontal + zone slot | live render 100/150; unit tests | ✅ (id truncation <60 → C2-1) |
+| R3 — labeled regions w/ color/emphasis | live render shows all region titles; unit tests | ✅ |
+| R4 — lower-right lifecycle `status:` badge, ≥6 states | `status_label` + `STATUS_STYLES`; live OK/FAILED/WAITING; parametrized tests | ✅ |
+| R5 — auto narrow/normal/wide, clamp [60,160] | width sweep 30–200 | ⚠️ **partial** — max clamp holds, **min-60 inert** (C2-1) |
+| R6 — non-TTY/NO_COLOR legible, status plain | live piped + `NO_COLOR=1`; unit test | ✅ |
+| R7 — info card == list card (shared renderer) | live `hs info` vs `hs list` same id; integration test | ✅ |
+| R8 — docs snippets + completions list `card`, same commit | grep of 3× rst + bash + zsh | ✅ |
+
+**Unmapped changes:** none blocking. Docstring reformatting (`dbfe83b`) of pre-existing functions is
+comments-only/behavior-inert (house style); the source content-fingerprint parenthetical sits within
+R3's submission/provenance region.
+
+### Human-gate triggers
+
+**None mandatory.** The sole CONFIRMED finding (C2-1) is in `task.py` rendering + its call sites —
+**not** a high-blast-radius core file and not a security/DB-lifecycle invariant. The `data/model.py`
+additions this cycle were re-verified read-only with no finding. Verdict routed to
+`changes-requested` per the rubric (any CONFIRMED finding loops to `/hs-build`); the fix is small and
+localized to the two call sites.

--- a/spec/task-card-view/REVIEW.md
+++ b/spec/task-card-view/REVIEW.md
@@ -1,0 +1,88 @@
+# REVIEW — Rich "card" view for tasks
+
+> Adversarial QA by `hs-review`, run in an isolated/clean context. The correctness pass grades the
+> branch diff against [`GOAL.md`](GOAL.md) + the AGENTS.md invariants **only** — it does not see
+> `PLAN.md`/`TECH.md` (avoids grading-its-own-homework / plan-sycophancy). Every finding cites an
+> **executed** command, not an assertion.
+
+- **Reviewed commit:** 232b2773caf4d7d17cc2c0acd39e7f1a37ff6b96  ·  **Base:** develop  ·  **Date:** 2026-08-01
+- **Verdict:** approved
+- **Cycle:** 1 of ≤3 — mirrors `review.cycle` in `TECH.md`
+
+## Verification run
+
+Blind correctness pass delegated to a fresh `general-purpose` reviewer (curated inputs: `GOAL.md`
+inline, spec-excluded diff `git diff develop...HEAD -- . ':(exclude)spec/'`, `invariants.md`,
+`review-rubric.md`; denied `PLAN.md`/`TECH.md`/`research/`/`META.md`). Commands actually executed
+and their outcomes (the spine of the review):
+
+- `uv run pytest -q -m unit -k "card or status_label"` → **34 passed**.
+- `uv run pytest -q -k card` → **27 passed** (incl. the `@mark.integration` card test).
+- `uv run pytest -q` (full suite) → **458 passed** in ~252s — **no regressions** (covers the
+  existing `normal`-output tests, proving the `format_task_fields` extraction is behavior-preserving).
+- Real CLI in a throwaway site (`.agents/factory/bin/temp_site.sh`, never the developer's DB):
+  - **OK** cards (`hsx` run to completion), **FAILED** cards (`false`, `sh -c 'exit 3'`), **WAITING**
+    cards (submit-only) — all with the correct lower-right badge.
+  - Shell-metachar commands `sed 's/x/[/]/'` and `echo '[bold]hi[/bold]'` render **verbatim** — no
+    `MarkupError`, no bracket stripping (the `rich.text.Text` cell-wrapping holds).
+  - Piped (non-TTY): every line exactly 80 wide, box border intact, `status: OK` survives as plain
+    text; `NO_COLOR=1` piped: no ANSI emitted, border drawn, status readable (**R6**).
+  - `hs info <id> --format=card` renders the **same** card as `hs list` for that id (**R7**).
+  - `json` / `csv` / `table` / `plain` / `normal` outputs all **unchanged** (**R1** non-goal held).
+  - `hs list id --format=card` correctly rejected: *"Cannot use --format=card with subset of field names"*.
+  - Controlled `render_card` at widths 60/70/80/90/100/130/150/160 → every line exactly the target
+    width (border alignment); `card_width(10)==60`, `card_width(9999)==160` (**R5** clamp).
+- `uv run sphinx-build docs docs/_build` → only pre-existing warnings
+  (`task_submit.rst`/`manual.rst` toctree + `pkg_resources` deprecation); **no new warnings**.
+- `git status --porcelain` empty at reviewer hand-back (tree left clean).
+
+Orchestrator sanity check: independently inspected the `data/model.py` diff — a single additive
+read-only `status_label` property, no query/state mutation, no new column; the lifecycle ladder
+reproduces the nullable-column predicates exactly and guards `None` before the numeric comparisons.
+
+## Requirement → evidence matrix
+
+| R-ID | Implemented by (file) | Verified how | Status |
+|------|-----------------------|--------------|--------|
+| R1 — card additive; `normal` default; other formats unchanged | `task.py` `output_formats`/dispatch (L172/199/218, L751); info branch (L206–208) | Full suite 458 passed (normal tests intact); live CLI json/csv/table/plain/normal unchanged; subset guard rejects `card` | ✅ |
+| R2 — self-contained border, custom layout (not `table`), id/fp/group/part horizontal + room for `zone` | `render_card` → `Panel(box=ROUNDED)` over `Table.grid`; identity header (L370–385) with reserved `zone` cell | CLI shows `╭─ task …╮` border, header row across the top; distinct from `print_table` | ✅ |
+| R3 — labeled logical regions w/ color/emphasis | `card_region` titled blocks: command/timing/resources/execution/output/retry/result/tags (L387–415) | CLI shows all region titles (`bold underline`), labels `dim` | ✅ |
+| R4 — lower-right `status:` badge from lifecycle, ≥6 states | `Task.status_label` (model.py:349–366) + `STATUS_STYLES` (task.py:260–269); Panel `subtitle`, `subtitle_align='right'` | Parametrized test + live OK/FAILED/WAITING; `None`-guard before numeric compare (no crash) | ✅ |
+| R5 — auto narrow/normal/wide, clamp [60,160] | `card_width` clamp; `ncols = 1 if <90 else 2 if <150 else 3`; header stacks <130 | 1/2/3-col verified at 70/100/155; clamp at 40/300 → 60/160 | ✅ |
+| R6 — non-TTY / NO_COLOR / COLOR_STDOUT-false legible; status plain | `Text` cells + rich off-terminal style drop | Piped 80-wide aligned; `NO_COLOR=1` no ANSI, border intact, `status:` plain | ✅ |
+| R7 — `hs info --format=card` == `hs list` card (shared renderer) | Both call `render_card`; `hs wait` delegates to `TaskInfoApp` | Live CLI: identical single card for the same id | ✅ |
+| R8 — docs snippets + completions list `card`, same commit | `task_{info,search,wait}_help.rst`, `bash_completion.d/hs`, `zsh/site-functions/_hs` | grep: every `-f/--format` completion in both shells includes `card`; updated in P3/P4 commits | ✅ |
+
+**Unmapped changes (possible scope creep):** none. `format_task_fields` is a behavior-preserving
+extraction shared by `normal` and the card (supports R3/R7, keeps `normal` byte-identical — a
+refactor, not a restyle, so the "normal unchanged" non-goal holds).
+
+## Findings
+
+**None.** No CRITICAL / HIGH / MEDIUM / LOW correctness findings survived the refutation protocol.
+The diff is clean against GOAL R1–R8 and the AGENTS.md invariants.
+
+Invariant check (informational, no violation): `data/model.py` gains only a read-only `status_label`
+property — no query, no state mutation. It reproduces the nullable-column lifecycle predicates
+exactly (`schedule_time`→WAITING, `completion_time`→RUNNING, `==CANCEL_STATUS`→CANCELLED **before**
+the signal range, `<=-1000`→ERROR, `None`-guard before numeric compare) and honors the `exit_status`
+reserved ranges. Correctly placed in the model per §1. No footgun tripped.
+
+Transparency note (not a finding): the generated man pages
+`share/man/man1/{hs,hsx,hyper-shell}.1` still list the old format set and do not yet mention `card`.
+This is **consistent with the documented repo workflow** — man pages are a release-time generated
+aggregate rebuilt by `/hs-release`; the §12 same-commit rule names `docs/_include` + `share/`
+completions, both of which **are** updated. Flagged only so the `card` man lines are not forgotten
+at the next release.
+
+## Human-gate triggers
+
+**None triggered.** The only high-blast-radius file touched (`data/model.py`) received a purely
+additive read-only property with **no** CONFIRMED finding against it, and no security/DB-lifecycle
+invariant was weakened. No human sign-off gate is forced by this cycle.
+
+## Optional completeness sub-pass (separate reviewer; may see TECH.md)
+
+Not run this cycle (invoked as plain `/hs-review`). All five planned phases (P1–P5) are marked `done`
+in `TECH.md` and the requirement→evidence matrix shows full R1–R8 coverage; scope stayed within the
+`big` appetite with no unmapped changes.

--- a/spec/task-card-view/TECH.md
+++ b/spec/task-card-view/TECH.md
@@ -6,7 +6,7 @@ appetite: big
 status: in_progress
 branch: feature/task-card-view
 base: develop
-current_phase: P4
+current_phase: P5
 last_updated: '2026-08-01'
 phases:
 - id: P1
@@ -50,7 +50,7 @@ phases:
     -N4 && uv run hs list --format=card"
 - id: P4
   name: Wire card into hs info (+ hs wait parity) with info/wait docs & completions
-  status: pending
+  status: done
   satisfies:
   - R7
   - R1
@@ -190,18 +190,25 @@ responsive to terminal width; `normal` stays default; search help/docs/completio
 `hs list` renders that task; `hs wait --info -f card` accepted for parity; info/wait
 help/docs/completions list `card`.
 
-- [ ] In `TaskInfoApp` (`task.py`): add `'card'` to `output_formats` (`:172`) and branch `run()`
-      (`:201`) so `card` computes the clamped width and prints `render_card(self.task, W)` for the
-      single loaded task (source resolved directly, no batch needed).
-- [ ] In `TaskWaitApp` (`task.py`): add `'card'` to its forwarded `output_formats` (`:339`) so
-      `hs wait --info -f card` delegates cleanly to `TaskInfoApp`.
-- [ ] Update `INFO_HELP` (`:141`) and `WAIT_HELP` `-f/--format` enumerations to include `card`.
-- [ ] Same commit (§12): `docs/_include/task_info_help.rst` (`:11`), `task_wait_help.rst` (`:19`);
-      `share/bash_completion.d/hs` info (`:297`) & wait (`:327`) word lists; `share/zsh/site-functions/_hs`
-      info (`:355`) & wait (`:377`) specs.
-- [ ] Unit/functional tests (`@mark.unit`, `-k card_info`): submit a task in a `temp_site`, then run
-      `hs info <id> --format=card` via the `tests.main(argv)` helper and assert the border + `status:`
-      + the id are present; assert `hs info` accepts `card` in its `choices`.
+- [x] In `TaskInfoApp` (`task.py`): added `'card'` to `output_formats` and a `run()` branch that
+      creates one `Console()` and prints `render_card(self.task, card_width(console.size.width))` for
+      the single loaded task (source resolved directly via the `source_map=None` path — no batch).
+- [x] In `TaskWaitApp` (`task.py`): added `'card'` to its forwarded `output_formats` so
+      `hs wait --info -f card` delegates cleanly to `TaskInfoApp` (which now handles it).
+- [x] Updated `INFO_HELP` and `WAIT_HELP` `-f/--format` enumerations to `([normal], card, json, yaml)`.
+- [x] Same commit (§12): `docs/_include/task_info_help.rst` (+ prose), `task_wait_help.rst`;
+      `share/bash_completion.d/hs` info & wait word lists (`normal card json yaml`);
+      `share/zsh/site-functions/_hs` info & wait specs (`:format:(normal card json yaml)`).
+- [x] Functional tests (`tests/test_card_info.py`, `@mark.unit`, `-k card_info`): `card` is a choice
+      for both info and wait; `hs info <id> --format=card` on a submitted task renders exactly one
+      card with the full id and `status: WAITING` (the honest unscheduled state, via `tests.main`);
+      `normal` remains the info default. The **completed-task `OK` card and `hs wait --info -f card`**
+      (which blocks until completion) are pinned by the **P5 integration** test — verified manually
+      here: a run-to-completion task renders `status: OK` via both `hs info` and `hs wait --info`.
+- **Verify:** `uv run pytest -m unit -k card_info` → 3 passed (full unit suite 203 passed).
+- **Touches:** `src/hypershell/task.py`, `docs/_include/task_info_help.rst`,
+  `docs/_include/task_wait_help.rst`, `share/bash_completion.d/hs`, `share/zsh/site-functions/_hs`,
+  `tests/test_card_info.py`.
 - **Verify:** `uv run pytest -m unit -k card_info`.
 - **Touches:** `src/hypershell/task.py`, `docs/_include/task_info_help.rst`,
   `docs/_include/task_wait_help.rst`, `share/bash_completion.d/hs`, `share/zsh/site-functions/_hs`.

--- a/spec/task-card-view/TECH.md
+++ b/spec/task-card-view/TECH.md
@@ -6,12 +6,12 @@ appetite: big
 status: in_progress
 branch: feature/task-card-view
 base: develop
-current_phase: P1
+current_phase: P2
 last_updated: '2026-08-01'
 phases:
 - id: P1
   name: Derive task status from lifecycle (Task.status_label)
-  status: pending
+  status: done
   satisfies:
   - R4
   depends_on: []
@@ -20,7 +20,8 @@ phases:
   hill: uphill
   verify: uv run pytest -m unit -k status_label
 - id: P2
-  name: Card renderer (Panel + header + regions + lower-right status + responsive width)
+  name: Card renderer (Panel + header + regions + lower-right status + responsive
+    width)
   status: pending
   satisfies:
   - R2
@@ -45,7 +46,8 @@ phases:
   parallel: false
   hammerable: false
   hill: crest
-  verify: ".agents/factory/bin/temp_site.sh sh -c \"seq 20 | uv run hsx -t 'echo {}' -N4 && uv run hs list --format=card\""
+  verify: .agents/factory/bin/temp_site.sh sh -c "seq 20 | uv run hsx -t 'echo {}'
+    -N4 && uv run hs list --format=card"
 - id: P4
   name: Wire card into hs info (+ hs wait parity) with info/wait docs & completions
   status: pending
@@ -77,7 +79,6 @@ review:
   blocked_reason: ''
   cycle: 0
 ---
-
 # TECH.md — Rich "card" view for tasks
 
 The **context engine and finite-state machine** for building this feature. The YAML frontmatter is the
@@ -108,20 +109,23 @@ the per-phase checklists below are the work. `hs-build` executes the next action
 **Goal:** A read-only `Task.status_label` property maps a fully-loaded task to exactly one lifecycle
 label, honoring the `exit_status` reserved ranges — the foundation the badge renders.
 
-- [ ] In `src/hypershell/data/model.py`, add a read-only property `Task.status_label -> str`
+- [x] In `src/hypershell/data/model.py`, add a read-only property `Task.status_label -> str`
       implementing the **order-critical** ladder (see [`research/02`](research/02-status-lifecycle-derivation.md)):
       `schedule_time is None`→`WAITING`; elif `completion_time is None`→`RUNNING`; elif
       `exit_status == 0`→`OK`; elif `exit_status == CANCEL_STATUS`→`CANCELLED`; elif
-      `exit_status <= -1000`→`ERROR`; elif `exit_status < 0`→`KILLED`; elif `exit_status > 0`→`FAILED`;
-      else→`UNKNOWN`. Comment it as a declarative statement of the invariant it reproduces.
-- [ ] Do **not** import `TASK_TEMPLATE_ERROR`/`TASK_RESOURCE_ERROR` (circular + heavy `client.py`
-      import) — classify never-ran by the documented `<= -1000` range.
-- [ ] Add `tests/` unit coverage (`@mark.unit`, SPDX header): construct `Task` objects covering each
-      branch (unscheduled; scheduled+incomplete; exit 0; `CANCEL_STATUS`; `-1001`; `-9`; `>0`;
-      completed+null-exit) and assert `status_label`. Name tests so `-k status_label` selects them.
-- **Verify:** `uv run pytest -m unit -k status_label`.
+      `exit_status is None`→`UNKNOWN`; elif `exit_status <= -1000`→`ERROR`; elif `exit_status < 0`→
+      `KILLED`; else (`> 0`)→`FAILED`. Comment it as a declarative statement of the invariant it
+      reproduces. (The `is None` check moved ahead of the numeric comparisons vs. the digest's
+      ordering, so a completed-but-unstamped row can't raise on `None < 0`.)
+- [x] Did **not** import `TASK_TEMPLATE_ERROR`/`TASK_RESOURCE_ERROR` (circular + heavy `client.py`
+      import) — never-ran classified by the documented `<= -1000` range.
+- [x] Added `tests/test_status_label.py` (`@mark.unit`, SPDX header): construct transient `Task`
+      objects covering every branch (unscheduled; scheduled+incomplete; exit 0; `CANCEL_STATUS`;
+      `-1001`/`-1002`/`-5000`; `-2`/`-9`/`-64`; `1`/`127`; completed+null-exit) and assert
+      `status_label`. Module name selects under `-k status_label`.
+- **Verify:** `uv run pytest -m unit -k status_label` → 8 passed.
 - **Touches:** `src/hypershell/data/model.py` (high-blast-radius, **additive read-only only**),
-  `tests/…`.
+  `tests/test_status_label.py`.
 
 ## Phase P2 — Card renderer
 **Satisfies:** R2, R3, R4, R5, R6 · **Depends on:** P1

--- a/spec/task-card-view/TECH.md
+++ b/spec/task-card-view/TECH.md
@@ -74,11 +74,10 @@ phases:
   hill: downhill
   verify: uv run pytest -m integration -k card
 review:
-  last_reviewed_commit: dbfe83b93ab04c59cdabda8bec987eb1d22bef75
-  verdict: changes-requested
-  blocked_reason: R5 min-60 width clamp inert below 60 cols (card call sites use bare
-    Console); id truncated
-  cycle: 2
+  last_reviewed_commit: b3fd5b79e2d5ac578225d33b692558c9e5ae0a74
+  verdict: approved
+  blocked_reason: ''
+  cycle: 3
 ---
 # TECH.md — Rich "card" view for tasks
 

--- a/spec/task-card-view/TECH.md
+++ b/spec/task-card-view/TECH.md
@@ -6,7 +6,7 @@ appetite: big
 status: in_progress
 branch: feature/task-card-view
 base: develop
-current_phase: P2
+current_phase: P3
 last_updated: '2026-08-01'
 phases:
 - id: P1
@@ -22,7 +22,7 @@ phases:
 - id: P2
   name: Card renderer (Panel + header + regions + lower-right status + responsive
     width)
-  status: pending
+  status: done
   satisfies:
   - R2
   - R3
@@ -133,27 +133,31 @@ label, honoring the `exit_status` reserved ranges — the foundation the badge r
 horizontal id/fingerprint/group/part/(zone) header, labeled regions, lower-right `status:` badge —
 that adapts across narrow/normal/wide and stays legible with no color.
 
-- [ ] In `src/hypershell/task.py`, add `STATUS_STYLES: Dict[str, str]` beside `select_style`:
+- [x] In `src/hypershell/task.py`, added `STATUS_STYLES: Dict[str, str]` beside `select_style`:
       OK→`bold green`, FAILED→`bold red`, CANCELLED→`yellow`, RUNNING→`cyan`, WAITING→`dim`,
       ERROR/KILLED/UNKNOWN→`magenta`.
-- [ ] Add `render_card(task, width, source_map=None) -> Panel` next to `print_normal`. Reuse
-      `print_normal`'s field-prep (waited/duration/timeout→`timedelta`, memory/`memory_max`→
-      `format_bytes`, cores, `resolve_source`, `format_tag`). Compose `Panel(Group(header, "",
-      regions), title="task", title_align="left", box=box.ROUNDED, width=width, padding=(0,1),
-      subtitle=f"status: {task.status_label}", subtitle_align="right",
-      border_style=STATUS_STYLES[task.status_label])`. Header = `Table.grid(expand=True)`. Regions =
-      `Table.grid` label:value blocks grouped command / timing / resources / hosts / output / retry /
-      source / tags, side-by-side via `Columns(expand=True, equal=True)` in normal/wide, **stacked** in
-      narrow. **Never truncate the id**; fingerprint may abbreviate in narrow.
-- [ ] Responsive: caller passes a clamped `width`; regions pick layout by `<90` narrow / `90–129`
-      normal / `>=130` wide. Style the badge/border via `STATUS_STYLES`; rely on rich to strip ANSI
-      when non-TTY so the literal `status:` text always survives (R6).
-- [ ] Unit tests (`@mark.unit`, `-k card_render`): render real `Task` objects through a width-forced
-      `Console(width=…, file=StringIO())` at 60/70/120/150; assert full id present, region labels
-      present, `status: <LABEL>` text present, output width within the clamp; assert a no-color render
-      (e.g. `Console(..., no_color=True)` / non-terminal) still shows border + literal status text.
-- **Verify:** `uv run pytest -m unit -k card_render`.
-- **Touches:** `src/hypershell/task.py`, `tests/…`.
+- [x] Added `render_card(task, width, source_map=None) -> Panel` next to `print_normal`, plus a shared
+      `format_task_fields` (extracted from `print_normal`, which now delegates to it — `normal` output
+      byte-identical), `card_region`, `card_width`, and `CARD_MIN_WIDTH`/`CARD_MAX_WIDTH`. Composes
+      `Panel(Group(header, command, columns[, tags]), title="task", box=box.ROUNDED, width=W,
+      subtitle=Text("status: <LABEL>"), subtitle_align="right", border_style=STATUS_STYLES[...])`.
+      Header = `Table.grid`; regions = `Table.grid` label:value blocks (command / timing / resources /
+      execution / output / retry / result / tags) arranged in a `Table.grid` of 1/2/3 columns. **Id
+      never truncated** (own line below 130).
+- [x] Responsive: `card_width` clamps to [60,160]; region columns = `<90` →1, `90–149` →2, `>=150` →3
+      (three columns only where a full UUID does not fold mid-token); identity header goes horizontal
+      at `>=130`. rich strips ANSI on a non-TTY so the literal `status:` text always survives (R6).
+- [x] **AMENDMENT (adversarial review, HIGH):** region values are wrapped in `rich.text.Text` so task
+      data renders literally — a bare string cell is parsed as `rich` markup, which silently stripped
+      brackets (`awk '{a[b]=1}'`) and raised `MarkupError` on `sed 's/x/[/]/'`, aborting the whole
+      listing. The header was already immune (`Text.assemble`). Regression test added.
+- [x] Unit tests (`tests/test_card_render.py`, `@mark.unit`, `-k card_render`): render real `Task`
+      objects through a width-forced `Console(file=StringIO())`; assert full id, fingerprint, region
+      titles, `status: <LABEL>`; the [60,160] clamp; distinct 1/2/3-column layouts; horizontal vs
+      stacked header; badge lower-right + pinned palette; tags present/omitted; no-color legibility;
+      color-on-TTY; and the markup-safety regression. 24 card tests, 200 unit total.
+- **Verify:** `uv run pytest -m unit -k card_render` → 24 passed (full unit suite 200 passed).
+- **Touches:** `src/hypershell/task.py`, `tests/test_card_render.py`.
 
 ## Phase P3 — Wire `card` into `hs list` / `hs search`
 **Satisfies:** R1, R8 · **Depends on:** P2

--- a/spec/task-card-view/TECH.md
+++ b/spec/task-card-view/TECH.md
@@ -74,10 +74,10 @@ phases:
   hill: downhill
   verify: uv run pytest -m integration -k card
 review:
-  last_reviewed_commit: ''
-  verdict: none
+  last_reviewed_commit: 232b2773caf4d7d17cc2c0acd39e7f1a37ff6b96
+  verdict: approved
   blocked_reason: ''
-  cycle: 0
+  cycle: 1
 ---
 # TECH.md — Rich "card" view for tasks
 

--- a/spec/task-card-view/TECH.md
+++ b/spec/task-card-view/TECH.md
@@ -3,7 +3,7 @@ slug: task-card-view
 title: Rich "card" view for tasks
 kind: feature
 appetite: big
-status: in_review
+status: done
 branch: feature/task-card-view
 base: develop
 current_phase: done

--- a/spec/task-card-view/TECH.md
+++ b/spec/task-card-view/TECH.md
@@ -6,7 +6,7 @@ appetite: big
 status: in_progress
 branch: feature/task-card-view
 base: develop
-current_phase: P3
+current_phase: P4
 last_updated: '2026-08-01'
 phases:
 - id: P1
@@ -37,7 +37,7 @@ phases:
   verify: uv run pytest -m unit -k card_render
 - id: P3
   name: Wire card into hs list / hs search (+ search docs & completions)
-  status: pending
+  status: done
   satisfies:
   - R1
   - R8
@@ -164,19 +164,23 @@ that adapts across narrow/normal/wide and stays legible with no color.
 **Goal:** `hs list --format=card` / `hs search … --format=card` render one card per matched task,
 responsive to terminal width; `normal` stays default; search help/docs/completions list `card`.
 
-- [ ] In `TaskSearchApp` (`task.py`): add `'card'` to `output_formats` (`:663`). Add
-      `print_card(self, results)` mirroring the static `print_normal` (`:783`) — build `Task` objects,
-      batch `Source.paths_for_ids`, create one `Console()`, compute `W = max(60, min(160,
-      console.size.width))`, loop `console.print(render_card(task, W, source_map))`. Extend the subset
-      guard in `check_output_format` (`:829`) from `== 'normal'` to `in ('normal', 'card')`.
-- [ ] Update the `SEARCH_HELP` `-f/--format` enumeration (`task.py:591`) to include `card`.
-- [ ] Same commit (§12): `docs/_include/task_search_help.rst` (`:75`),
-      `share/bash_completion.d/hs` search word list (`:418`), `share/zsh/site-functions/_hs` search
-      spec (`:417`, append ` card` inside the `(…)`). (`hsx` bash file is a symlink → covered.)
-- [ ] Sanity: `zsh -n share/zsh/site-functions/_hs`; confirm `--format` rejects unknown values and
-      `card` requires all fields (`hs list id --format=card` → the subset error).
-- **Verify:** `.agents/factory/bin/temp_site.sh sh -c "seq 20 | uv run hsx -t 'echo {}' -N4 && uv run hs list --format=card"`
-  (also eyeball under `COLUMNS=70` and `COLUMNS=140`).
+- [x] In `TaskSearchApp` (`task.py`): added `'card'` to `output_formats` (after `normal`). Added the
+      static `print_card(results)` mirroring `print_normal` — build `Task` objects, batch
+      `Source.paths_for_ids`, one `Console()`, `card_width(console.size.width)`, loop
+      `console.print(render_card(task, W, source_map))` with a blank line between cards. Extended the
+      subset guard in `check_output_format` from `== 'normal'` to `in ('normal', 'card')` (message now
+      interpolates the format).
+- [x] Updated the `SEARCH_HELP` `-f/--format` enumeration to `(normal, card, plain, table, csv, json)`.
+- [x] Same commit (§12): `docs/_include/task_search_help.rst` (added `card` to the list + a prose
+      sentence), `share/bash_completion.d/hs` search word list (`normal card plain table csv json`),
+      `share/zsh/site-functions/_hs` search spec (`:format:(normal card plain table csv json)`).
+      (`hsx` bash file is a symlink → covered.)
+- [x] Sanity: `zsh -n share/zsh/site-functions/_hs` OK; module import OK; `hs list id --format=card`
+      → `Cannot use --format=card with subset of field names`.
+- **Verify:** drove `hs list --format=card` in a `temp_site` (20 echo tasks, `-N4`): **20 cards, all
+      `status: OK`**; subset rejected; `normal` still the default (0 cards without `--format`);
+      responsive confirmed live at `COLUMNS=70`(1-col) / `100`(2-col) / `155`(3-col + horizontal
+      header). Full unit suite 200 passed.
 - **Touches:** `src/hypershell/task.py`, `docs/_include/task_search_help.rst`,
   `share/bash_completion.d/hs`, `share/zsh/site-functions/_hs`.
 

--- a/spec/task-card-view/TECH.md
+++ b/spec/task-card-view/TECH.md
@@ -3,7 +3,7 @@ slug: task-card-view
 title: Rich "card" view for tasks
 kind: feature
 appetite: big
-status: blocked
+status: in_review
 branch: feature/task-card-view
 base: develop
 current_phase: done
@@ -33,7 +33,7 @@ phases:
   - P1
   parallel: false
   hammerable: false
-  hill: uphill
+  hill: downhill
   verify: uv run pytest -m unit -k card_render
 - id: P3
   name: Wire card into hs list / hs search (+ search docs & completions)
@@ -157,7 +157,18 @@ that adapts across narrow/normal/wide and stays legible with no color.
       titles, `status: <LABEL>`; the [60,160] clamp; distinct 1/2/3-column layouts; horizontal vs
       stacked header; badge lower-right + pinned palette; tags present/omitted; no-color legibility;
       color-on-TTY; and the markup-safety regression. 24 card tests, 200 unit total.
-- **Verify:** `uv run pytest -m unit -k card_render` → 24 passed (full unit suite 200 passed).
+- [x] **REMEDIATION (review cycle 2, C2-1 · MEDIUM · R5):** the min-60 clamp was *inert below 60
+      columns* — the `hs list`/`hs info` call sites printed into a bare `Console()` sized to the raw
+      terminal, so rich clipped the ≥60 Panel down to the terminal width and truncated the id
+      (`COLUMNS=30` → `id 019fbe23-…-0…`). Added a shared `card_console()` (a `Console` fixed to
+      `card_width(detected)`) and routed both call sites (`TaskInfoApp.run`, `TaskSearchApp.print_card`)
+      through it, so the console — not just the Panel — carries the clamped width. `is_terminal`
+      detection is untouched, so R6 (non-TTY drops color, status stays literal) still holds. Regression
+      test `test_card_console_clamps_terminal_width` (COLUMNS 30→60, 9999→160, 100→100). No CLI-surface
+      change, so no docs/completions delta.
+- **Verify:** `uv run pytest -m unit -k card_render` → 26 passed (full unit suite 206 passed). CLI
+      drive at `COLUMNS=30`: `hs list`/`hs info --format=card` render a 60-wide card with the **full id
+      present**; default piped width still 80; `NO_COLOR=1` piped emits 0 ANSI with `status: OK` plain.
 - **Touches:** `src/hypershell/task.py`, `tests/test_card_render.py`.
 
 ## Phase P3 — Wire `card` into `hs list` / `hs search`

--- a/spec/task-card-view/TECH.md
+++ b/spec/task-card-view/TECH.md
@@ -3,7 +3,7 @@ slug: task-card-view
 title: Rich "card" view for tasks
 kind: feature
 appetite: big
-status: in_review
+status: blocked
 branch: feature/task-card-view
 base: develop
 current_phase: done
@@ -74,10 +74,11 @@ phases:
   hill: downhill
   verify: uv run pytest -m integration -k card
 review:
-  last_reviewed_commit: 232b2773caf4d7d17cc2c0acd39e7f1a37ff6b96
-  verdict: approved
-  blocked_reason: ''
-  cycle: 1
+  last_reviewed_commit: dbfe83b93ab04c59cdabda8bec987eb1d22bef75
+  verdict: changes-requested
+  blocked_reason: R5 min-60 width clamp inert below 60 cols (card call sites use bare
+    Console); id truncated
+  cycle: 2
 ---
 # TECH.md — Rich "card" view for tasks
 

--- a/spec/task-card-view/TECH.md
+++ b/spec/task-card-view/TECH.md
@@ -1,0 +1,228 @@
+---
+slug: task-card-view
+title: Rich "card" view for tasks
+kind: feature
+appetite: big
+status: in_progress
+branch: feature/task-card-view
+base: develop
+current_phase: P1
+last_updated: '2026-08-01'
+phases:
+- id: P1
+  name: Derive task status from lifecycle (Task.status_label)
+  status: pending
+  satisfies:
+  - R4
+  depends_on: []
+  parallel: false
+  hammerable: false
+  hill: uphill
+  verify: uv run pytest -m unit -k status_label
+- id: P2
+  name: Card renderer (Panel + header + regions + lower-right status + responsive width)
+  status: pending
+  satisfies:
+  - R2
+  - R3
+  - R4
+  - R5
+  - R6
+  depends_on:
+  - P1
+  parallel: false
+  hammerable: false
+  hill: uphill
+  verify: uv run pytest -m unit -k card_render
+- id: P3
+  name: Wire card into hs list / hs search (+ search docs & completions)
+  status: pending
+  satisfies:
+  - R1
+  - R8
+  depends_on:
+  - P2
+  parallel: false
+  hammerable: false
+  hill: crest
+  verify: ".agents/factory/bin/temp_site.sh sh -c \"seq 20 | uv run hsx -t 'echo {}' -N4 && uv run hs list --format=card\""
+- id: P4
+  name: Wire card into hs info (+ hs wait parity) with info/wait docs & completions
+  status: pending
+  satisfies:
+  - R7
+  - R1
+  - R8
+  depends_on:
+  - P3
+  parallel: false
+  hammerable: false
+  hill: crest
+  verify: uv run pytest -m unit -k card_info
+- id: P5
+  name: Regenerate man pages, add integration test, confirm docs build clean
+  status: pending
+  satisfies:
+  - R8
+  - R1
+  depends_on:
+  - P4
+  parallel: false
+  hammerable: false
+  hill: downhill
+  verify: uv run pytest -m integration -k card
+review:
+  last_reviewed_commit: ''
+  verdict: none
+  blocked_reason: ''
+  cycle: 0
+---
+
+# TECH.md — Rich "card" view for tasks
+
+The **context engine and finite-state machine** for building this feature. The YAML frontmatter is the
+resume ground-truth (`uv run python .agents/factory/bin/next_phase.py spec/task-card-view/TECH.md`);
+the per-phase checklists below are the work. `hs-build` executes the next actionable phase, runs its
+`verify:` command, updates state via `set_phase.py`, and makes one atomic code+state commit.
+
+- **Vision / requirements (locked):** [`GOAL.md`](GOAL.md) — R-IDs are the contract.
+- **Authoritative design:** [`PLAN.md`](PLAN.md).
+- **Backing research:** [`research/00-digest.md`](research/00-digest.md) + briefs `01`–`05`.
+
+## Conventions (apply to every phase)
+
+- Commit conventions, code style, and load-bearing invariants come from [`AGENTS.md`](../../AGENTS.md);
+  the curated footgun list is [`.agents/factory/invariants.md`](../../.agents/factory/invariants.md).
+- One phase per `hs-build` invocation; one atomic commit containing **both** the code and the
+  `TECH.md` state change. Subject: `[feature] Build task-card-view P<n>: …`. **No `Co-Authored-By`
+  trailer.**
+- A CLI/feature change updates `docs/_include/*.rst` help snippets and `share/` completions **in the
+  same commit** (§12). The help-string constant in `task.py` is the source of truth those mirror.
+- `card` is purely additive: `normal` stays the default and `normal`/`plain`/`table`/`json`/`csv` must
+  remain byte-identical in behavior.
+
+---
+
+## Phase P1 — Derive task status from lifecycle (`Task.status_label`)
+**Satisfies:** R4 · **Depends on:** —
+**Goal:** A read-only `Task.status_label` property maps a fully-loaded task to exactly one lifecycle
+label, honoring the `exit_status` reserved ranges — the foundation the badge renders.
+
+- [ ] In `src/hypershell/data/model.py`, add a read-only property `Task.status_label -> str`
+      implementing the **order-critical** ladder (see [`research/02`](research/02-status-lifecycle-derivation.md)):
+      `schedule_time is None`→`WAITING`; elif `completion_time is None`→`RUNNING`; elif
+      `exit_status == 0`→`OK`; elif `exit_status == CANCEL_STATUS`→`CANCELLED`; elif
+      `exit_status <= -1000`→`ERROR`; elif `exit_status < 0`→`KILLED`; elif `exit_status > 0`→`FAILED`;
+      else→`UNKNOWN`. Comment it as a declarative statement of the invariant it reproduces.
+- [ ] Do **not** import `TASK_TEMPLATE_ERROR`/`TASK_RESOURCE_ERROR` (circular + heavy `client.py`
+      import) — classify never-ran by the documented `<= -1000` range.
+- [ ] Add `tests/` unit coverage (`@mark.unit`, SPDX header): construct `Task` objects covering each
+      branch (unscheduled; scheduled+incomplete; exit 0; `CANCEL_STATUS`; `-1001`; `-9`; `>0`;
+      completed+null-exit) and assert `status_label`. Name tests so `-k status_label` selects them.
+- **Verify:** `uv run pytest -m unit -k status_label`.
+- **Touches:** `src/hypershell/data/model.py` (high-blast-radius, **additive read-only only**),
+  `tests/…`.
+
+## Phase P2 — Card renderer
+**Satisfies:** R2, R3, R4, R5, R6 · **Depends on:** P1
+**Goal:** A pure `render_card(task, width, source_map=None) -> Panel` produces a bordered card —
+horizontal id/fingerprint/group/part/(zone) header, labeled regions, lower-right `status:` badge —
+that adapts across narrow/normal/wide and stays legible with no color.
+
+- [ ] In `src/hypershell/task.py`, add `STATUS_STYLES: Dict[str, str]` beside `select_style`:
+      OK→`bold green`, FAILED→`bold red`, CANCELLED→`yellow`, RUNNING→`cyan`, WAITING→`dim`,
+      ERROR/KILLED/UNKNOWN→`magenta`.
+- [ ] Add `render_card(task, width, source_map=None) -> Panel` next to `print_normal`. Reuse
+      `print_normal`'s field-prep (waited/duration/timeout→`timedelta`, memory/`memory_max`→
+      `format_bytes`, cores, `resolve_source`, `format_tag`). Compose `Panel(Group(header, "",
+      regions), title="task", title_align="left", box=box.ROUNDED, width=width, padding=(0,1),
+      subtitle=f"status: {task.status_label}", subtitle_align="right",
+      border_style=STATUS_STYLES[task.status_label])`. Header = `Table.grid(expand=True)`. Regions =
+      `Table.grid` label:value blocks grouped command / timing / resources / hosts / output / retry /
+      source / tags, side-by-side via `Columns(expand=True, equal=True)` in normal/wide, **stacked** in
+      narrow. **Never truncate the id**; fingerprint may abbreviate in narrow.
+- [ ] Responsive: caller passes a clamped `width`; regions pick layout by `<90` narrow / `90–129`
+      normal / `>=130` wide. Style the badge/border via `STATUS_STYLES`; rely on rich to strip ANSI
+      when non-TTY so the literal `status:` text always survives (R6).
+- [ ] Unit tests (`@mark.unit`, `-k card_render`): render real `Task` objects through a width-forced
+      `Console(width=…, file=StringIO())` at 60/70/120/150; assert full id present, region labels
+      present, `status: <LABEL>` text present, output width within the clamp; assert a no-color render
+      (e.g. `Console(..., no_color=True)` / non-terminal) still shows border + literal status text.
+- **Verify:** `uv run pytest -m unit -k card_render`.
+- **Touches:** `src/hypershell/task.py`, `tests/…`.
+
+## Phase P3 — Wire `card` into `hs list` / `hs search`
+**Satisfies:** R1, R8 · **Depends on:** P2
+**Goal:** `hs list --format=card` / `hs search … --format=card` render one card per matched task,
+responsive to terminal width; `normal` stays default; search help/docs/completions list `card`.
+
+- [ ] In `TaskSearchApp` (`task.py`): add `'card'` to `output_formats` (`:663`). Add
+      `print_card(self, results)` mirroring the static `print_normal` (`:783`) — build `Task` objects,
+      batch `Source.paths_for_ids`, create one `Console()`, compute `W = max(60, min(160,
+      console.size.width))`, loop `console.print(render_card(task, W, source_map))`. Extend the subset
+      guard in `check_output_format` (`:829`) from `== 'normal'` to `in ('normal', 'card')`.
+- [ ] Update the `SEARCH_HELP` `-f/--format` enumeration (`task.py:591`) to include `card`.
+- [ ] Same commit (§12): `docs/_include/task_search_help.rst` (`:75`),
+      `share/bash_completion.d/hs` search word list (`:418`), `share/zsh/site-functions/_hs` search
+      spec (`:417`, append ` card` inside the `(…)`). (`hsx` bash file is a symlink → covered.)
+- [ ] Sanity: `zsh -n share/zsh/site-functions/_hs`; confirm `--format` rejects unknown values and
+      `card` requires all fields (`hs list id --format=card` → the subset error).
+- **Verify:** `.agents/factory/bin/temp_site.sh sh -c "seq 20 | uv run hsx -t 'echo {}' -N4 && uv run hs list --format=card"`
+  (also eyeball under `COLUMNS=70` and `COLUMNS=140`).
+- **Touches:** `src/hypershell/task.py`, `docs/_include/task_search_help.rst`,
+  `share/bash_completion.d/hs`, `share/zsh/site-functions/_hs`.
+
+## Phase P4 — Wire `card` into `hs info` (+ `hs wait` parity)
+**Satisfies:** R7, R1, R8 · **Depends on:** P3
+**Goal:** `hs info <id> --format=card` renders one card via the shared `render_card`, identical to how
+`hs list` renders that task; `hs wait --info -f card` accepted for parity; info/wait
+help/docs/completions list `card`.
+
+- [ ] In `TaskInfoApp` (`task.py`): add `'card'` to `output_formats` (`:172`) and branch `run()`
+      (`:201`) so `card` computes the clamped width and prints `render_card(self.task, W)` for the
+      single loaded task (source resolved directly, no batch needed).
+- [ ] In `TaskWaitApp` (`task.py`): add `'card'` to its forwarded `output_formats` (`:339`) so
+      `hs wait --info -f card` delegates cleanly to `TaskInfoApp`.
+- [ ] Update `INFO_HELP` (`:141`) and `WAIT_HELP` `-f/--format` enumerations to include `card`.
+- [ ] Same commit (§12): `docs/_include/task_info_help.rst` (`:11`), `task_wait_help.rst` (`:19`);
+      `share/bash_completion.d/hs` info (`:297`) & wait (`:327`) word lists; `share/zsh/site-functions/_hs`
+      info (`:355`) & wait (`:377`) specs.
+- [ ] Unit/functional tests (`@mark.unit`, `-k card_info`): submit a task in a `temp_site`, then run
+      `hs info <id> --format=card` via the `tests.main(argv)` helper and assert the border + `status:`
+      + the id are present; assert `hs info` accepts `card` in its `choices`.
+- **Verify:** `uv run pytest -m unit -k card_info`.
+- **Touches:** `src/hypershell/task.py`, `docs/_include/task_info_help.rst`,
+  `docs/_include/task_wait_help.rst`, `share/bash_completion.d/hs`, `share/zsh/site-functions/_hs`.
+
+## Phase P5 — Regenerate man pages, integration test, docs build
+**Satisfies:** R8, R1 · **Depends on:** P4
+**Goal:** Generated assets carry `card`, the feature is proven end-to-end through the installed CLI,
+and the docs build is clean.
+
+- [ ] Regenerate man pages: `uv run sphinx-build -b man docs docs/_build/man`, copy to
+      `share/man/man1/hs.1` and `hyper-shell.1`, and copy `hs.1`→`share/man/man1/hsx.1` (per the
+      `/hs-release` process). **Inspect the diff:** if it's only the `card` additions (±a date line),
+      keep it; if noisy/unrelated, **defer man to the next `/hs-release`** and note it in the commit
+      body (completions + `docs/_include` from P3/P4 remain the hard §12 requirement).
+- [ ] Add an integration test (`@mark.integration`, `-k card`): in a throwaway site submit a few
+      tasks and drive `hs list --format=card` and `hs info <id> --format=card`; assert a border glyph
+      and `status:` appear. (Integration tests shell out — needs `uv sync`.)
+- [ ] `uv run sphinx-build docs docs/_build` — no **new** warnings (the pre-existing
+      `task_submit.rst`/`manual.rst` toctree warnings are expected).
+- [ ] Final sweep: grep that `card` appears in every `-f/--format` enumeration (help strings,
+      `docs/_include/*`, bash, zsh, man).
+- **Verify:** `uv run pytest -m integration -k card`.
+- **Touches:** `share/man/man1/*.1`, `tests/…` (integration).
+
+---
+
+## How `hs-build` drives this
+
+1. `next_phase.py` prints the next actionable phase (statuses authoritative; `current_phase`
+   reconciled against them).
+2. Pre-flight: clean tree, on `feature/task-card-view`, `develop` reachable.
+3. Execute every `[ ]` in the phase (consult `PLAN.md` / `research/` for detail).
+4. Run the phase's `verify:` command — never advance on a checkbox alone.
+5. Amend this file if reality diverges (regenerate frontmatter with `set_phase.py`; note it in the
+   commit body). STOP and escalate only on a **`GOAL.md` contradiction**.
+6. Mark the phase `done`, advance `current_phase`, `--touch`; one `[feature]` commit; stop and report.

--- a/spec/task-card-view/TECH.md
+++ b/spec/task-card-view/TECH.md
@@ -3,10 +3,10 @@ slug: task-card-view
 title: Rich "card" view for tasks
 kind: feature
 appetite: big
-status: in_progress
+status: in_review
 branch: feature/task-card-view
 base: develop
-current_phase: P5
+current_phase: done
 last_updated: '2026-08-01'
 phases:
 - id: P1
@@ -63,7 +63,7 @@ phases:
   verify: uv run pytest -m unit -k card_info
 - id: P5
   name: Regenerate man pages, add integration test, confirm docs build clean
-  status: pending
+  status: done
   satisfies:
   - R8
   - R1
@@ -209,29 +209,31 @@ help/docs/completions list `card`.
 - **Touches:** `src/hypershell/task.py`, `docs/_include/task_info_help.rst`,
   `docs/_include/task_wait_help.rst`, `share/bash_completion.d/hs`, `share/zsh/site-functions/_hs`,
   `tests/test_card_info.py`.
-- **Verify:** `uv run pytest -m unit -k card_info`.
-- **Touches:** `src/hypershell/task.py`, `docs/_include/task_info_help.rst`,
-  `docs/_include/task_wait_help.rst`, `share/bash_completion.d/hs`, `share/zsh/site-functions/_hs`.
 
 ## Phase P5 — Regenerate man pages, integration test, docs build
 **Satisfies:** R8, R1 · **Depends on:** P4
 **Goal:** Generated assets carry `card`, the feature is proven end-to-end through the installed CLI,
 and the docs build is clean.
 
-- [ ] Regenerate man pages: `uv run sphinx-build -b man docs docs/_build/man`, copy to
-      `share/man/man1/hs.1` and `hyper-shell.1`, and copy `hs.1`→`share/man/man1/hsx.1` (per the
-      `/hs-release` process). **Inspect the diff:** if it's only the `card` additions (±a date line),
-      keep it; if noisy/unrelated, **defer man to the next `/hs-release`** and note it in the commit
-      body (completions + `docs/_include` from P3/P4 remain the hard §12 requirement).
-- [ ] Add an integration test (`@mark.integration`, `-k card`): in a throwaway site submit a few
-      tasks and drive `hs list --format=card` and `hs info <id> --format=card`; assert a border glyph
-      and `status:` appear. (Integration tests shell out — needs `uv sync`.)
-- [ ] `uv run sphinx-build docs docs/_build` — no **new** warnings (the pre-existing
-      `task_submit.rst`/`manual.rst` toctree warnings are expected).
-- [ ] Final sweep: grep that `card` appears in every `-f/--format` enumeration (help strings,
-      `docs/_include/*`, bash, zsh, man).
-- **Verify:** `uv run pytest -m integration -k card`.
-- **Touches:** `share/man/man1/*.1`, `tests/…` (integration).
+- [x] Man regeneration **DEFERRED to the next `/hs-release`** (per the plan's noisy-diff fallback). A
+      trial `uv run sphinx-build -b man docs docs/_build/man` produced a diff carrying **unrelated**
+      content — the already-merged `--part`/`--rotate` (part-tag-to-column) doc changes the committed
+      man pages predate, plus a today `.TH` date bump — not just `card`. Bundling that into this
+      feature commit would muddy the diff; man is a release-time generated aggregate, so the man pages
+      were reverted to their committed state. R8's hard requirement (bash/zsh completions +
+      `docs/_include`) is fully met by P3/P4; the man `card` lines land at the next release alongside
+      the pending `--part` ones.
+- [x] Added `tests/test_card_integration.py` (`@mark.integration`, `-k card`): runs a file-mode
+      cluster to completion, then drives `hs list --format=card` (asserts **2 cards, 2× `status: OK`**),
+      `hs info <id> --format=card` (one card, full id, `status: OK`), and `hs wait <id> --info -f card`
+      (`status: OK`).
+- [x] `uv run sphinx-build docs docs/_build` — no **new** warnings (only the pre-existing
+      `task_submit.rst`/`manual.rst` toctree + `pkg_resources` deprecation warnings).
+- [x] Final sweep: `card` present in `task.py` help strings, all three `docs/_include/*`, bash (search
+      + info + wait), and zsh (search + info + wait). (Man deferred as above.)
+- **Verify:** `uv run pytest -m integration -k card` → 1 passed (full unit suite 203; all `-k card`
+      tests 27 passed).
+- **Touches:** `tests/test_card_integration.py`. (Man pages intentionally **not** touched — deferred.)
 
 ---
 

--- a/spec/task-card-view/research/00-digest.md
+++ b/spec/task-card-view/research/00-digest.md
@@ -1,0 +1,93 @@
+# Research digest — task-card-view
+
+Consolidated decisions from briefs `01`–`05`. Where briefs overlapped, the single recommendation
+is stated here.
+
+## Decisions (locked for the design)
+
+1. **rich is sufficient as-is.** Floor `rich>=13.7.1` (`pyproject.toml`), resolved `13.9.4`
+   (`uv.lock`). All needed APIs (`Panel`, `Table.grid`, `Columns`, `Group`, `box`,
+   `Console.size.width`) exist at the floor — **no dependency bump** ([`01`](01-rich-card-layout.md)).
+
+2. **Outer container = `Panel`.** `Panel(body, title="task", title_align="left",
+   box=box.ROUNDED, width=W, padding=(0,1))`. Chosen over a bordered `Table` because the Panel's
+   **subtitle slot lands the status badge flush in the lower-right border** —
+   `subtitle="status: OK", subtitle_align="right"` renders `╰… status: OK ─╯` (live-verified).
+   Zero extra layout to satisfy R4's "lower-right corner" ([`01`](01-rich-card-layout.md)).
+
+3. **Body = header grid + labeled regions.** Header: one `Table.grid(expand=True)` row with columns
+   for **id · fingerprint · group · part · (reserved) zone**. Regions: `kv_grid` = `Table.grid`
+   with a right-justified `bold`-label column + a folding value column; placed side-by-side via
+   `Columns([...], expand=True, equal=True)` in wide/normal, **stacked** in narrow. Assemble with
+   `Group(header, "", regions)` ([`01`](01-rich-card-layout.md)).
+
+4. **Status derivation lives on the model.** Add a read-only **`Task.status_label`** property in
+   `data/model.py` (per AGENTS.md §1 — state-query logic belongs on `Task`, alongside
+   `revert_interrupted`/`select_failed` which use the same predicates). The **order-critical
+   ladder** on a fully-loaded task ([`02`](02-status-lifecycle-derivation.md)):
+   1. `schedule_time is None` → **WAITING**
+   2. `completion_time is None` → **RUNNING**
+   3. `exit_status == 0` → **OK**
+   4. `exit_status == CANCEL_STATUS` (−1) → **CANCELLED** *(must precede all negatives; −1 also = SIGHUP death, documented collision)*
+   5. `exit_status <= -1000` → **ERROR** *(never-ran sentinel range; must precede step 6)*
+   6. `exit_status < 0` (−2..−64) → **KILLED** *(signal death)*
+   7. `exit_status > 0` → **FAILED**
+   8. else (completed but `exit_status is None`) → **UNKNOWN** *(defensive)*
+
+   Do **not** import `TASK_TEMPLATE_ERROR`/`TASK_RESOURCE_ERROR` from `client.py` — it imports
+   `data.model` (circular) and is import-heavy. Classify never-ran by the **documented
+   `<= -1000` range** instead (forward-compatible with future sentinels).
+
+5. **Label→style map lives in the presentation layer** (`task.py`, beside `select_style`). Map:
+   OK→`bold green`, FAILED→`bold red`, CANCELLED→`yellow`, RUNNING→`cyan`, WAITING→`dim`,
+   ERROR/KILLED/UNKNOWN→`magenta`. **CANCELLED=yellow is a deliberate card palette** that diverges
+   from the existing `select_style` (CANCEL→`dim`, other-negative→`yellow`) — the GOAL fixes it, and
+   the card's whole-row derivation can tell CANCELLED from a signal-kill, which `select_style`
+   (exit_status-only) cannot ([`02`](02-status-lifecycle-derivation.md)).
+
+6. **Shared renderer = `render_card(task, width, source_map=None) -> Panel` in `task.py`** (NOT
+   `core/pretty_print.py` — it needs `Task`/`select_*`/`resolve_source`, which live in `task.py`;
+   moving out creates an import cycle). It mirrors the field-prep block of the module-level
+   `print_normal` (waited/duration/timeout → `timedelta`, memory → `format_bytes`, source →
+   `resolve_source`), all helpers already imported. Callers compute width once and print each
+   returned Panel ([`03`](03-output-wiring.md)).
+
+7. **Wiring, both apps** ([`03`](03-output-wiring.md), [`05`](05-docs-completions.md)):
+   - `TaskSearchApp` (`hs list`/`hs search`): add `'card'` to `output_formats` (`task.py:663`);
+     dispatch is already `getattr(self, f'print_{fmt}')`, so add `print_card(self, results)`
+     mirroring the static `print_normal` (build `Task` objects, batch `Source.paths_for_ids`, loop
+     `console.print(render_card(...))`). Extend the subset guard in `check_output_format` (`:829`)
+     from `== 'normal'` to `in ('normal','card')` — card needs `ALL_FIELDS`.
+   - `TaskInfoApp` (`hs info`): add `'card'` to `output_formats` (`:172`) and branch `run()` to call
+     `render_card` for the single loaded task.
+   - **`TaskWaitApp` parity** (`:339`): it forwards `output_format` into `TaskInfoApp`, so add
+     `'card'` there too, or `hs wait --info -f card` is spuriously rejected. Small, adjacent,
+     included ([`05`](05-docs-completions.md)).
+
+8. **Width & color** ([`04`](04-tty-width-color.md)): one bare `Console()`; read
+   `console.size.width` (handles live TTY, `COLUMNS`, and the 80-col pipe fallback for free); clamp
+   `W = max(60, min(160, raw))`. **Layout thresholds:** `<90` narrow (stacked regions), `90–129`
+   normal, `>=130` wide (side-by-side). Piped/non-TTY → width 80 → narrow (safest). rich
+   auto-strips ANSI when `not is_terminal` and honors `NO_COLOR`; `COLOR_STDOUT` (cmdkit:
+   `isatty() and not NO_COLOR`) already gates the rest of `task.py`. **Non-TTY fallback = same code
+   path**: borders survive as Unicode, and the status is always emitted as literal
+   `status: FAILED` text (never color-only) — satisfies R6. `BrokenPipeError` is already handled;
+   let it propagate.
+
+9. **Docs/completions surface** ([`05`](05-docs-completions.md)) — add `card` to:
+   help strings `task.py` `SEARCH_HELP` (`:591`) & `INFO_HELP` (`:141`) & `WAIT_HELP`; argparse
+   `choices` at `:663`/`:172`/`:339`; `docs/_include/task_search_help.rst:75`,
+   `task_info_help.rst:11`, `task_wait_help.rst:19`; `share/bash_completion.d/hs` (`:418` search,
+   `:297` info, `:327` wait — `hsx` is a symlink, covered); `share/zsh/site-functions/_hs` (`:417`
+   search, `:355` info, `:377` wait — syntax `...:format:(normal json yaml)`, append ` card`).
+   **Man pages** (`share/man/man1/{hs,hsx,hyper-shell}.1`) are **generated** (`sphinx-build -b man`,
+   then copy `hs.1`→`hsx.1`); regenerate at the end so they carry `card` — with a fallback if the
+   diff is noisy (see PLAN risks). CI (`tests.yml`) asserts share/ *paths* only; we add values to
+   existing files, so no path list changes.
+
+## Header UX constraint (decided here)
+
+The **id is actionable** (users copy it into `hs info <id>`), so the card **never truncates the
+id**. In narrow mode the header stacks (full id on its own line); the **fingerprint** may be
+abbreviated (it's a dedup hash, rarely copied). group/part/zone are short ints. Exact narrow-mode
+composition is left to build.

--- a/spec/task-card-view/research/01-rich-card-layout.md
+++ b/spec/task-card-view/research/01-rich-card-layout.md
@@ -1,0 +1,173 @@
+# Research: `rich` building blocks for the `card` output format
+
+## 1. Pinned version
+
+- **Floor:** `rich>=13.7.1` (`pyproject.toml:35`).
+- **Resolved:** `rich==13.9.4` (`uv.lock:1333-1334`).
+
+Every API below is verified against 13.9.4 in this repo's venv. All of it also exists in the
+13.7.1 floor, so no floor bump is needed. `rich` has no `__version__` attr — use
+`importlib.metadata.version("rich")` if you ever need it at runtime (we don't).
+
+## 2. How the repo already uses `rich`
+
+Imports are narrow and consistent — mirror them:
+
+- `src/hypershell/task.py:26-28` — `from rich.console import Console`, `from rich.syntax import
+  Syntax`, `from rich.table import Table`.
+- `src/hypershell/config.py:25-26` — `Console`, `Syntax`.
+- Render idiom throughout is `Console().print(<renderable>)` (fresh `Console()` per call, no
+  shared singleton): `task.py:781` (`print_table`), `:806` (JSON via `Syntax`), `:218/:229`
+  (`hs info` yaml/json). **Follow this — instantiate `Console()` at the call site.**
+- `print_table` (`task.py:772-781`) is the closest existing template: `Table(title=None)`,
+  `add_column(name)` per field, `add_row(*row, style=select_style(...))`, then print.
+- **Theme:** `config.console.theme` (default `'monokai'`, `core/config.py:183-184`) is only ever
+  passed to `Syntax(...)` for code/JSON/YAML highlighting. It is **not** a rich `Theme` object
+  and does **not** apply to Table/Panel styling — don't try to feed it to the card.
+- **Color gating:** `COLOR_STDOUT` (from `cmdkit.ansi`, `task.py:31`) gates ANSI. The
+  table/plain paths colorize via `select_style`/`select_color` keyed on `exit_status`
+  (`task.py:1335-1360`): `None`→plain, `0`→green/`'green'`, `CANCEL_STATUS`→faint/`'dim'`,
+  other-negative→yellow, positive→red. **Reuse `select_style` for the card's border/status
+  style** so the new view stays visually consistent (rich style *names*, not the ANSI callables).
+- `core/pretty_print.py` does **not** import rich (custom ANSI dict-printer) — irrelevant here.
+- Field set + logical grouping to reproduce: `NORMAL_MODE_TEMPLATE` (`task.py:1294-1320`) and
+  `print_normal` (`task.py:1382-1400`), which already formats every value (`format_json`,
+  timedeltas, `format_bytes`, `resolve_source`, tags). The card should consume the same
+  pre-formatted `task_data` dict, not re-derive it.
+
+Note: there is **no existing status-string derivation** (`unscheduled`/`running`/`done`/
+`cancelled`); the virtual `status:` badge value must be computed by the build from the
+nullable-column lifecycle contract (see AGENTS.md). That is a build concern, not a rich one.
+
+## 3. Recommended building blocks (verified, buildable)
+
+Import surface to add: `from rich.panel import Panel`, `from rich.columns import Columns`,
+`from rich.console import Group`, `from rich import box` (keep existing `Table`/`Console`).
+
+### Outer container → `Panel`
+
+`Panel` is the right choice over a bordered `Table` because it gives title **and** subtitle in
+the border for free — the subtitle is exactly the lower-right badge slot.
+
+```python
+Panel(body, title="task", title_align="left",
+      subtitle=status_text, subtitle_align="right",   # <-- lower-right badge, in bottom border
+      box=box.ROUNDED, width=w, padding=(0, 1), border_style=select_style(task.exit_status) or "none")
+```
+
+- **Box:** `box.ROUNDED` (clean default). `box.SQUARE`/`box.HEAVY`/`box.MINIMAL` all available if
+  a heavier look is wanted. Verified `ROUNDED/SQUARE/HEAVY/MINIMAL/HEAVY_HEAD` all present.
+- **Title placement:** `title="task"`, `title_align="left"`.
+
+### Horizontal identity header → `Table.grid(expand=True)`
+
+Recommended over `Columns`/tab-stops: `Table.grid` gives explicit, ratio-sized columns that
+fill the width and wrap predictably.
+
+```python
+header = Table.grid(expand=True)
+for _ in range(5):                       # id, fingerprint, group, part, + reserved zone slot
+    header.add_column(justify="left", ratio=1)
+header.add_row(f"id: {id}", f"fp: {fp}", f"group: {group}", f"part: {part}", f"zone: {zone}")
+```
+
+`Table.grid(*headers, padding=0, expand=False)` is a classmethod (verified sig). Pass
+`expand=True` so it fills the panel interior. The reserved `zone` cell can render `-`/empty
+until the field lands.
+
+### Two labeled regions (label+value pairs) → `Table.grid` per region, side-by-side via `Columns`
+
+```python
+def kv_grid(pairs):
+    g = Table.grid(padding=(0, 1))
+    g.add_column(justify="right", style="bold cyan", no_wrap=True)   # labels
+    g.add_column(justify="left", overflow="fold")                    # values (fold long cmds)
+    for k, v in pairs:
+        g.add_row(f"{k}:", str(v))
+    return g
+
+regions = Columns([kv_grid(left_pairs), kv_grid(right_pairs)], expand=True, equal=True)
+```
+
+Group the `NORMAL_MODE_TEMPLATE` fields into ~2-3 logical blocks (identity already in header;
+e.g. *execution* = command/args/cores/memory/timeout/exit_status; *timeline* = submit/schedule/
+start/complete/waited/duration; *provenance* = hosts/ids/paths/attempt/retried/previous/next/
+source/tags).
+
+### Assemble body → `Group`
+
+```python
+body = Group(header, "", regions)        # "" = blank spacer line between header and regions
+card = Panel(body, ...)
+```
+
+`Group` (from `rich.console`) stacks renderables vertically; a bare `""` string is a valid
+blank-line member.
+
+### Lower-right `status:` badge
+
+Two idioms — **prefer (a)**:
+
+- **(a) Panel subtitle** (shown above): `subtitle="status: OK"`, `subtitle_align="right"`
+  renders it inside the bottom border, flush lower-right. Verified: renders as
+  `╰──… status: OK ─╯`. Zero extra layout. Style it inline, e.g.
+  `subtitle="[green]status: OK[/]"` or a `Text("status: OK", style=select_style(...))`.
+- **(b)** If you want it *inside* the body instead of the border: append a
+  `Table.grid(expand=True)` with one right-justified column and one row, or `Align.right(Text(...))`.
+  More code, no advantage here.
+
+### Rendering many cards
+
+```python
+console = Console()
+for task in tasks:
+    console.print(make_card(task, width=w))   # Panel already has border margins; no separator needed
+```
+
+The panel border provides visual separation, so no explicit `---` rule is required (unlike
+`print_normal`, which prints `'---'` between blocks). One `Console()` reused in the loop is fine.
+
+## 4. Responsive width
+
+Read effective width from the console (verified attrs on 13.9.4):
+
+- `Console().size.width` / `Console().width` — terminal width (both `80` in a pipe / no TTY).
+- `console.options.max_width` — the render-width budget; same as `width` at top level.
+
+Use `console.width`, then **clamp**:
+
+```python
+w = max(60, min(160, Console().width))
+```
+
+Then select a layout variant from `w` and pass `width=w` to the `Panel`:
+
+- **narrow (`w < ~80`):** stack regions vertically — put all label/value pairs in **one shared
+  `kv_grid`** (so labels align) inside the `Group`, no `Columns`.
+- **normal (`~80 ≤ w < ~120`):** two regions side-by-side via `Columns(..., equal=True)`.
+- **wide (`w ≥ ~120`):** same side-by-side, optionally 3 regions, wider value columns.
+
+Pick thresholds inside the clamped [60,160] band; tune against the prototype.
+
+### `width=` vs `expand` interaction (gotcha)
+
+- Passing `Panel(..., width=w)` **overrides** `expand` and fixes the outer width to exactly `w`
+  — this is how you enforce the [60,160] clamp regardless of the real terminal (prevents a
+  1000-col terminal from producing an unreadable card). **Set `width=w` explicitly.**
+- Interior grids/`Columns` should use `expand=True` so they fill the clamped panel; but the
+  Panel's fixed `width` is the hard bound.
+- If instead you `Console(width=w).print(card)` with an `expand=True` panel, the panel fills `w`
+  — equivalent, but setting `Panel(width=w)` is more explicit and lets you keep a single
+  `Console()`.
+
+### Gotchas summary
+
+1. `rich` has **no `__version__`** — use `importlib.metadata.version`.
+2. `config.console.theme` is a *Syntax* theme string, **not** a Table/Panel theme — don't pass
+   it to the card.
+3. **Narrow-mode label alignment:** two *separate* `kv_grid`s stacked don't share column widths,
+   so labels won't line up. In narrow mode use **one** grid for all pairs.
+4. `Panel(width=w)` overrides `expand`; that's the lever for the [60,160] clamp.
+5. No TTY ⇒ `console.width == 80`; the clamp floor of 60 keeps piped output sane. Consider
+   respecting `COLOR_STDOUT` for whether to apply border/status color (mirror table path).
+6. `overflow="fold"` on the value column prevents long `command`/paths from truncating with `…`.

--- a/spec/task-card-view/research/02-status-lifecycle-derivation.md
+++ b/spec/task-card-view/research/02-status-lifecycle-derivation.md
@@ -1,0 +1,147 @@
+# Status label + color derivation for the `card` view
+
+Research topic: how to derive a virtual `status:` badge (OK / FAILED / CANCELLED /
+RUNNING / WAITING / abnormal) from a fully-loaded `Task`, and where that logic belongs.
+
+## 1. Lifecycle predicates (ground truth from `data/model.py`)
+
+Task state is a function of nullable columns, not a stored enum. Confirmed against the
+`Task` classmethods:
+
+- **unscheduled / WAITING** — `schedule_time IS NULL`
+  (`select_new`: `.filter(cls.schedule_time.is_(None))`, `model.py:559`).
+- **in-flight / interrupted / RUNNING** — `schedule_time` set AND `completion_time IS NULL`
+  (`select_interrupted` / `count_interrupted` / `select_orphaned`, `model.py:647-666,728-738`).
+  Note: an *interrupted* task (server died mid-flight) is indistinguishable here from a live
+  running one; both correctly read as RUNNING until `revert_interrupted()` resets them on the
+  next server start.
+- **done (terminal)** — `completion_time` set (`count_remaining`: `.filter(cls.completion_time.is_(None))`
+  for the *not*-done set, `model.py:641`).
+- **cancelled (terminal)** — `exit_status == CANCEL_STATUS` AND `completion_time` set.
+  `cancel_all` (`model.py:704-720`) stamps `schedule_time`, `completion_time` (both = now) and
+  `exit_status = CANCEL_STATUS`. The comment there is load-bearing: completion_time is set so
+  the task is terminal, else it reads as interrupted and gets reverted/re-run.
+
+`CANCEL_STATUS: Final[int] = -1` (`model.py:49`). Its docstring: cancelled is terminal, never
+scheduled/retried/counted-as-failure; distinguished from genuine failure *solely* by this value.
+Every failure/retry query filters `exit_status IS NOT NULL AND != 0 AND != CANCEL_STATUS`
+(`select_failed` `model.py:564-576`, `increment_group` `model.py:530-538`). **-1 collides with a
+SIGHUP death** (`SIGHUP = 1` → subprocess exit_status -1); this collision is documented and
+accepted — a SIGHUP-killed task reads as CANCELLED.
+
+## 2. "Never ran" sentinels
+
+Defined in `client.py:616-617` (NOT in model.py):
+
+```
+TASK_TEMPLATE_ERROR: Final[int] = -1001  # Template expansion failed (task never ran)
+TASK_RESOURCE_ERROR: Final[int] = -1002  # Insufficient local resources (task never ran)
+```
+
+Documented rule (client.py:611-615 and AGENTS.md): signal deaths occupy `-1..-64`
+(exit_status = -N); **all HyperShell-internal "never ran" sentinels live below -1000** to stay
+clear of that range. So `exit_status <= -1000` is a stable, forward-compatible predicate for the
+never-ran class *without importing the exact constants*.
+
+**Do NOT import these from `client.py` for the derivation.** `client.py` imports
+`from hypershell.data.model import Task` (client.py:59), so model.py importing client.py is a
+circular import. `client.py` is also import-heavy (multiprocessing, subprocess, `core.resource`
+which computes `CPU_COUNT`/`MEMORY_TOTAL` at import, config singleton, template). Pulling that
+into `task.py` or `model.py` just to read two ints is wrong. Classify by the `<= -1000` range
+instead. (Optional future refactor: promote both sentinels into `model.py` next to
+`CANCEL_STATUS` to centralize the whole `exit_status` vocabulary, and have client.py import them
+from there — clean, but out of scope for this feature.)
+
+## 3. Existing classification in `task.py`
+
+- `no_color(_text)` — identity passthrough (task.py:1323).
+- `SPECIAL_TASK_COLORS = {None: no_color, 0: green, CANCEL_STATUS: faint}` (task.py:1328).
+- `select_color(status)` (task.py:1335-1345): `SPECIAL_TASK_COLORS.get(status, yellow if status
+  is not None and status < 0 else red)`. So: **None → uncolored, 0 → green, -1 → faint,
+  other-negative → yellow, positive → red.** The `None` guard is deliberate — `dict.get`
+  evaluates the default eagerly and `None < 0` would raise.
+- `SPECIAL_TASK_STYLES = {None: None, 0: 'green', CANCEL_STATUS: 'dim'}` + `select_style`
+  (task.py:1351-1360): rich-style analog for table rows (`dim` == same SGR as `faint`);
+  other-negative → 'yellow', positive → 'red'.
+- `print_normal` (task.py:1382-1401) applies ONE flat `select_color(task.exit_status)` over the
+  whole rendered block. The card view replaces this flat coloring with a per-badge status.
+
+Key gap: `select_color`/`select_style` key on `exit_status` ALONE, so they cannot tell WAITING
+(unscheduled) from RUNNING (in-flight) — both have `exit_status IS NULL`. The card badge needs
+the nullable-column predicates, i.e. the whole row, which is exactly why derivation must see the
+`Task`, not just its `exit_status`.
+
+Color rendering primitives available: `cmdkit.ansi` exports `bold, faint, italic, underline,
+black, red, green, yellow, blue, magenta, cyan, white`. `format_ansi` composes safely
+(`bold(green(t))` yields `BOLD GREEN t RESET` — the inner wrap ends in RESET so the outer only
+prepends). If the card renders via `rich` (like `print_table`) use style strings; if via
+`cmdkit.ansi` (like `print_normal`) use composed callables. `print_normal` uses cmdkit.ansi, so
+the card most likely does too.
+
+## 4. RECOMMENDATION
+
+### 4a. Predicate ladder (on a fully-loaded Task; order matters)
+
+```
+1. schedule_time is None                         -> WAITING     (unscheduled)
+2. completion_time is None                        -> RUNNING     (scheduled, in-flight/interrupted)
+3. exit_status == 0                               -> OK
+4. exit_status == CANCEL_STATUS (-1)              -> CANCELLED    (also SIGHUP death, documented)
+5. exit_status is not None and exit_status <= -1000 -> abnormal:ERROR   (never-ran sentinel)
+6. exit_status is not None and exit_status < 0    -> abnormal:KILLED  (signal death, -2..-64)
+7. exit_status is not None and exit_status > 0    -> FAILED
+8. else (completion_time set, exit_status None)   -> abnormal:UNKNOWN (defensive; anomalous row)
+```
+
+Ordering rationale: steps 1-2 use the lifecycle nullable-column predicates first (only these
+distinguish WAITING vs RUNNING). Once terminal (completion_time set), classify by exit_status.
+CANCELLED (step 4) MUST precede the generic negative branches or it degrades to KILLED. Never-ran
+(`<= -1000`, step 5) MUST precede the signal-kill branch (step 6) since both are `< 0`. Step 8
+handles the inconsistent "completed but no status" row honestly as abnormal rather than
+mislabeling. This reproduces the model's predicates exactly and stays consistent with
+`select_color`'s exit_status semantics (0=OK/green, -1=cancel, other-neg=abnormal, pos=FAILED).
+
+The GOAL lists a single "abnormal" state; I recommend the property return the *granular*
+sub-labels (ERROR / KILLED, plus UNKNOWN defensively) and let the style map collapse them to one
+"abnormal" style. This costs nothing and gives a strictly more useful badge; if the GOAL insists
+on a single literal, return `ABNORMAL` for steps 5/6/8.
+
+### 4b. Where the logic lives
+
+**Put the predicate ladder on `Task` as a read-only property in `data/model.py`** — e.g.
+`Task.status_label -> str` (or a small `TaskStatus` Enum). This is the AGENTS.md invariant:
+"task state/query logic → `Task` classmethods; never hand-roll state predicates in FSM [or,
+here, presentation] code." The ladder *is* lifecycle-state logic (it re-derives the same
+nullable-column predicates as `select_new`/`select_interrupted`/`cancel_all`); scattering it into
+`task.py` would create a second, drift-prone copy of the lifecycle contract. It needs no DB/query
+imports (pure attribute reads), so it adds no import weight to model.py and cannot import
+client.py. Use the `<= -1000` range check for never-ran (see §2).
+
+**Keep the label→style mapping in `task.py`** next to `select_color`/`SPECIAL_TASK_STYLES` — that
+is presentation, the layer that already owns cmdkit.ansi/rich rendering. So: model.py owns
+*state → label*; task.py owns *label → color*. This split respects both the invariant and the
+existing precedent (select_color stays put). `select_color`/`select_style` remain for the
+plain/table row coloring (they key on exit_status and are fine there); the card badge uses the
+new `status_label` + a new label→style map.
+
+### 4c. Label -> style map (task.py, parallel to SPECIAL_TASK_STYLES)
+
+GOAL-fixed: OK = bold green, FAILED = bold red, CANCELLED = yellow. Recommended for the rest
+(chosen to stay distinct from CANCELLED's yellow and readable in light/dark):
+
+| Label     | rich style     | cmdkit.ansi callable   |
+|-----------|----------------|------------------------|
+| OK        | `bold green`   | `lambda t: bold(green(t))` |
+| FAILED    | `bold red`     | `lambda t: bold(red(t))`   |
+| CANCELLED | `yellow`       | `yellow`               |
+| RUNNING   | `cyan`         | `cyan`                 |
+| WAITING   | `dim`          | `faint`                |
+| abnormal (ERROR/KILLED/UNKNOWN) | `magenta` | `magenta`   |
+
+Notes: CANCELLED = yellow per the GOAL *diverges* from `select_style` (which maps CANCEL→'dim'
+and other-negative→'yellow'); this is an intentional card-specific choice — flag it so the two
+schemes are consciously different. `dim`/`faint` for WAITING matches "not started, low emphasis"
+and echoes select_color's uncolored/None handling. `magenta` for abnormal keeps it visually
+distinct from CANCELLED's yellow while reading as "something weird happened"; `bold yellow` is a
+reasonable alternative if a warm caution tone is preferred. If a single "abnormal" label is used,
+map it to `magenta`.

--- a/spec/task-card-view/research/03-output-wiring.md
+++ b/spec/task-card-view/research/03-output-wiring.md
@@ -1,0 +1,98 @@
+# Output-format wiring: where `card` plugs in
+
+All refs `src/hypershell/task.py` unless noted. Verified 2026-08-01.
+
+## 1. `TaskSearchApp` (`hs list` / `hs search`), L605+
+
+Format plumbing:
+- `output_format: str = '<default>'` (L662) — sentinel resolved later by `check_output_format`.
+- `output_formats: List[str] = ['normal', 'plain', 'table', 'json', 'csv']` (L663) — the argparse
+  `choices` for `-f/--format` (L665-666).
+- Const aliases (L667-668): `--json` → `'json'`, `--csv` → `'csv'`, all in one
+  `add_mutually_exclusive_group()` (L664) with `-f`. (`hs list` has **no** `--yaml`.)
+- `check_output_format()` (L821-843): if `field_names == ALL_FIELDS` and format is `'<default>'`
+  → `'normal'` (L823-825). Else (a field subset): `'<default>'` → `'plain'` (L827-828), and
+  `'normal'` with a subset raises `ArgumentError('Cannot use --format=normal with subset of
+  field names')` (L829-830). Then `--delimiter` is only valid for `plain`/`csv` (L831-832),
+  size-checked (L833-835), defaulted (`,` for csv else `\t`, L836-840), and csv demands a
+  single-char delimiter (L841-843).
+- Dispatch: `print_output` `cached_property` (L742-745) returns
+  `getattr(self, f'print_{self.output_format}')`, called with `query.all()` at L711. So a new
+  format name `card` requires a `print_card` method (else AttributeError).
+- Color helpers only matter for `plain`/`table`: `colorize_rows` (L747-750, true only for
+  `plain`/`table` + COLOR_STDOUT), `status_injected` (L752-755), `status_index` (L757-762),
+  `fields` (L764-770, appends `Task.exit_status` when injected). **`card`/`normal` do NOT use
+  these** — they color per-task inside the renderer via `select_color`.
+- `print_normal` (static, L783-790): rebuilds full `Task` objects via
+  `Task.from_dict(dict(zip(Task.columns, record)))`, batch-resolves sources with
+  `Source.paths_for_ids([t.source for t in tasks if t.source])` (L787, avoids N+1), prints a
+  `'---'` separator per task, then calls the **module-level** `print_normal(task,
+  source_map=...)` (L1382). For `normal`, `colorize_rows` is false so `record` == all columns
+  in order (no injected col) — the `zip(Task.columns, record)` is exact.
+
+## 2. `TaskInfoApp` (`hs info`), L153-286 — SINGLE task
+
+- `output_format: str = 'normal'` (L171); `output_formats = ['normal', 'json', 'yaml']` (L172).
+- `-f/--format` choices + `--json`/`--yaml` const aliases in one mutually-exclusive group
+  (L173-176). No `--csv`; no plain/table.
+- `run()` (L187-204): `elif self.output_format == 'normal': print_normal(self.task)` (L201-202,
+  the **module-level** function, no source_map) else `self.print_formatted()` (L204).
+- `format_method` dict (L243-249): `{'yaml': yaml.dump…, 'json': json.dumps…}` — used by
+  `print_formatted` (L222-231) and `print_field` (L206-220). It maps format name → a
+  `Callable[[dict], str]` applied to `task.to_json()`, then Syntax-highlighted if a TTY.
+- Task loaded once via `task` `cached_property` (L268-271): `Task.from_id(self.uuid)`.
+- `TaskWaitApp` (L319-344) also carries the same `normal/json/yaml` triple and forwards
+  `output_format` into `TaskInfoApp` (L361) — add `card` there too for parity.
+
+## 3. Shared `normal` renderer today
+
+The module-level `print_normal(task, source_map=None)` (L1382-1400) is the single shared
+renderer: `hs info` calls it with one task (L202), `hs list` calls it per-task with a batched
+`source_map` (L790). It builds `task_data` from `task.to_dict()` via `format_json`, overrides
+`waited`/`duration`/`timeout` as `timedelta(seconds=int(...))` (L1389-90, 1396), `tag` via
+`format_tag` (L1391), `cores`/`cores_max` (L1392-93), `memory`/`memory_max` via `format_bytes`
+(L1394-95), `source_id`+`source` via `resolve_source` (L1397-98, L1363-1379), then colorizes
+the whole `NORMAL_MODE_TEMPLATE` (L1294-1320) block with `select_color(task.exit_status)`
+(L1335-1345) and prints. **`card` should mirror this exactly** — a `render_card(task,
+source_map=None)` built the same way, just a different template/layout.
+
+## 4. Recommended plug-in points (minimal edits)
+
+**Shared renderer — put it in `task.py` next to `print_normal` (~L1382).** It needs `timedelta`
+(imported L20), `format_json`/`format_tag`/`format_bytes`/`format_source` (imported L47),
+`resolve_source` (L1363, local), `select_color` (L1335, local), and a new
+`CARD_MODE_TEMPLATE`. All already in-module → keep `render_card` in `task.py`, not
+`core/pretty_print.py` (which has no access to `select_color`/`resolve_source`/`Task` and would
+create an import cycle). Signature: `def render_card(task: Task, source_map=None) -> None`
+(or return str + print at call sites), same field-derivation block as `print_normal`.
+
+**`TaskSearchApp`:**
+1. `output_formats` (L663): add `'card'` → `['normal', 'plain', 'table', 'json', 'csv', 'card']`.
+2. `check_output_format` (L821-830): make `card` behave like `normal` — it needs ALL_FIELDS.
+   In the `else` (subset) branch add `card` to the `normal` rejection:
+   `elif self.output_format in ('normal', 'card'): raise ArgumentError(...)`. (Leave the
+   `<default>` logic alone; `card` is only reached when explicitly passed, so ALL_FIELDS is
+   already guaranteed after this guard.) No delimiter interaction (card isn't plain/csv, so the
+   L831 "Unused --delimiter" check already covers it).
+3. Add `print_card(self, results)` mirroring `print_normal` (L783-790): build `Task` objects,
+   `source_map = Source.paths_for_ids(...)`, loop calling `render_card(task, source_map=...)`
+   (decide whether to keep the `'---'` separator — cards likely self-delimit).
+
+**`TaskInfoApp`:**
+1. `output_formats` (L172): add `'card'`.
+2. `run()` (L201): `elif self.output_format in ('normal', 'card'):` and dispatch
+   `render_card(self.task)` vs `print_normal(self.task)` — or a small local map. `card` must
+   NOT go through `print_formatted`/`format_method` (those are for json/yaml structured dumps).
+3. (Parity) `TaskWaitApp.output_formats` (L339): add `'card'`.
+
+## 5. Validation / conflicts
+
+- `-f/--format` uses argparse `choices=output_formats`, so adding `'card'` to that list is the
+  only change needed for the flag to accept it in both apps.
+- `card` needs no const alias, so it does NOT touch the `--json`/`--csv`/`--yaml`
+  mutually-exclusive groups.
+- Field-subset handling: `card` (like `normal`) requires ALL_FIELDS. The single guard in
+  `check_output_format` (`hs list`) enforces this. `hs info` always loads the full task, so no
+  subset concern there.
+- Help snippets: update `INFO_HELP` (L141), `SEARCH_HELP` (L591), and `WAIT_HELP` (L310) plus
+  `docs/_include/*.rst` and `share/` completions in the same commit (repo rule).

--- a/spec/task-card-view/research/04-tty-width-color.md
+++ b/spec/task-card-view/research/04-tty-width-color.md
@@ -1,0 +1,112 @@
+# Research 04 — Terminal width detection & color/TTY gating
+
+Scope: how the repo gates color/TTY today and how the responsive `card` format should
+obtain width and degrade on non-TTY / NO_COLOR. Facts verified against the installed
+`rich 13.9.4` and `cmdkit.ansi`.
+
+## 1. `COLOR_STDOUT` — where it comes from
+
+It is **not** defined in HyperShell. It is imported from cmdkit:
+`task.py:31` → `from cmdkit.ansi import red, green, yellow, faint, COLOR_STDOUT`.
+
+Definition (`.venv/.../cmdkit/ansi.py:26-37`), computed **once at import time**:
+
+```python
+NO_COLOR    = False if not os.getenv('NO_COLOR') else True
+FORCE_COLOR = False if not os.getenv('FORCE_COLOR') else True
+COLOR_STDOUT = True
+COLOR_STDERR = True
+if not sys.stdout.isatty() or NO_COLOR:
+    COLOR_STDOUT = False          # piped OR NO_COLOR -> off
+if not sys.stderr.isatty() or NO_COLOR:
+    COLOR_STDERR = False
+if FORCE_COLOR:                   # FORCE_COLOR wins over both
+    COLOR_STDOUT = True
+    COLOR_STDERR = True
+```
+
+So `COLOR_STDOUT` = `sys.stdout.isatty() and not NO_COLOR`, overridden `True` by `FORCE_COLOR`.
+It honors the `NO_COLOR` / `FORCE_COLOR` env conventions. **Caveat: import-time** — a test/
+harness that swaps `sys.stdout` after import won't change it.
+
+Only use in `task.py`: `colorize_rows` (`task.py:747-750`):
+```python
+return not self.show_count and self.output_format in ('plain', 'table') and COLOR_STDOUT
+```
+It gates whether `print_plain` wraps lines with `select_color(...)` and whether `print_table`
+passes a per-row `style=`. When off, the ANSI shorthands (`red`, etc.) are already no-ops too
+(`format_ansi` returns text unchanged when `not COLOR_STDOUT`).
+
+## 2. How the repo builds a rich `Console` today
+
+Every call is a bare, throwaway `Console()` with **no args** — no theme, no `force_terminal`,
+no width: `config.py:226`, `task.py:218`, `:229`, `:781`, `:806`. There is **no shared/module
+console**. Width and color are thus auto-detected from the real terminal each time.
+
+`config.console.theme` (`core/config.py:183-185`) defaults to `'monokai'` and is used **only**
+as the Pygments theme for `Syntax(...)` JSON highlighting — it is a syntax-highlight theme, not
+a rich `Theme` object, and is unrelated to width/color gating.
+
+## 3. Existing non-TTY behavior
+
+- **JSON** (`print_json`, `task.py:801-810`) and `print_field`/`print_formatted`
+  (`:215-231`) branch on `sys.stdout.isatty()`: TTY → `Console().print(Syntax(...))` (pretty,
+  themed); non-TTY → plain `print(json.dumps(...))`. This is the established pattern: **only
+  prettify on a TTY**.
+- **Broken pipe**: `exceptions = {BrokenPipeError: handle_broken_pipe}` on the search/list app
+  (`task.py:684`) and info app (`:183`). `handle_broken_pipe` (`core/exceptions.py:99-114`)
+  dup2's stdout to `/dev/null` and returns `exit_status.success`, so `hs list --all --csv | head`
+  exits cleanly instead of dumping a traceback. **Any card renderer must not defeat this** — let
+  `BrokenPipeError` propagate to the app's exception mapping (don't catch/swallow it).
+
+## 4. rich width & color behavior (verified, rich 13.9.4)
+
+- **Non-TTY width fallback = 80.** `Console(file=StringIO()).size.width == 80`,
+  `.is_terminal == False`, `.options.max_width == 80`. On a real TTY, `.size.width` is the live
+  terminal width. `.width == .size.width` for a default console.
+- **`COLUMNS` env overrides width** even when redirected: `COLUMNS=200` → `.width == 200`
+  (verified). rich honors `COLUMNS`/`LINES`.
+- **Color auto-drops on non-TTY.** Printing styled text / a `Panel` to a StringIO emitted **zero
+  ESC bytes** — but the box-drawing border chars (`╭─╮│╰╯`) and the text still render. So a
+  bordered card piped to a file is legible, just uncolored.
+- **`NO_COLOR`**: rich reads it independently of cmdkit. With `force_terminal=True` +
+  `NO_COLOR=1`, `console.no_color` is `True` and **color** escapes are stripped, though
+  non-color attributes (e.g. bold `\x1b[1m`) may remain. Net: status text stays readable.
+- **`console.options.max_width`** is the width used to measure/constrain a renderable; construct
+  child options via `console.options.update_width(n)` to render a card at a chosen width, or set
+  `Console(width=n)` / `Panel(..., width=n)` to pin it.
+
+## 5. Recommendations
+
+**Obtaining effective width.** In the card renderer, construct one `Console()` (bare, like the
+rest of the module) and read `console.size.width`. This transparently gives the live TTY width,
+the `COLUMNS` override, and the 80-col non-TTY fallback for free — no manual `os.get_terminal_size`
+/ `shutil` needed. Reuse that same console object to `print` the card so width used for layout ==
+width used for render.
+
+**Clamp + thresholds (starting point):**
+```
+raw   = console.size.width            # 80 when piped
+width = max(60, min(160, raw))        # clamp to [60, 160]
+if   width < 90:   layout = 'narrow'  # stacked / single column, labels above values
+elif width < 130:  layout = 'normal'  # 2-column label:value
+else:              layout = 'wide'    # multi-column / room for output preview
+```
+Rationale: piped output lands at 80 → `narrow`, which is the safest stacked layout for redirected
+consumers. Render the card body at the clamped `width` (e.g. `Panel(..., width=width)` or via
+`console.options.update_width(width)`) so a very wide terminal caps at 160 and a tiny one floors
+at 60 rather than producing an unusable card.
+
+**Non-TTY / no-color fallback.** rich already strips ANSI when `not console.is_terminal` (matches
+`COLOR_STDOUT` being off) and keeps the Unicode border + text, so a single code path can serve
+both. Recommended: **still emit the bordered card** (borders survive as legible box chars) but
+guarantee the status is plain-text readable — render it as literal `status: FAILED` /
+`status: SUCCESS (0)` text, never color-only. Pick the layout from the (clamped) width, which is
+`narrow` at the 80-col pipe default. Optionally, if `not COLOR_STDOUT` (or `not console.is_terminal`),
+consider ASCII/`box.ASCII` borders for maximal portability — but plain-text legibility is already
+satisfied without it, so this is optional polish, not required. Do **not** special-case away the
+border for pipes unless a `--plain`-style flag is requested; the JSON precedent only swaps *pretty
+highlighting* for plain text, and a card's border carries no color dependency.
+
+**Don't break the pipe.** Keep `BrokenPipeError: handle_broken_pipe` in the app's `exceptions`
+and let it propagate (as `hs list` does) so `hs ... --format card | head` exits 0.

--- a/spec/task-card-view/research/05-docs-completions.md
+++ b/spec/task-card-view/research/05-docs-completions.md
@@ -1,0 +1,128 @@
+# 05 — Docs & completions checklist for adding `card` to `-f/--format`
+
+Scope: add a new `card` value to `hs info`, `hs list`/`hs search` (`hs list` and `hs search`
+are the **same** app — `TaskSearchApp`; `__init__.py:127,130` map both to it). `hs wait --info`
+is **adjacent** (mirrors `info`, shares `(normal, json, yaml)`) — flagged below but out of the
+stated feature scope.
+
+Line numbers are current-tree snapshots; re-verify before editing.
+
+---
+
+## A. In-source help strings + argparse choices (source of truth) — `src/hypershell/task.py`
+
+These are the truth the `docs/_include/*.rst` snippets and man pages mirror. The **`choices`
+list is load-bearing** (argparse rejects `card` unless added); the help string is cosmetic.
+
+- **`hs info` (TaskInfoApp)**
+  - `task.py:141` — help text: `  -f, --format     FORMAT   Format task info ([normal], json, yaml).` → add `card`.
+  - `task.py:172` — `output_formats: List[str] = ['normal', 'json', 'yaml']` → **add `'card'`** (choices).
+  - (Synopsis `task.py:127` shows only `[-f FORMAT]`; no enumeration to edit.)
+- **`hs list`/`hs search` (TaskSearchApp)**
+  - `task.py:591` — help: `  -f, --format      FORMAT   Format output (normal, plain, table, csv, json).` → add `card`.
+  - `task.py:663` — `output_formats: List[str] = ['normal', 'plain', 'table', 'json', 'csv']` → **add `'card'`** (choices).
+  - Impl notes (out of docs scope but required for the feature to work): formatter dispatch is
+    `getattr(self, f'print_{self.output_format}')` (`task.py:745`) → needs a `print_card` method;
+    `check_output_format()` (`task.py:821+`) may need a `card` branch. Not a docs/completion edit.
+- **`hs wait --info` (TaskWaitApp) — ADJACENT, out of scope**
+  - `task.py:310` help + `task.py:339` `output_formats = ['normal','json','yaml']`. `wait` delegates to
+    `TaskInfoApp(output_format=self.output_format)` (`task.py:361`), so **`hs wait --info -f card`
+    would be rejected** unless this list also gains `'card'`. Decide during planning; not required
+    by the stated scope.
+
+---
+
+## B. docs/_include/*.rst help snippets (same-commit per AGENTS.md §Config/Docs)
+
+- **`docs/_include/task_info_help.rst:11`** — `Format task info ([normal], json, yaml).` → add `card`.
+- **`docs/_include/task_search_help.rst:75`** — ``Specify output format (either ``normal``, ``plain``, ``table``, ``csv``, ``json``).`` → add ``card``.
+  - Surrounding prose `task_search_help.rst:77–79` explains when to use each format — optionally add a
+    sentence for `card` (not strictly an enumeration line).
+- **`docs/_include/task_wait_help.rst:19`** — ADJACENT: `Format task info ([normal], json, yaml).`
+  (edit only if `wait` gains `card` per A above).
+
+---
+
+## C. Other docs
+
+- No hand-written format enumerations exist outside `_include` and the generated man pages.
+  `docs/manual.rst` only `.. include::`s the `_include/*.rst` snippets, so editing B propagates.
+- `docs/_build/**` is generated Sphinx output — **do not edit**.
+
+---
+
+## D. bash completion — `share/bash_completion.d/hs`
+
+`share/bash_completion.d/hsx` is a **symlink → hs**, so editing `hs` covers both. Values are a
+space-separated `compgen -W "..."` word list — just add `card`.
+
+- **`share/bash_completion.d/hs:297`** — `_hs_task_info`: `compgen -W "normal json yaml"` → add `card`.
+- **`share/bash_completion.d/hs:418`** — `_hs_task_search` (list/search): `compgen -W "normal plain table csv json"` → add `card`.
+- **`share/bash_completion.d/hs:327`** — ADJACENT: `_hs_task_wait` `compgen -W "normal json yaml"`
+  (edit only if `wait` gains `card`).
+- (The search opts blob at `hs:377–380` lists flags, not format values — no change.)
+
+---
+
+## E. zsh completion — `share/zsh/site-functions/_hs`
+
+Spec syntax: `'(<mutex flags>)'{-f,--format}'[<desc>]:format:(<space-separated values>)'`.
+Add `card` inside the trailing `(...)`.
+
+- **`_hs:355`** — info: `'(-f --format --json --yaml)'{-f,--format}'[Format task info]:format:(normal json yaml)'` → `(normal json yaml card)`.
+- **`_hs:417`** — search/list: `'(-f --format --json --csv)'{-f,--format}'[Format output]:format:(normal plain table csv json)'` → `(normal plain table csv json card)`.
+- **`_hs:377`** — ADJACENT: wait `:format:(normal json yaml)` (edit only if `wait` gains `card`).
+
+---
+
+## F. man pages — GENERATED (not hand-maintained for content)
+
+Man pages are built by Sphinx from `docs/manual.rst` (→ the `_include` snippets), per the
+`hs-release` skill (`.agents/skills/hs-release/SKILL.md:157–165`):
+
+```
+uv run sphinx-build -b man docs docs/_build/man
+cp docs/_build/man/hs.1          share/man/man1/hs.1
+cp docs/_build/man/hyper-shell.1 share/man/man1/hyper-shell.1
+cp share/man/man1/hs.1           share/man/man1/hsx.1     # hsx.1 is a copy of hs.1
+```
+
+`hs.1` and `hsx.1` are byte-identical (25042→115608B); `hyper-shell.1` differs only by program
+name. Current enumeration lines (identical across all three): **info = line 1228**, **wait =
+line 1289**, **search = line 1436**.
+
+**Recommendation:** after editing the `_include` snippets (B), **regenerate** the three man pages
+with the command above rather than hand-patching. Version is unchanged, so the diff should be
+exactly the format-enumeration lines (no `.TH` change). Regenerating in the same commit keeps
+`share/man` consistent with the snippets and prevents a surprise non-version man diff at the next
+`/hs-release` (Step 4 verifies the man diff is version-only). Hand-patching lines 1228/1436 in all
+3 files is possible but fragile — prefer regeneration.
+
+---
+
+## G. CI metadata guard — only ADDING values, no new files
+
+`.github/workflows/tests.yml:96–113` ("Assert completions & man pages ship in the wheel") asserts
+these **wheel** paths exist:
+`share/bash-completion/completions/{hs,hsx}`, `share/zsh/site-functions/_hs`,
+`share/man/man1/{hs,hsx,hyper-shell}.1`. Those are the *installed* paths; `pyproject.toml:119–125`
+(`[tool.hatch.build.targets.wheel.shared-data]`) remaps the on-disk `share/bash_completion.d/{hs,hsx}`
+→ `share/bash-completion/completions/{hs,hsx}`. **All edits above modify existing files only** (bash
+`hsx` is a symlink to `hs`), so the asserted path list is **unaffected** — no new files, no CI list
+change.
+
+---
+
+## Edit summary (minimum required for stated scope: info + list/search)
+
+| File | Line(s) | Change |
+|------|---------|--------|
+| `src/hypershell/task.py` | 141, 172 (info); 591, 663 (search) | help text + **choices** `+card` |
+| `docs/_include/task_info_help.rst` | 11 | help `+card` |
+| `docs/_include/task_search_help.rst` | 75 (+77–79 prose optional) | help `+card` |
+| `share/bash_completion.d/hs` | 297 (info), 418 (search) | word list `+card` (hsx symlink covered) |
+| `share/zsh/site-functions/_hs` | 355 (info), 417 (search) | `:format:(...)` `+card` |
+| `share/man/man1/{hs,hsx,hyper-shell}.1` | 1228 (info), 1436 (search) | **regenerate** via sphinx-build -b man |
+
+Adjacent (decide in planning, NOT in stated scope): `wait` at `task.py:310/339`,
+`task_wait_help.rst:19`, `bash hs:327`, `zsh _hs:377`, man line 1289.

--- a/src/hypershell/data/model.py
+++ b/src/hypershell/data/model.py
@@ -1045,6 +1045,17 @@ class Source(Entity):
             return {}
         return dict(cls.query(cls.id, cls.path).filter(cls.id.in_(set(ids))).all())
 
+    @classmethod
+    def fingerprints_for_ids(cls: Type[Source], ids: List[str]) -> Dict[str, str]:
+        """Map of source id -> content fingerprint for the given `ids` (batched presentation lookup).
+
+        A source with a NULL fingerprint (the reserved `<direct>`/`<stdin>` rows, or a pre-
+        fingerprinting row) maps to None; callers render no parenthetical for those.
+        """
+        if not ids:
+            return {}
+        return dict(cls.query(cls.id, cls.fingerprint).filter(cls.id.in_(set(ids))).all())
+
 
 # Indices for efficient queries
 index_source_lookup = Index('index_source_lookup', Source.path, Source.fingerprint)

--- a/src/hypershell/data/model.py
+++ b/src/hypershell/data/model.py
@@ -430,11 +430,13 @@ class Task(Entity):
     @classmethod
     def compute_fingerprint(cls: Type[Task], raw_command: str, group: int,
                             tags: Optional[Dict[str, JSONData]]) -> str:
-        """Stable, order-independent identity fingerprint.
+        """
+        Stable, order-independent identity fingerprint.
 
-        An md5 over canonical JSON of the pre-template ``raw_command``, the task
-        ``group``, and user ``tags`` (resource knobs are already popped from the tag
-        dict before this is called; the bookkeeping ``part`` is a column, never a tag).
+        An md5 over canonical JSON of the pre-template ``raw_command``, the task ``group``,
+        and user ``tags`` (resource knobs are already popped from the tag dict before this
+        is called; the bookkeeping ``part`` is a column, never a tag).
+
         The uuid, attempt/retry counters, timing, exit status, and execution template
         deliberately do not participate — re-running the same work under a different
         template yields the same fingerprint. MD5 matches the SOURCE content fingerprint
@@ -468,7 +470,8 @@ class Task(Entity):
 
     @staticmethod
     def ensure_valid_tag(tag: Optional[Dict[str, JSONData]], *, strict: bool = True) -> None:
-        """Check tag dictionary and raise if invalid.
+        """
+        Check tag dictionary and raise if invalid.
 
         With ``strict=False`` (used for JSON-sourced tags) the character-set and
         length restrictions on keys and values are relaxed; only the structural
@@ -1047,7 +1050,8 @@ class Source(Entity):
 
     @classmethod
     def fingerprints_for_ids(cls: Type[Source], ids: List[str]) -> Dict[str, str]:
-        """Map of source id -> content fingerprint for the given `ids` (batched presentation lookup).
+        """
+        Map of source id -> content fingerprint for the given `ids` (batched presentation lookup).
 
         A source with a NULL fingerprint (the reserved `<direct>`/`<stdin>` rows, or a pre-
         fingerprinting row) maps to None; callers render no parenthetical for those.

--- a/src/hypershell/data/model.py
+++ b/src/hypershell/data/model.py
@@ -347,6 +347,25 @@ class Task(Entity):
     class AlreadyExists(AlreadyExists):
         pass
 
+    @property
+    def status_label(self: Task) -> str:
+        """Human-readable lifecycle status for display (e.g. the `card`-view badge)."""
+        if self.schedule_time is None:
+            return 'WAITING'
+        if self.completion_time is None:
+            return 'RUNNING'
+        if self.exit_status == 0:
+            return 'OK'
+        if self.exit_status == CANCEL_STATUS:
+            return 'CANCELLED'
+        if self.exit_status is None:
+            return 'UNKNOWN'
+        if self.exit_status <= -1000:
+            return 'ERROR'
+        if self.exit_status < 0:
+            return 'KILLED'
+        return 'FAILED'
+
     @classmethod
     def from_id(cls: Type[Task], id: str, caching: bool = True) -> Task:
         """Look up task by unique `id`."""

--- a/src/hypershell/task.py
+++ b/src/hypershell/task.py
@@ -799,13 +799,15 @@ class TaskSearchApp(Application, SearchableMixin):
     def print_card(results: List[Tuple]) -> None:
         """Print each task as a richly-formatted, width-responsive card (see `render_card`)."""
         tasks = [Task.from_dict(dict(zip(Task.columns, record))) for record in results]
-        source_map = Source.paths_for_ids([task.source for task in tasks if task.source])
+        source_ids = [task.source for task in tasks if task.source]
+        source_map = Source.paths_for_ids(source_ids)
+        fingerprint_map = Source.fingerprints_for_ids(source_ids)
         console = Console()
         width = card_width(console.size.width)
         for i, task in enumerate(tasks):
             if i:
                 console.print()  # A blank line separates adjacent cards.
-            console.print(render_card(task, width, source_map=source_map))
+            console.print(render_card(task, width, source_map=source_map, fingerprint_map=fingerprint_map))
 
     def print_plain(self: TaskSearchApp, results: List[Tuple]) -> None:
         """Print plain text output with given field names, one task per line."""
@@ -1413,6 +1415,25 @@ def resolve_source(source: Optional[str], source_map: Optional[Dict[str, str]] =
     return format_source(path) if path else source
 
 
+def resolve_source_fingerprint(source: Optional[str],
+                               fingerprint_map: Optional[Dict[str, str]] = None) -> Optional[str]:
+    """Resolve a task's `source` UUID to its Source content-fingerprint for the card's `source id`.
+
+    Mirrors `resolve_source`: a batched `fingerprint_map` (id -> fingerprint) is consulted first to
+    avoid an N+1 lookup; otherwise a single `Source.from_id` resolves it. Returns None when the task
+    has no source, the source row is missing, or the source predates fingerprinting - callers then
+    render no parenthetical.
+    """
+    if not source:
+        return None
+    if fingerprint_map is not None:
+        return fingerprint_map.get(source)
+    try:
+        return Source.from_id(source).fingerprint
+    except Source.NotFound:
+        return None
+
+
 def format_task_fields(task: Task, source_map: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
     """Prepare a task's columns as display values shared by the `normal` and `card` views.
 
@@ -1473,7 +1494,8 @@ def card_region(title: str, rows: List[Tuple[str, Any]]) -> Group:
     return Group(Text(''), Text(title, style='bold underline'), grid)
 
 
-def render_card(task: Task, width: int, source_map: Optional[Dict[str, str]] = None) -> Panel:
+def render_card(task: Task, width: int, source_map: Optional[Dict[str, str]] = None,
+                fingerprint_map: Optional[Dict[str, str]] = None) -> Panel:
     """Build a `rich` card for one task (the `card` output format).
 
     `width` is clamped to [60, 160]; the metadata region layout is chosen from it (one column
@@ -1481,7 +1503,8 @@ def render_card(task: Task, width: int, source_map: Optional[Dict[str, str]] = N
     top - the id on its own line below 130 so it is never truncated - and the virtual `status:`
     badge from `Task.status_label` is pinned to the lower-right via the Panel subtitle. Renders
     legibly with no color: rich drops styling on a non-terminal and the status stays literal
-    text.
+    text. `source_map`/`fingerprint_map` (id -> path / id -> fingerprint) let a multi-task caller
+    batch-resolve the source's path and content-fingerprint and avoid N+1 lookups.
     """
     width = card_width(width)
     # One column below 90; two through 149; three only when wide enough that a full UUID
@@ -1490,6 +1513,9 @@ def render_card(task: Task, width: int, source_map: Optional[Dict[str, str]] = N
     data = format_task_fields(task, source_map)
     label = task.status_label
     style = STATUS_STYLES.get(label, 'magenta')
+    # The Source content-fingerprint rides in parens on the `source id` line, when the source has one.
+    source_fingerprint = resolve_source_fingerprint(task.source, fingerprint_map)
+    source_id = data['source_id'] if not source_fingerprint else f"{data['source_id']} ({source_fingerprint})"
 
     # Identity header. A future `zone` column adds another cell here without further change.
     def field(key: str, value: Any) -> Text:
@@ -1509,11 +1535,15 @@ def render_card(task: Task, width: int, source_map: Optional[Dict[str, str]] = N
         second.add_row(*identity)
         header.add_row(second)
 
-    command = card_region('command', [('args', data['args']), ('command', data['command'])])
+    # The command and its provenance/outcome (source, exit status) go full-width, above the
+    # responsive grid, so long source paths and the command line are never cramped into a cell.
+    submission = card_region('submission', [('args', data['args']), ('command', data['command']),
+                                            ('source', data['source']), ('source id', source_id),
+                                            ('exit status', data['exit_status'])])
     metadata = [
         card_region('timing', [('submitted', data['submit_time']), ('scheduled', data['schedule_time']),
-                               ('started', data['start_time']), ('waited', data['waited']),
-                               ('completed', data['completion_time']), ('duration', data['duration']),
+                               ('started', data['start_time']), ('completed', data['completion_time']),
+                               ('waited', data['waited']), ('duration', data['duration']),
                                ('timeout', data['timeout'])]),
         card_region('resources', [('cores', f"{data['cores']} (max {data['cores_max']})"),
                                   ('memory', f"{data['memory']} (max {data['memory_max']})")]),
@@ -1524,8 +1554,6 @@ def render_card(task: Task, width: int, source_map: Optional[Dict[str, str]] = N
                                ('csv', data['csvpath'])]),
         card_region('retry', [('attempt', data['attempt']), ('retried', data['retried']),
                               ('prev', data['previous_id']), ('next', data['next_id'])]),
-        card_region('result', [('source', data['source']), ('source id', data['source_id']),
-                               ('exit status', data['exit_status'])]),
     ]
     columns = Table.grid(expand=True, padding=(0, 3))
     for _ in range(ncols):
@@ -1535,7 +1563,7 @@ def render_card(task: Task, width: int, source_map: Optional[Dict[str, str]] = N
         cells += [''] * (ncols - len(cells))
         columns.add_row(*cells)
 
-    body = [header, command, columns]
+    body = [header, submission, columns]
     if task.tag:
         body.append(card_region('tags', [('', data['tag'])]))
     badge = Text.assemble(('status: ', 'dim'), (label, style))

--- a/src/hypershell/task.py
+++ b/src/hypershell/task.py
@@ -141,7 +141,7 @@ Arguments:
   ID                        Unique task UUID.
 
 Options:
-  -f, --format     FORMAT   Format task info ([normal], json, yaml).
+  -f, --format     FORMAT   Format task info ([normal], card, json, yaml).
       --json                Format task metadata as JSON.
       --yaml                Format task metadata as YAML.
   -x, --extract    FIELD    Print single field.
@@ -172,7 +172,7 @@ class TaskInfoApp(Application):
     print_interface.add_argument('-x', '--extract', default=None, choices=Task.columns, dest='extract_field')
 
     output_format: str = 'normal'
-    output_formats: List[str] = ['normal', 'json', 'yaml']
+    output_formats: List[str] = ['normal', 'card', 'json', 'yaml']
     output_interface = interface.add_mutually_exclusive_group()
     output_interface.add_argument('-f', '--format', default=output_format, dest='output_format', choices=output_formats)
     output_interface.add_argument('--json', action='store_const', const='json', dest='output_format')
@@ -203,6 +203,9 @@ class TaskInfoApp(Application):
             self.print_file('csvpath')
         elif self.output_format == 'normal':
             print_normal(self.task)
+        elif self.output_format == 'card':
+            console = Console()
+            console.print(render_card(self.task, card_width(console.size.width)))
         else:
             self.print_formatted()
 
@@ -310,7 +313,7 @@ Arguments:
 Options:
   -n, --interval  SEC     Time to wait between polling (default: {DEFAULT_INTERVAL}).
   -i, --info              Print info on task.
-  -f, --format    FORMAT  Format task info ([normal], json, yaml).
+  -f, --format    FORMAT  Format task info ([normal], card, json, yaml).
       --json              Format info as JSON.
       --yaml              Format info as YAML.
   -s, --status            Print exit status for task.
@@ -339,7 +342,7 @@ class TaskWaitApp(Application):
     print_interface.add_argument('-r', '--return', action='store_true', dest='return_status')
 
     output_format: str = 'normal'
-    output_formats: List[str] = ['normal', 'json', 'yaml']
+    output_formats: List[str] = ['normal', 'card', 'json', 'yaml']
     output_interface = interface.add_mutually_exclusive_group()
     output_interface.add_argument('-f', '--format', default=output_format,
                                   dest='output_format', choices=output_formats)

--- a/src/hypershell/task.py
+++ b/src/hypershell/task.py
@@ -591,7 +591,7 @@ Options:
   -X, --cancelled            Alias for `-w exit_status == {CANCEL_STATUS}`.
       --retries              Alias for `-w attempt > 1`.
       --signal      NAME     Match tasks killed by signal NAME (e.g. TERM, KILL, HUP).
-  -f, --format      FORMAT   Format output (normal, plain, table, csv, json).
+  -f, --format      FORMAT   Format output (normal, card, plain, table, csv, json).
       --json                 Format output as JSON (alias for `--format=json`).
       --csv                  Format output as CSV (alias for `--format=csv`).
   -d, --delimiter   CHAR     Field seperator for plain/csv formats.
@@ -663,7 +663,7 @@ class TaskSearchApp(Application, SearchableMixin):
     interface.add_argument('--signal', default=None, dest='signal_filter')
 
     output_format: str = '<default>'  # 'plain' if field_names else 'normal'
-    output_formats: List[str] = ['normal', 'plain', 'table', 'json', 'csv']
+    output_formats: List[str] = ['normal', 'card', 'plain', 'table', 'json', 'csv']
     output_interface = interface.add_mutually_exclusive_group()
     output_interface.add_argument('-f', '--format', default=output_format,
                                   dest='output_format', choices=output_formats)
@@ -792,6 +792,18 @@ class TaskSearchApp(Application, SearchableMixin):
             print('---')
             print_normal(task, source_map=source_map)
 
+    @staticmethod
+    def print_card(results: List[Tuple]) -> None:
+        """Print each task as a richly-formatted, width-responsive card (see `render_card`)."""
+        tasks = [Task.from_dict(dict(zip(Task.columns, record))) for record in results]
+        source_map = Source.paths_for_ids([task.source for task in tasks if task.source])
+        console = Console()
+        width = card_width(console.size.width)
+        for i, task in enumerate(tasks):
+            if i:
+                console.print()  # A blank line separates adjacent cards.
+            console.print(render_card(task, width, source_map=source_map))
+
     def print_plain(self: TaskSearchApp, results: List[Tuple]) -> None:
         """Print plain text output with given field names, one task per line."""
         for record in results:
@@ -829,8 +841,8 @@ class TaskSearchApp(Application, SearchableMixin):
         else:
             if self.output_format == '<default>':
                 self.output_format = 'plain'
-            elif self.output_format == 'normal':
-                raise ArgumentError('Cannot use --format=normal with subset of field names')
+            elif self.output_format in ('normal', 'card'):
+                raise ArgumentError(f'Cannot use --format={self.output_format} with subset of field names')
         if self.output_delimiter != '<default>' and self.output_format not in ['plain', 'csv']:
             raise ArgumentError(f'Unused --delimiter for --format={self.output_format}')
         if len(self.output_delimiter) > DELIMITER_MAX_SIZE:

--- a/src/hypershell/task.py
+++ b/src/hypershell/task.py
@@ -1353,7 +1353,8 @@ SPECIAL_TASK_COLORS: Final[Dict[Optional[int], Callable[[str], str]]] = {
 
 
 def select_color(status: Optional[int]) -> Callable[[str], str]:
-    """Delegate function for colorization based on task exit status.
+    """
+    Delegate function for colorization based on task exit status.
 
     Remaining (unrun) tasks are uncolored, successful tasks are green, and cancelled tasks
     (exit_status == CANCEL_STATUS, including those terminated by SIGHUP) are faint. Any other
@@ -1397,7 +1398,8 @@ STATUS_STYLES: Final[Dict[str, str]] = {
 
 
 def resolve_source(source: Optional[str], source_map: Optional[Dict[str, str]] = None) -> str:
-    """Resolve a task's `source` UUID to a display path/sentinel for the normal view.
+    """
+    Resolve a task's `source` UUID to a display path/sentinel for the normal view.
 
     NULL (historical rows) renders as ``null``. A batched `source_map` (id -> path) is
     consulted first to avoid an N+1 lookup; otherwise a single `Source.from_id` resolves
@@ -1417,7 +1419,8 @@ def resolve_source(source: Optional[str], source_map: Optional[Dict[str, str]] =
 
 def resolve_source_fingerprint(source: Optional[str],
                                fingerprint_map: Optional[Dict[str, str]] = None) -> Optional[str]:
-    """Resolve a task's `source` UUID to its Source content-fingerprint for the card's `source id`.
+    """
+    Resolve a task's `source` UUID to its Source content-fingerprint for the card's `source id`.
 
     Mirrors `resolve_source`: a batched `fingerprint_map` (id -> fingerprint) is consulted first to
     avoid an N+1 lookup; otherwise a single `Source.from_id` resolves it. Returns None when the task
@@ -1435,12 +1438,13 @@ def resolve_source_fingerprint(source: Optional[str],
 
 
 def format_task_fields(task: Task, source_map: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
-    """Prepare a task's columns as display values shared by the `normal` and `card` views.
+    """
+    Prepare a task's columns as display values shared by the `normal` and `card` views.
 
     Every column is JSON-formatted first, then the human-friendly overrides are applied:
     durations/timeout as `timedelta`, memory via `format_bytes`, the resolved `source` path
     plus its raw id (`source_id`), and tags flattened to `key:value` pairs. `source_map`
-    (id -> path) lets a multi-task caller batch-resolve sources and avoid an N+1 lookup.
+    (id -> path) lets a multitask caller batch-resolve sources and avoid an N+1 lookup.
     """
     data = {k: format_json(v) for k, v in task.to_dict().items()}
     data['waited'] = 'null' if task.waited is None else timedelta(seconds=int(task.waited))
@@ -1457,9 +1461,10 @@ def format_task_fields(task: Task, source_map: Optional[Dict[str, str]] = None) 
 
 
 def print_normal(task: Task, source_map: Optional[Dict[str, str]] = None) -> None:
-    """Print semi-structured task metadata with all field names.
+    """
+    Print semi-structured task metadata with all field names.
 
-    `source_map` (id -> path) lets a multi-task caller batch-resolve sources up front and
+    `source_map` (id -> path) lets a multitask caller batch-resolve sources up front and
     avoid an N+1 lookup; when omitted (e.g. `hs info`), the single source is resolved directly.
     """
     color = select_color(task.exit_status)
@@ -1478,7 +1483,8 @@ def card_width(console_width: int) -> int:
 
 
 def card_region(title: str, rows: List[Tuple[str, Any]]) -> Group:
-    """A titled label:value block for one logical group of card fields.
+    """
+    A titled label:value block for one logical group of card fields.
 
     Each block carries one leading blank line so regions stay evenly spaced whether stacked
     in one column or laid side by side in a grid, without doubling separators.
@@ -1496,7 +1502,8 @@ def card_region(title: str, rows: List[Tuple[str, Any]]) -> Group:
 
 def render_card(task: Task, width: int, source_map: Optional[Dict[str, str]] = None,
                 fingerprint_map: Optional[Dict[str, str]] = None) -> Panel:
-    """Build a `rich` card for one task (the `card` output format).
+    """
+    Build a `rich` card for one task (the `card` output format).
 
     `width` is clamped to [60, 160]; the metadata region layout is chosen from it (one column
     below 90, two below 150, three at or above 150). Identity fields sit horizontally across the

--- a/src/hypershell/task.py
+++ b/src/hypershell/task.py
@@ -23,9 +23,12 @@ from shutil import copyfileobj
 
 # External libs
 import yaml
-from rich.console import Console
+from rich.console import Console, Group
 from rich.syntax import Syntax
 from rich.table import Table
+from rich.panel import Panel
+from rich.text import Text
+from rich import box
 from cmdkit.app import Application, ApplicationGroup, exit_status
 from cmdkit.cli import Interface, ArgumentError
 from cmdkit.ansi import red, green, yellow, faint, COLOR_STDOUT
@@ -1360,6 +1363,22 @@ def select_style(status: Optional[int]) -> Optional[str]:
     return SPECIAL_TASK_STYLES.get(status, 'yellow' if status is not None and status < 0 else 'red')
 
 
+# Rich styles for the `card` view's virtual status badge and border, keyed by
+# `Task.status_label`. Unlike `select_style` (exit-status only), the whole-lifecycle
+# derivation tells WAITING from RUNNING and colors CANCELLED yellow - a deliberate card
+# palette; normal/plain/table keep the exit-status coloring above.
+STATUS_STYLES: Final[Dict[str, str]] = {
+    'OK': 'bold green',
+    'FAILED': 'bold red',
+    'CANCELLED': 'yellow',
+    'RUNNING': 'cyan',
+    'WAITING': 'dim',
+    'ERROR': 'magenta',
+    'KILLED': 'magenta',
+    'UNKNOWN': 'magenta',
+}
+
+
 def resolve_source(source: Optional[str], source_map: Optional[Dict[str, str]] = None) -> str:
     """Resolve a task's `source` UUID to a display path/sentinel for the normal view.
 
@@ -1379,22 +1398,132 @@ def resolve_source(source: Optional[str], source_map: Optional[Dict[str, str]] =
     return format_source(path) if path else source
 
 
+def format_task_fields(task: Task, source_map: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+    """Prepare a task's columns as display values shared by the `normal` and `card` views.
+
+    Every column is JSON-formatted first, then the human-friendly overrides are applied:
+    durations/timeout as `timedelta`, memory via `format_bytes`, the resolved `source` path
+    plus its raw id (`source_id`), and tags flattened to `key:value` pairs. `source_map`
+    (id -> path) lets a multi-task caller batch-resolve sources and avoid an N+1 lookup.
+    """
+    data = {k: format_json(v) for k, v in task.to_dict().items()}
+    data['waited'] = 'null' if task.waited is None else timedelta(seconds=int(task.waited))
+    data['duration'] = 'null' if task.duration is None else timedelta(seconds=int(task.duration))
+    data['tag'] = ', '.join(format_tag(k, v) for k, v in task.tag.items())
+    data['cores'] = int(task.cores or 0)
+    data['cores_max'] = 'null' if not task.cores_max else f'{task.cores_max:.2f}'
+    data['memory'] = format_bytes(int(task.memory or 0))
+    data['memory_max'] = 'null' if not task.memory_max else format_bytes(int(task.memory_max))
+    data['timeout'] = 'null' if not task.timeout else timedelta(seconds=int(task.timeout))
+    data['source_id'] = format_json(task.source)          # raw Source.id, shown in parens on `source`
+    data['source'] = resolve_source(task.source, source_map)
+    return data
+
+
 def print_normal(task: Task, source_map: Optional[Dict[str, str]] = None) -> None:
     """Print semi-structured task metadata with all field names.
 
     `source_map` (id -> path) lets a multi-task caller batch-resolve sources up front and
     avoid an N+1 lookup; when omitted (e.g. `hs info`), the single source is resolved directly.
     """
-    task_data = {k: format_json(v) for k, v in task.to_dict().items()}
-    task_data['waited'] = 'null' if task.waited is None else timedelta(seconds=int(task_data['waited']))
-    task_data['duration'] = 'null' if task.duration is None else timedelta(seconds=int(task_data['duration']))
-    task_data['tag'] = ', '.join(format_tag(k, v) for k, v in task.tag.items())
-    task_data['cores'] = int(task.cores or 0)
-    task_data['cores_max'] = 'null' if not task.cores_max else f'{task.cores_max:.2f}'
-    task_data['memory'] = format_bytes(int(task.memory or 0))
-    task_data['memory_max'] = 'null' if not task.memory_max else format_bytes(int(task.memory_max))
-    task_data['timeout'] = 'null' if not task.timeout else timedelta(seconds=int(task.timeout))
-    task_data['source_id'] = format_json(task.source)          # raw Source.id, shown in parens on `source`
-    task_data['source'] = resolve_source(task.source, source_map)
     color = select_color(task.exit_status)
-    print(color(NORMAL_MODE_TEMPLATE.format(**task_data)))
+    print(color(NORMAL_MODE_TEMPLATE.format(**format_task_fields(task, source_map))))
+
+
+# The `card` view supports terminal widths in this range; a raw console width is clamped
+# into it and the region layout (one/two/three columns) is chosen from the result.
+CARD_MIN_WIDTH: Final[int] = 60
+CARD_MAX_WIDTH: Final[int] = 160
+
+
+def card_width(console_width: int) -> int:
+    """Clamp a raw console width to the card's supported [60, 160] range."""
+    return max(CARD_MIN_WIDTH, min(CARD_MAX_WIDTH, console_width))
+
+
+def card_region(title: str, rows: List[Tuple[str, Any]]) -> Group:
+    """A titled label:value block for one logical group of card fields.
+
+    Each block carries one leading blank line so regions stay evenly spaced whether stacked
+    in one column or laid side by side in a grid, without doubling separators.
+    """
+    grid = Table.grid(padding=(0, 1))
+    grid.add_column(justify='right', style='dim', no_wrap=True)
+    grid.add_column(overflow='fold')
+    for key, value in rows:
+        # Values are task data (commands, paths, tags) and must render literally: a bare string
+        # cell is parsed as `rich` console markup, so brackets (`sed 's/[/]/'`, bash arrays) would
+        # be silently stripped or raise MarkupError. Text renders verbatim, as the header does.
+        grid.add_row(key, Text(str(value)))
+    return Group(Text(''), Text(title, style='bold underline'), grid)
+
+
+def render_card(task: Task, width: int, source_map: Optional[Dict[str, str]] = None) -> Panel:
+    """Build a `rich` card for one task (the `card` output format).
+
+    `width` is clamped to [60, 160]; the metadata region layout is chosen from it (one column
+    below 90, two below 150, three at or above 150). Identity fields sit horizontally across the
+    top - the id on its own line below 130 so it is never truncated - and the virtual `status:`
+    badge from `Task.status_label` is pinned to the lower-right via the Panel subtitle. Renders
+    legibly with no color: rich drops styling on a non-terminal and the status stays literal
+    text.
+    """
+    width = card_width(width)
+    # One column below 90; two through 149; three only when wide enough that a full UUID
+    # value does not fold mid-token. The identity header goes fully horizontal at >= 130.
+    ncols = 1 if width < 90 else 2 if width < 150 else 3
+    data = format_task_fields(task, source_map)
+    label = task.status_label
+    style = STATUS_STYLES.get(label, 'magenta')
+
+    # Identity header. A future `zone` column adds another cell here without further change.
+    def field(key: str, value: Any) -> Text:
+        return Text.assemble((f'{key} ', 'dim'), str(value))
+    identity = [field('fp', data['fingerprint']), field('group', data['group']), field('part', data['part'])]
+    header = Table.grid(padding=(0, 3))
+    if width >= 130:
+        for _ in range(4):
+            header.add_column(no_wrap=True)
+        header.add_row(field('id', data['id']), *identity)
+    else:
+        header.add_column()
+        header.add_row(field('id', data['id']))
+        second = Table.grid(padding=(0, 2))
+        for _ in range(3):
+            second.add_column(no_wrap=True)
+        second.add_row(*identity)
+        header.add_row(second)
+
+    command = card_region('command', [('args', data['args']), ('command', data['command'])])
+    metadata = [
+        card_region('timing', [('submitted', data['submit_time']), ('scheduled', data['schedule_time']),
+                               ('started', data['start_time']), ('waited', data['waited']),
+                               ('completed', data['completion_time']), ('duration', data['duration']),
+                               ('timeout', data['timeout'])]),
+        card_region('resources', [('cores', f"{data['cores']} (max {data['cores_max']})"),
+                                  ('memory', f"{data['memory']} (max {data['memory_max']})")]),
+        card_region('execution', [('submit', f"{data['submit_host']} ({data['submit_id']})"),
+                                  ('server', f"{data['server_host']} ({data['server_id']})"),
+                                  ('client', f"{data['client_host']} ({data['client_id']})")]),
+        card_region('output', [('out', data['outpath']), ('err', data['errpath']),
+                               ('csv', data['csvpath'])]),
+        card_region('retry', [('attempt', data['attempt']), ('retried', data['retried']),
+                              ('prev', data['previous_id']), ('next', data['next_id'])]),
+        card_region('result', [('source', data['source']), ('source id', data['source_id']),
+                               ('exit status', data['exit_status'])]),
+    ]
+    columns = Table.grid(expand=True, padding=(0, 3))
+    for _ in range(ncols):
+        columns.add_column(ratio=1, overflow='fold')
+    for i in range(0, len(metadata), ncols):
+        cells = list(metadata[i:i + ncols])
+        cells += [''] * (ncols - len(cells))
+        columns.add_row(*cells)
+
+    body = [header, command, columns]
+    if task.tag:
+        body.append(card_region('tags', [('', data['tag'])]))
+    badge = Text.assemble(('status: ', 'dim'), (label, style))
+    return Panel(Group(*body), title='task', title_align='left', box=box.ROUNDED,
+                 width=width, padding=(0, 1), subtitle=badge, subtitle_align='right',
+                 border_style=style)

--- a/src/hypershell/task.py
+++ b/src/hypershell/task.py
@@ -204,8 +204,8 @@ class TaskInfoApp(Application):
         elif self.output_format == 'normal':
             print_normal(self.task)
         elif self.output_format == 'card':
-            console = Console()
-            console.print(render_card(self.task, card_width(console.size.width)))
+            console = card_console()
+            console.print(render_card(self.task, console.width))
         else:
             self.print_formatted()
 
@@ -802,8 +802,8 @@ class TaskSearchApp(Application, SearchableMixin):
         source_ids = [task.source for task in tasks if task.source]
         source_map = Source.paths_for_ids(source_ids)
         fingerprint_map = Source.fingerprints_for_ids(source_ids)
-        console = Console()
-        width = card_width(console.size.width)
+        console = card_console()
+        width = console.width
         for i, task in enumerate(tasks):
             if i:
                 console.print()  # A blank line separates adjacent cards.
@@ -1480,6 +1480,18 @@ CARD_MAX_WIDTH: Final[int] = 160
 def card_width(console_width: int) -> int:
     """Clamp a raw console width to the card's supported [60, 160] range."""
     return max(CARD_MIN_WIDTH, min(CARD_MAX_WIDTH, console_width))
+
+
+def card_console() -> Console:
+    """
+    A `Console` whose render width is the clamped card width for the current terminal.
+
+    Sizing the console itself (not just the Panel) to `card_width` is what honors the minimum-60
+    floor: a bare `Console` renders at the raw terminal width and clips a wider Panel, truncating
+    the id below 60 columns. Fixing `width` leaves `is_terminal` detection intact, so a non-TTY
+    still drops color and the status stays literal text.
+    """
+    return Console(width=card_width(Console().size.width))
 
 
 def card_region(title: str, rows: List[Tuple[str, Any]]) -> Group:

--- a/tests/test_card_info.py
+++ b/tests/test_card_info.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2026 Geoffrey Lentner
+# SPDX-License-Identifier: Apache-2.0
+
+"""Functional tests for `--format=card` on `hs info` (and its `hs wait --info` parity).
+
+These are unit-level and use a freshly-submitted (unscheduled) task, so the card honestly
+renders `status: WAITING`. The completed-task path (an `OK` card, and `hs wait --info -f card`
+which blocks until completion) is exercised end-to-end by the P5 integration test.
+"""
+
+
+# Type annotations
+from __future__ import annotations
+
+# Standard libs
+import re
+from pathlib import Path
+
+# External libs
+from pytest import mark, fixture
+from cmdkit.app import exit_status as cli_status
+
+# Internal libs
+from hypershell.task import TaskInfoApp, TaskWaitApp
+from tests import main, main_lines, create_taskfile
+
+
+ANSI = re.compile(r'\x1b\[[0-9;]*m')
+UUID = re.compile(r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
+
+
+def strip_ansi(text: str) -> str:
+    return ANSI.sub('', text)
+
+
+@fixture
+def pending_task(temp_site: Path) -> str:
+    """Submit one task (left unscheduled → WAITING) and return its UUID."""
+    taskfile = create_taskfile(temp_site, ['echo hello  # HYPERSHELL: n:0'])
+    assert main(['hs', 'submit', str(taskfile)])[0] == cli_status.success
+    rc, lines, _ = main_lines(['hs', 'list', 'id'])
+    assert rc == cli_status.success
+    ids = [line for line in lines if UUID.fullmatch(line)]
+    assert len(ids) == 1
+    return ids[0]
+
+
+@mark.unit
+class TestCardInfo:
+    """`hs info` renders the shared card, and `card` is a format for both info and wait."""
+
+    def test_card_is_a_format_choice_for_info_and_wait(self) -> None:
+        """R7/R8: `card` is a valid format for `hs info` and `hs wait --info` (parity)."""
+        assert 'card' in TaskInfoApp.output_formats
+        assert 'card' in TaskWaitApp.output_formats
+
+    def test_info_renders_one_card(self, pending_task: str) -> None:
+        """`hs info <id> --format=card` prints exactly one card with the full id and a badge."""
+        rc, out, err = main(['hs', 'info', pending_task, '--format=card'])
+        assert rc == cli_status.success
+        clean = strip_ansi(out)
+        assert clean.count('╭─ task') == 1        # a single card via the shared renderer
+        assert pending_task in clean              # full id present
+        assert 'status: WAITING' in clean         # a freshly-submitted task is unscheduled
+
+    def test_normal_still_default_for_info(self, pending_task: str) -> None:
+        """`hs info` without --format stays the plain `normal` block (no card border)."""
+        rc, out, err = main(['hs', 'info', pending_task])
+        assert rc == cli_status.success
+        assert '╭─ task' not in strip_ansi(out)

--- a/tests/test_card_integration.py
+++ b/tests/test_card_integration.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2026 Geoffrey Lentner
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end integration test for the `card` output format.
+
+Runs a real (file-mode) cluster so tasks reach a genuine terminal state, then drives
+`hs list`, `hs info`, and `hs wait --info` with `--format=card` through the installed CLI.
+"""
+
+
+# Type annotations
+from __future__ import annotations
+
+# Standard libs
+import re
+from pathlib import Path
+
+# External libs
+from pytest import mark
+from cmdkit.app import exit_status
+
+# Internal libs
+from tests import main, main_lines, create_taskfile
+
+
+ANSI = re.compile(r'\x1b\[[0-9;]*m')
+UUID = re.compile(r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
+
+
+def strip_ansi(text: str) -> str:
+    return ANSI.sub('', text)
+
+
+@mark.integration
+def test_card_format_end_to_end(temp_site: Path) -> None:
+    """`--format=card` renders completed tasks as OK cards via list, info, and wait."""
+    taskfile = create_taskfile(temp_site, ['echo CARD_0  # HYPERSHELL: n:0',
+                                           'echo CARD_1  # HYPERSHELL: n:1'])
+    rc, _, _ = main(['hs', 'cluster', str(taskfile), '-N1'])
+    assert rc == exit_status.success
+
+    # hs list --format=card → one OK card per completed task.
+    rc, out, _ = main(['hs', 'list', '--format=card'])
+    assert rc == exit_status.success
+    listing = strip_ansi(out)
+    assert listing.count('╭─ task') == 2
+    assert listing.count('status: OK') == 2
+
+    # hs info <id> --format=card → a single OK card carrying the full id.
+    rc, ids, _ = main_lines(['hs', 'list', 'id'])
+    assert rc == exit_status.success
+    task_ids = [line for line in ids if UUID.fullmatch(line)]
+    assert len(task_ids) == 2
+    task_id = task_ids[0]
+    rc, out, _ = main(['hs', 'info', task_id, '--format=card'])
+    assert rc == exit_status.success
+    info = strip_ansi(out)
+    assert info.count('╭─ task') == 1
+    assert task_id in info
+    assert 'status: OK' in info
+
+    # hs wait --info -f card → completed task returns immediately with the same card.
+    rc, out, _ = main(['hs', 'wait', task_id, '--info', '-f', 'card'])
+    assert rc == exit_status.success
+    assert 'status: OK' in strip_ansi(out)

--- a/tests/test_card_integration.py
+++ b/tests/test_card_integration.py
@@ -31,20 +31,27 @@ def strip_ansi(text: str) -> str:
     return ANSI.sub('', text)
 
 
+SOURCE_ID_FP = re.compile(r'source id [0-9a-f-]{36} \([0-9a-f]{32}\)')
+
+
 @mark.integration
-def test_card_format_end_to_end(temp_site: Path) -> None:
+def test_card_format_end_to_end(temp_site: Path, monkeypatch) -> None:
     """`--format=card` renders completed tasks as OK cards via list, info, and wait."""
+    # A wide, non-folding card keeps the `source id <uuid> (<fingerprint>)` line intact to assert on.
+    monkeypatch.setenv('COLUMNS', '160')
     taskfile = create_taskfile(temp_site, ['echo CARD_0  # HYPERSHELL: n:0',
                                            'echo CARD_1  # HYPERSHELL: n:1'])
     rc, _, _ = main(['hs', 'cluster', str(taskfile), '-N1'])
     assert rc == exit_status.success
 
-    # hs list --format=card → one OK card per completed task.
+    # hs list --format=card → one OK card per completed task, each carrying the batched
+    # Source content-fingerprint in parens on the source id line.
     rc, out, _ = main(['hs', 'list', '--format=card'])
     assert rc == exit_status.success
     listing = strip_ansi(out)
     assert listing.count('╭─ task') == 2
     assert listing.count('status: OK') == 2
+    assert len(SOURCE_ID_FP.findall(listing)) == 2
 
     # hs info <id> --format=card → a single OK card carrying the full id.
     rc, ids, _ = main_lines(['hs', 'list', 'id'])
@@ -58,6 +65,8 @@ def test_card_format_end_to_end(temp_site: Path) -> None:
     assert info.count('╭─ task') == 1
     assert task_id in info
     assert 'status: OK' in info
+    # The single-task path resolves the same fingerprint directly via `Source.from_id`.
+    assert SOURCE_ID_FP.search(info)
 
     # hs wait --info -f card → completed task returns immediately with the same card.
     rc, out, _ = main(['hs', 'wait', task_id, '--info', '-f', 'card'])

--- a/tests/test_card_render.py
+++ b/tests/test_card_render.py
@@ -73,8 +73,11 @@ class TestCardRender:
         out = strip_ansi(render(make(), 100))
         assert UID in out                       # id shown in full
         assert FP in out                        # fingerprint in the header
-        for title in ('command', 'timing', 'resources', 'execution', 'output', 'retry', 'result'):
+        for title in ('submission', 'timing', 'resources', 'execution', 'output', 'retry'):
             assert title in out
+        # The command's provenance and outcome live in the full-width `submission` region.
+        for label in ('source', 'source id', 'exit status'):
+            assert label in out
         assert 'status: OK' in out
 
     def test_id_never_truncated_even_at_min_width(self) -> None:
@@ -137,6 +140,25 @@ class TestCardRender:
         with_tags = strip_ansi(render(make(tag={'priority': 'high'}), 100))
         assert 'tags' in with_tags and 'priority:high' in with_tags
         assert 'tags' not in strip_ansi(render(make(tag={}), 100))
+
+    def test_source_fingerprint_in_parens(self) -> None:
+        """The Source content-fingerprint rides in parens on the `source id` line when present."""
+        src = 'a1b2c3d4-0000-4000-8000-000000000001'
+        fp = 'd41d8cd98f00b204e9800998ecf8427e'
+        buffer = io.StringIO()
+        Console(width=120, file=buffer).print(
+            render_card(make(source=src), 120,
+                        source_map={src: 'tasks.txt'}, fingerprint_map={src: fp}))
+        assert f'{src} ({fp})' in strip_ansi(buffer.getvalue())
+
+    def test_source_fingerprint_omitted_when_absent(self) -> None:
+        """A source with a NULL/missing fingerprint shows the id alone - no empty parens."""
+        src = 'a1b2c3d4-0000-4000-8000-000000000001'
+        buffer = io.StringIO()
+        Console(width=120, file=buffer).print(
+            render_card(make(source=src), 120, source_map={src: 'tasks.txt'}, fingerprint_map={src: None}))
+        id_line = next(line for line in strip_ansi(buffer.getvalue()).splitlines() if 'source id' in line)
+        assert src in id_line and '(' not in id_line
 
     def test_markup_safe_values_do_not_crash_or_corrupt(self) -> None:
         """Regression: bracketed shell (rich markup) renders verbatim, never MarkupError."""

--- a/tests/test_card_render.py
+++ b/tests/test_card_render.py
@@ -19,7 +19,8 @@ from rich.panel import Panel
 
 # Internal libs
 from hypershell.data.model import Task
-from hypershell.task import render_card, card_width, CARD_MIN_WIDTH, CARD_MAX_WIDTH, STATUS_STYLES
+from hypershell.task import (render_card, card_width, card_console,
+                             CARD_MIN_WIDTH, CARD_MAX_WIDTH, STATUS_STYLES)
 
 
 UID = '3f2a9c1e-7b4d-4a2e-9c1e-7b4d4a2e9c1e'
@@ -90,6 +91,19 @@ class TestCardRender:
         assert card_width(123) == 123
         assert max_line_width(render(make(), 40)) <= 60      # clamped up to the minimum
         assert max_line_width(render(make(), 300)) <= 160    # clamped down to the maximum
+
+    def test_card_console_clamps_terminal_width(self, monkeypatch) -> None:
+        """The card console clamps the detected terminal width to [60, 160] so the id survives.
+
+        Sizing the console (not just the Panel) is the fix: a bare console renders at the raw
+        terminal width and clips a wider Panel, truncating the id below 60 columns.
+        """
+        monkeypatch.setenv('COLUMNS', '30')
+        assert card_console().width == CARD_MIN_WIDTH == 60
+        monkeypatch.setenv('COLUMNS', '9999')
+        assert card_console().width == CARD_MAX_WIDTH == 160
+        monkeypatch.setenv('COLUMNS', '100')
+        assert card_console().width == 100
 
     def test_narrow_one_column(self) -> None:
         """Below 90 cols, regions stack: no single line holds two region titles."""

--- a/tests/test_card_render.py
+++ b/tests/test_card_render.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: 2026 Geoffrey Lentner
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the `card` view renderer (`render_card`, `card_width`, `STATUS_STYLES`)."""
+
+
+# Type annotations
+from __future__ import annotations
+
+# Standard libs
+import io
+import re
+from datetime import datetime
+
+# External libs
+from pytest import mark
+from rich.console import Console
+from rich.panel import Panel
+
+# Internal libs
+from hypershell.data.model import Task
+from hypershell.task import render_card, card_width, CARD_MIN_WIDTH, CARD_MAX_WIDTH, STATUS_STYLES
+
+
+UID = '3f2a9c1e-7b4d-4a2e-9c1e-7b4d4a2e9c1e'
+FP = 'a1b2c3d4e5f60718293a4b5c6d7e8f90'
+ANSI = re.compile(r'\x1b\[[0-9;]*m')
+NOW = datetime(2026, 7, 31, 10, 12, 4)
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI SGR sequences."""
+    return ANSI.sub('', text)
+
+
+def make(**over) -> Task:
+    """A transient Task with the columns the card reads; `tag` defaults to {} (never None)."""
+    fields = dict(
+        id=UID, group=4, part=0, fingerprint=FP, args='echo hello', command='echo hello',
+        cores=1, memory=536870912, cores_max=0.5, memory_max=402653184.0,
+        submit_host='login01', server_host='head', client_host='node042',
+        schedule_time=NOW, start_time=NOW, completion_time=NOW, exit_status=0,
+        source=None, tag={},
+    )
+    fields.update(over)
+    return Task(**fields)
+
+
+def render(task: Task, width: int, *, color: bool = False) -> str:
+    """Render a card to a string at the given width (no color unless asked)."""
+    buffer = io.StringIO()
+    console = Console(width=width, file=buffer,
+                      force_terminal=(True if color else None),
+                      color_system=('standard' if color else None))
+    console.print(render_card(task, width))
+    return buffer.getvalue()
+
+
+def max_line_width(text: str) -> int:
+    """Widest visible (ANSI-stripped) line."""
+    return max(len(line) for line in strip_ansi(text).splitlines())
+
+
+@mark.unit
+class TestCardRender:
+    """The card renderer: content, responsiveness, clamping, status badge, no-color legibility."""
+
+    def test_returns_panel(self) -> None:
+        assert isinstance(render_card(make(), 100), Panel)
+
+    def test_core_content_present(self) -> None:
+        """Full id (never truncated), fingerprint, region titles, and the status badge appear."""
+        out = strip_ansi(render(make(), 100))
+        assert UID in out                       # id shown in full
+        assert FP in out                        # fingerprint in the header
+        for title in ('command', 'timing', 'resources', 'execution', 'output', 'retry', 'result'):
+            assert title in out
+        assert 'status: OK' in out
+
+    def test_id_never_truncated_even_at_min_width(self) -> None:
+        assert UID in strip_ansi(render(make(), 60))
+
+    def test_width_clamped_to_range(self) -> None:
+        """A tiny or huge terminal is clamped to [60, 160]."""
+        assert card_width(10) == CARD_MIN_WIDTH == 60
+        assert card_width(9999) == CARD_MAX_WIDTH == 160
+        assert card_width(123) == 123
+        assert max_line_width(render(make(), 40)) <= 60      # clamped up to the minimum
+        assert max_line_width(render(make(), 300)) <= 160    # clamped down to the maximum
+
+    def test_narrow_one_column(self) -> None:
+        """Below 90 cols, regions stack: no single line holds two region titles."""
+        lines = strip_ansi(render(make(), 70)).splitlines()
+        assert not any('timing' in line and 'resources' in line for line in lines)
+
+    def test_normal_two_columns(self) -> None:
+        """90-149 cols: two columns — timing|resources share a line but execution does not."""
+        lines = strip_ansi(render(make(), 100)).splitlines()
+        assert any('timing' in line and 'resources' in line and 'execution' not in line
+                   for line in lines)
+        assert any('execution' in line and 'output' in line for line in lines)
+
+    def test_wide_three_columns(self) -> None:
+        """>=150 cols: three columns — timing, resources, AND execution share one line."""
+        lines = strip_ansi(render(make(), 155)).splitlines()
+        assert any(all(t in line for t in ('timing', 'resources', 'execution')) for line in lines)
+
+    def test_header_horizontal_when_wide(self) -> None:
+        """At >=130 the whole identity row (id, fp, group, part) sits on one line."""
+        lines = strip_ansi(render(make(), 150)).splitlines()
+        assert any(UID in line and FP in line and 'group 4' in line and 'part 0' in line
+                   for line in lines)
+
+    def test_header_stacks_id_when_narrow(self) -> None:
+        """Below 130 the id gets its own line (never truncated, never crowded)."""
+        lines = strip_ansi(render(make(), 100)).splitlines()
+        id_line = next(line for line in lines if UID in line)
+        assert 'part 0' not in id_line          # id is alone on its row
+        out = '\n'.join(lines)
+        assert 'group 4' in out and 'part 0' in out and FP in out
+
+    def test_status_badge_lower_right(self) -> None:
+        """R4: the status badge renders on the bottom border, right-aligned."""
+        lines = [line for line in strip_ansi(render(make(), 100)).splitlines() if line.strip()]
+        bottom = lines[-1]
+        assert 'status: OK' in bottom
+        assert bottom.index('status:') > len(bottom) // 2      # in the right half
+
+    def test_status_palette_pinned(self) -> None:
+        """R4: the three GOAL-fixed colors do not drift."""
+        assert STATUS_STYLES['OK'] == 'bold green'
+        assert STATUS_STYLES['FAILED'] == 'bold red'
+        assert STATUS_STYLES['CANCELLED'] == 'yellow'
+
+    def test_tags_region_present_and_omitted(self) -> None:
+        """R3: the tags region shows key:value pairs, and is omitted when there are no tags."""
+        with_tags = strip_ansi(render(make(tag={'priority': 'high'}), 100))
+        assert 'tags' in with_tags and 'priority:high' in with_tags
+        assert 'tags' not in strip_ansi(render(make(tag={}), 100))
+
+    def test_markup_safe_values_do_not_crash_or_corrupt(self) -> None:
+        """Regression: bracketed shell (rich markup) renders verbatim, never MarkupError."""
+        for cmd in ("sed 's/x/[/]/'", 'echo [/red]', "awk '{a[b]=1}'", 'echo [bold]hi[/bold] ${arr[i]}'):
+            out = strip_ansi(render(make(args=cmd, command=cmd, tag={'note': '[i]'}), 100))
+            assert cmd in out                 # command shown exactly as the user wrote it
+            assert 'note:[i]' in out          # tag brackets survive too
+
+    @mark.parametrize('exit_status, schedule, complete, label', [
+        (0, True, True, 'OK'),
+        (1, True, True, 'FAILED'),
+        (-1, True, True, 'CANCELLED'),
+        (-9, True, True, 'KILLED'),
+        (-1001, True, True, 'ERROR'),
+        (None, True, False, 'RUNNING'),
+        (None, False, False, 'WAITING'),
+    ])
+    def test_status_badge_reflects_lifecycle(self, exit_status, schedule, complete, label) -> None:
+        task = make(exit_status=exit_status,
+                    schedule_time=(NOW if schedule else None),
+                    completion_time=(NOW if complete else None))
+        assert task.status_label == label
+        assert f'status: {label}' in strip_ansi(render(task, 100))
+
+    def test_every_label_has_a_style(self) -> None:
+        """Drift guard: every label `status_label` can emit maps to a rich style."""
+        labels = {'OK', 'FAILED', 'CANCELLED', 'RUNNING', 'WAITING', 'ERROR', 'KILLED', 'UNKNOWN'}
+        assert labels <= set(STATUS_STYLES)
+
+    def test_no_color_when_not_a_terminal(self) -> None:
+        """R6: piped/non-tty output drops ANSI but keeps the border and literal status text."""
+        out = render(make(exit_status=1), 100, color=False)
+        assert '\x1b[' not in out                # no color codes
+        assert '─' in out and '│' in out         # box border still drawn
+        assert 'status: FAILED' in out           # status readable as plain text
+
+    def test_color_when_terminal(self) -> None:
+        """On a real terminal the badge carries ANSI styling."""
+        out = render(make(), 100, color=True)
+        assert '\x1b[' in out
+        assert 'status: OK' in strip_ansi(out)

--- a/tests/test_status_label.py
+++ b/tests/test_status_label.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2026 Geoffrey Lentner
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for `Task.status_label` lifecycle derivation."""
+
+
+# Type annotations
+from __future__ import annotations
+
+# Standard libs
+from datetime import datetime
+
+# External libs
+from pytest import mark
+
+# Internal libs
+from hypershell.data.model import Task, CANCEL_STATUS
+
+
+# A fixed timestamp for the schedule/completion columns; the value is irrelevant to the
+# derivation (only NULL vs. set matters), so one constant serves every case.
+NOW = datetime(2026, 1, 1, 12, 0, 0)
+
+
+def make(*, scheduled: bool = True, completed: bool = True, exit_status: int = None) -> Task:
+    """Construct a transient Task with only the lifecycle-relevant columns set."""
+    return Task(
+        schedule_time=(NOW if scheduled else None),
+        completion_time=(NOW if completed else None),
+        exit_status=exit_status,
+    )
+
+
+@mark.unit
+class TestStatusLabel:
+    """The lifecycle -> status-label ladder (order-critical; honors exit_status ranges)."""
+
+    def test_waiting_when_unscheduled(self) -> None:
+        """schedule_time NULL dominates every later column."""
+        assert make(scheduled=False, completed=False).status_label == 'WAITING'
+        assert make(scheduled=False, completed=True, exit_status=0).status_label == 'WAITING'
+
+    def test_running_when_scheduled_but_incomplete(self) -> None:
+        """Scheduled with no completion_time is in-flight (or interrupted, pre-revert)."""
+        assert make(scheduled=True, completed=False).status_label == 'RUNNING'
+        assert make(scheduled=True, completed=False, exit_status=0).status_label == 'RUNNING'
+
+    def test_ok_on_zero_exit(self) -> None:
+        assert make(exit_status=0).status_label == 'OK'
+
+    def test_cancelled_on_cancel_status(self) -> None:
+        """CANCEL_STATUS (-1) must be classified before generic signal deaths."""
+        assert make(exit_status=CANCEL_STATUS).status_label == 'CANCELLED'
+        assert make(exit_status=-1).status_label == 'CANCELLED'
+
+    def test_error_on_never_ran_sentinel(self) -> None:
+        """The documented <= -1000 range (TASK_TEMPLATE_ERROR / TASK_RESOURCE_ERROR, and future)."""
+        assert make(exit_status=-1001).status_label == 'ERROR'
+        assert make(exit_status=-1002).status_label == 'ERROR'
+        assert make(exit_status=-5000).status_label == 'ERROR'
+
+    def test_killed_on_signal_death(self) -> None:
+        """Signal deaths (-2..-64); -1 is excluded (that is CANCEL_STATUS)."""
+        assert make(exit_status=-2).status_label == 'KILLED'
+        assert make(exit_status=-9).status_label == 'KILLED'
+        assert make(exit_status=-64).status_label == 'KILLED'
+
+    def test_failed_on_positive_exit(self) -> None:
+        assert make(exit_status=1).status_label == 'FAILED'
+        assert make(exit_status=127).status_label == 'FAILED'
+
+    def test_unknown_when_completed_without_exit_status(self) -> None:
+        """Defensive: completed but exit_status NULL, and the None-before-numeric ordering
+        must not raise on `None < 0`."""
+        assert make(completed=True, exit_status=None).status_label == 'UNKNOWN'


### PR DESCRIPTION
## Summary

Adds an opt-in `card` output format to `hs list` / `hs search` and `hs info`: each task
renders as a self-contained bordered *baseball-card* — identity fields (id, fingerprint,
group, part, with a reserved slot for a future `zone`) laid horizontally across the top,
the rest of the metadata grouped into labeled regions (submission, timing, resources,
execution, output, retry, tags), and a virtual `status: <LABEL>` badge pinned lower-right
whose color and label are derived from the task lifecycle (not a stored column). Layout
auto-selects narrow / normal / wide from the terminal width, clamped to [60, 160]. `normal`
stays the default; `plain` / `table` / `json` / `csv` are untouched — purely additive.

## Goal
[GOAL.md](https://github.com/hypershell/hypershell/blob/c77ba3fe66e2526d1299c6d4041683d03f106f47/spec/task-card-view/GOAL.md)

## Design
[PLAN.md](https://github.com/hypershell/hypershell/blob/c77ba3fe66e2526d1299c6d4041683d03f106f47/spec/task-card-view/PLAN.md)
(historical design record — retained per "build in the open")

## Research
[00-digest](https://github.com/hypershell/hypershell/blob/c77ba3fe66e2526d1299c6d4041683d03f106f47/spec/task-card-view/research/00-digest.md)
· [01-rich-card-layout](https://github.com/hypershell/hypershell/blob/c77ba3fe66e2526d1299c6d4041683d03f106f47/spec/task-card-view/research/01-rich-card-layout.md)
· [02-status-lifecycle-derivation](https://github.com/hypershell/hypershell/blob/c77ba3fe66e2526d1299c6d4041683d03f106f47/spec/task-card-view/research/02-status-lifecycle-derivation.md)
· [03-output-wiring](https://github.com/hypershell/hypershell/blob/c77ba3fe66e2526d1299c6d4041683d03f106f47/spec/task-card-view/research/03-output-wiring.md)
· [04-tty-width-color](https://github.com/hypershell/hypershell/blob/c77ba3fe66e2526d1299c6d4041683d03f106f47/spec/task-card-view/research/04-tty-width-color.md)
· [05-docs-completions](https://github.com/hypershell/hypershell/blob/c77ba3fe66e2526d1299c6d4041683d03f106f47/spec/task-card-view/research/05-docs-completions.md)

## Phases completed
| Phase | Name | Satisfies |
|-------|------|-----------|
| P1 | Derive task status from lifecycle (`Task.status_label`) | R4 |
| P2 | Card renderer (Panel, header, regions, lower-right status, responsive width) | R2, R3, R4, R5, R6 |
| P3 | Wire `card` into `hs list` / `hs search` | R1, R8 |
| P4 | Wire `card` into `hs info` (+ `hs wait` parity) | R7, R1, R8 |
| P5 | Integration test + clean docs build | R8, R1 |

## Verification
Reviewed across 3 cycles ([REVIEW.md](https://github.com/hypershell/hypershell/blob/c77ba3fe66e2526d1299c6d4041683d03f106f47/spec/task-card-view/REVIEW.md)); approved at cycle 3.

- `uv run pytest` — full suite green; card + `status_label` unit tests + the `@mark.integration` card test.
- Real CLI in a throwaway site: OK / FAILED / WAITING / RUNNING badges correct; shell-metachar
  commands (`sed 's/x/[/]/'`, `echo '[bold]hi[/bold]'`) render verbatim (rich-markup safety); piped
  non-TTY + `NO_COLOR=1` emit zero ANSI with the border intact and `status:` as literal text (R6);
  `hs info … --format=card` matches `hs list` for the same id (R7); `json` / `csv` / `table` /
  `plain` / `normal` unchanged (R1).
- Width clamp [60, 160] verified end-to-end, incl. the cycle-2 fix (C2-1): a shared `card_console()`
  sizes the console — not just the Panel — so the min-60 floor holds and the id is never truncated
  below 60 columns.
- `uv run sphinx-build docs docs/_build` — no new warnings.

## Docs & completions
Same-commit rule honored: `docs/_include/task_{search,info,wait}_help.rst` and both
`share/bash_completion.d/hs` + `share/zsh/site-functions/_hs` list `card`. **Man pages deferred to
the next `/hs-release`** — regenerating them here would pull in unrelated pending `--part` / `--rotate`
man diffs; R8's hard requirement (`docs/_include` + completions) is fully met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
